### PR TITLE
[13091605] Add new strings from LC for SalesLogix 8.0 and Mobile 2.0

### DIFF
--- a/localization/saleslogix/de.js
+++ b/localization/saleslogix/de.js
@@ -15,7 +15,7 @@ localize("Mobile.SalesLogix.Views.Activity.Complete", {
   "opportunityText": "Verk.chance",
   "ticketNumberText": "Ticket",
   "companyText": "Unternehmen",
-  "leadText": "Inter.",
+  "leadText": "Interessent",
   "asScheduledText": "wie geplant",
   "categoryText": "Kategorie",
   "categoryTitleText": "Aktivit.kategorie",
@@ -23,8 +23,8 @@ localize("Mobile.SalesLogix.Views.Activity.Complete", {
   "completionText": "Abschluss",
   "durationText": "Dauer",
   "durationInvalidText": "Feld '${2}' muss Wert enthalten.",
-  "carryOverNotesText": "Notizen übertr.",
-  "followUpText": "Folgeakt.",
+  "carryOverNotesText": "Notizen übertragen",
+  "followUpText": "Folgeaktivität",
   "followUpTitleText": "Typ für Nachfassen",
   "leaderText": "Organisator",
   "longNotesText": "Notizen",
@@ -82,12 +82,12 @@ localize("Mobile.SalesLogix.Views.Activity.Detail", {
   "regardingText": "Betreff",
   "rolloverText": "Auto-Rollover",
   "startTimeText": "Startzeit",
-  "allDayText": "Ganztäg.",
+  "allDayText": "Ganztägig",
   "timelessText": "ohne Zeitangabe",
   "titleText": "Aktivität",
   "typeText": "Typ",
   "companyText": "Unternehmen",
-  "leadText": "Inter.",
+  "leadText": "Interessent",
   "accountText": "Firma",
   "contactText": "Kontakt",
   "opportunityText": "Verk.chance",
@@ -132,8 +132,8 @@ localize("Mobile.SalesLogix.Views.Activity.Edit", {
   "opportunityText": "Verk.chance",
   "ticketNumberText": "Ticket",
   "companyText": "Unternehmen",
-  "leadText": "Inter.",
-  "isLeadText": "für Inter.",
+  "leadText": "Interessent",
+  "isLeadText": "Für Interessent",
   "yesText": "JA",
   "noText": "NEIN",
   "updateUserActErrorText": "Fehler beim Aktualis. von Ben.aktivitäten.",
@@ -244,7 +244,7 @@ localize("Mobile.SalesLogix.Views.Event.Detail", {
   "startTimeText": "Startdatum",
   "endTimeText": "Enddatum",
   "titleText": "Ereignis",
-  "descriptionText": "Beschreib.",
+  "descriptionText": "Beschreibung",
   "typeText": "Typ",
   "whenText": "Wann"
 });
@@ -258,7 +258,7 @@ localize("Mobile.SalesLogix.Views.Event.List", {
 localize("Mobile.SalesLogix.Views.History.Detail", {
   "dateFormatText": "d/M/yyyy h:mm:ss tt",
   "categoryText": "Kategorie",
-  "completedText": "abgeschl.",
+  "completedText": "Abgeschlossen",
   "durationText": "Dauer",
   "leaderText": "Organisator",
   "longNotesText": "Notizen",
@@ -269,14 +269,14 @@ localize("Mobile.SalesLogix.Views.History.Detail", {
   "scheduledText": "geplant",
   "timelessText": "ohne Zeitangabe",
   "companyText": "Unternehmen",
-  "leadText": "Inter.",
+  "leadText": "Interessent",
   "titleText": "Historie",
   "accountText": "Firma",
   "contactText": "Kontakt",
   "opportunityText": "Verk.chance",
   "ticketNumberText": "Ticket",
   "moreDetailsText": "Mehr Details",
-  "relatedItemsText": "Zugeh. Elemente",
+  "relatedItemsText": "Zugehörige Elemente",
   "modifiedText": "geändert",
   "typeText": "Typ",
   "activityTypeText": {
@@ -300,12 +300,12 @@ localize("Mobile.SalesLogix.Views.History.Edit", {
   "opportunityText": "Verk.chance",
   "ticketNumberText": "Ticket",
   "regardingText": "Betreff",
-  "isLeadText": "für Inter.",
+  "isLeadText": "Für Interessent",
   "startingText": "Zeit",
   "titleText": "Notiz",
   "companyText": "Unternehmen",
-  "leadText": "Inter.",
-  "relatedItemsText": "Zugeh. Elemente",
+  "leadText": "Interessent",
+  "relatedItemsText": "Zugehörige Elemente",
   "yesText": "JA",
   "noText": "NEIN"
 });
@@ -326,13 +326,26 @@ localize("Mobile.SalesLogix.Views.History.List", {
     "note": "Notiz",
     "phonecall": "Anruf",
     "meeting": "Meeting",
-    "personal": "Persönl.",
+    "personal": "Persönlich",
     "email": "E-Mail"
   },
   "titleText": "Notizen/Historie",
   "viewAccountActionText": "Firma",
   "viewOpportunityActionText": "VK-Chance",
   "viewContactActionText": "Kontakt"
+});
+
+localize("Mobile.SalesLogix.Views.TicketActivity.Edit", {
+  "startingFormatText": "d.  M yyyy h:mm tt",
+  "titleText": "Ticket-Aktivität bearbeiten",
+  "activityTypeText": "Typ",
+  "activityTypeTitleText": "Typ",
+  "publicAccessText": "öffentl. Zugriff",
+  "publicAccessTitleText": "Öffentlicher Zugriff",
+  "userText": "Benutzer",
+  "startDateText": "Startdatum",
+  "endDateText": "Enddatum",
+  "commentsText": "Kommentare"
 });
 
 localize("Mobile.SalesLogix.Views.TicketActivity.List", {
@@ -389,7 +402,7 @@ localize("Sage.Platform.Mobile.Fields.DurationField", {
 });
 
 localize("Sage.Platform.Mobile.Fields.EditorField", {
-  "lookupLabelText": "Bearb.",
+  "lookupLabelText": "Bearbeiten",
   "lookupText": "...",
   "emptyText": "leer",
   "completeText": "OK"
@@ -463,12 +476,12 @@ localize("Mobile.SalesLogix.Action", {
 });
 
 localize("Mobile.SalesLogix.Fields.AddressField", {
-  "lookupLabelText": "Bearb.",
-  "emptyText": "keine Adr."
+  "lookupLabelText": "Bearbeiten",
+  "emptyText": ""
 });
 
 localize("Mobile.SalesLogix.Fields.NameField", {
-  "emptyText": "kein Name"
+  "emptyText": ""
 });
 
 localize("Mobile.SalesLogix.Fields.RecurrencesField", {
@@ -546,11 +559,11 @@ localize("Mobile.SalesLogix.Views.Account.Detail", {
   "createDateText": "Erstellt am",
   "createUserText": "Erstellt von",
   "faxText": "Fax",
-  "importSourceText": "Int.quelle",
+  "importSourceText": "Interessentenquelle",
   "industryText": "Branche",
   "notesText": "Notizen",
   "ownerText": "Eigentümer",
-  "phoneText": "Tel.",
+  "phoneText": "Telefon",
   "activityTypeText": {
     "atPhoneCall": "Anruf"
   },
@@ -558,7 +571,7 @@ localize("Mobile.SalesLogix.Views.Account.Detail", {
   "relatedActivitiesText": "Aktivitäten",
   "relatedContactsText": "Kontakte",
   "relatedHistoriesText": "Notizen/Historie",
-  "relatedItemsText": "Zugeh. Elemente",
+  "relatedItemsText": "Zugehörige Elemente",
   "relatedNotesText": "Notizen",
   "relatedOpportunitiesText": "Verkaufschancen",
   "relatedTicketsText": "Tickets",
@@ -568,10 +581,10 @@ localize("Mobile.SalesLogix.Views.Account.Detail", {
   "titleText": "Firma",
   "typeText": "Typ",
   "webText": "Web",
-  "callMainNumberText": "Hauptnr. anrufen",
+  "callMainNumberText": "Festnetz anrufen",
   "scheduleActivityText": "Aktivität planen",
-  "addNoteText": "Notiz hinzuf",
-  "viewAddressText": "Adresse anz.",
+  "addNoteText": "Notiz hinzufügen",
+  "viewAddressText": "Adresse anzeigen",
   "moreDetailsText": "Mehr Details",
   "calledText": "${0} angerufen"
 });
@@ -587,11 +600,11 @@ localize("Mobile.SalesLogix.Views.Account.Edit", {
   "descriptionText": "Beschr.",
   "faxText": "Fax",
   "fullAddressText": "Adresse",
-  "importSourceText": "Int.quelle",
+  "importSourceText": "Interessentenquelle",
   "industryText": "Branche",
   "industryTitleText": "Branche",
   "ownerText": "Eigentümer",
-  "phoneText": "Tel.",
+  "phoneText": "Telefon",
   "statusText": "Status",
   "subTypeText": "Untertyp",
   "titleText": "Firma",
@@ -605,7 +618,7 @@ localize("Mobile.SalesLogix.Views.Account.List", {
   "notesText": "Notizen",
   "scheduleText": "Planen",
   "editActionText": "Bearbeiten",
-  "callMainActionText": "Hauptnr. anrufen",
+  "callMainActionText": "Festnetz anrufen",
   "viewContactsActionText": "Kontakte",
   "addNoteActionText": "Notiz hinzufügen",
   "addActivityActionText": "Aktivität hinzufügen"
@@ -623,7 +636,7 @@ localize("Mobile.SalesLogix.Views.Activity.Recurring", {
   "monthText": "Monat",
   "onText": "am",
   "occurrencesText": "Wiederholungen",
-  "summaryText": "Zus.fassung",
+  "summaryText": "Zusammenfassung",
   "frequencyOptionsText": {
     "0": "Tage",
     "1": "Wochen",
@@ -656,7 +669,7 @@ localize("Mobile.SalesLogix.Views.AddAccountContact", {
   "accountTypeTitleText": "Firmentyp",
   "addressText": "Adresse",
   "contactTitleText": "Titel",
-  "descriptionText": "Beschreib.",
+  "descriptionText": "Beschreibung",
   "detailsAccountText": "Firmeninfo",
   "detailsContactText": "Kontaktinfo",
   "detailsText": "Kontakt-/Firmeninfo",
@@ -669,10 +682,10 @@ localize("Mobile.SalesLogix.Views.AddAccountContact", {
   "nameText": "Name",
   "statusText": "Status",
   "subTypeText": "Untertyp",
-  "titleText": "Firma/Kontakt hinzuf",
+  "titleText": "Firma/Kontakt hinzufügen",
   "typeText": "Typ",
   "webText": "Web",
-  "workText": "Geschäftl.",
+  "workText": "Geschäftlich",
   "industryTitleText": "Branche"
 });
 
@@ -684,13 +697,13 @@ localize("Mobile.SalesLogix.Views.Address.Edit", {
   "cityTitleText": "Stadt",
   "countryText": "Land",
   "countryTitleText": "Land",
-  "descriptionText": "Beschreib.",
+  "descriptionText": "Beschreibung",
   "descriptionTitleText": "Beschreibung",
   "isMailingText": "Lieferung",
   "isPrimaryText": "Haupt",
   "postalCodeText": "PLZ",
   "salutationText": "Zu Händen",
-  "stateText": "Bundesl.",
+  "stateText": "Bundesland",
   "stateTitleText": "Bundesland/Kanton",
   "titleText": "Adresse"
 });
@@ -731,28 +744,28 @@ localize("Mobile.SalesLogix.Views.Contact.Detail", {
   "relatedAccountsText": "Firmen",
   "relatedActivitiesText": "Aktivitäten",
   "relatedHistoriesText": "Notizen/Historie",
-  "relatedItemsText": "Zugeh. Elemente",
+  "relatedItemsText": "Zugehörige Elemente",
   "relatedNotesText": "Notizen",
   "relatedOpportunitiesText": "Verkaufschancen",
   "relatedTicketsText": "Tickets",
   "relatedAddressesText": "Adressen",
   "titleText": "Kontakt",
   "webText": "Web",
-  "workText": "Tel.",
+  "workText": "Telefon",
   "cuisinePreferenceText": "Küche",
-  "callMobileNumberText": "Auf Handy anr.",
-  "callWorkNumberText": "Hauptnr. anrufen",
+  "callMobileNumberText": "Handy anrufen",
+  "callWorkNumberText": "Festnetz anrufen",
   "scheduleActivityText": "Aktivität planen",
-  "addNoteText": "Notiz hinzuf",
+  "addNoteText": "Notiz hinzufügen",
   "sendEmailText": "E-Mail senden",
-  "viewAddressText": "Adresse anz.",
+  "viewAddressText": "Adresse anzeigen",
   "moreDetailsText": "Mehr Details"
 });
 
 localize("Mobile.SalesLogix.Views.Contact.Edit", {
   "titleText": "Kontakt",
   "nameText": "Name",
-  "workText": "Tel.",
+  "workText": "Telefon",
   "mobileText": "Mobil",
   "emailText": "E-Mail",
   "webText": "Web",
@@ -775,8 +788,8 @@ localize("Mobile.SalesLogix.Views.Contact.List", {
   "notesText": "Notizen",
   "scheduleText": "Planen",
   "editActionText": "Bearbeiten",
-  "callMainActionText": "Hauptnr. anrufen",
-  "callMobileActionText": "Auf Handy anrufen",
+  "callMainActionText": "Festnetz anrufen",
+  "callMobileActionText": "Handy anrufen",
   "sendEmailActionText": "E-Mail",
   "viewAccountActionText": "Firma",
   "addNoteActionText": "Notiz hinzufügen",
@@ -790,7 +803,7 @@ localize("Mobile.SalesLogix.Views.Contract.List", {
 localize("Mobile.SalesLogix.Views.Event.Edit", {
   "titleText": "Ereignis",
   "typeText": "Typ",
-  "descriptionText": "Beschreib.",
+  "descriptionText": "Beschreibung",
   "startDateText": "Startdatum",
   "endDateText": "Enddatum"
 });
@@ -812,7 +825,7 @@ localize("Mobile.SalesLogix.Views.Help", {
 
 localize("Mobile.SalesLogix.Views.Home", {
   "configureText": "Konfigur.",
-  "addAccountContactText": "Firma/Kontakt hinzuf",
+  "addAccountContactText": "Firma/Kontakt hinzufügen",
   "titleText": "Home",
   "actionsText": "Schnellaktionen",
   "viewsText": "Gehe zu"
@@ -829,7 +842,7 @@ localize("Mobile.SalesLogix.Views.Lead.Detail", {
   "createDateText": "Erstellt am",
   "createUserText": "Erstellt von",
   "eMailText": "E-Mail",
-  "leadSourceText": "Int.quelle",
+  "leadSourceText": "Interessentenquelle",
   "industryText": "Branche",
   "interestsText": "Interessen",
   "leadTitleText": "Titel",
@@ -838,19 +851,19 @@ localize("Mobile.SalesLogix.Views.Lead.Detail", {
   "ownerText": "Eigentümer",
   "relatedActivitiesText": "Aktivitäten",
   "relatedHistoriesText": "Notizen/Historie",
-  "relatedItemsText": "Zugeh. Elemente",
+  "relatedItemsText": "Zugehörige Elemente",
   "relatedNotesText": "Notizen",
   "sicCodeText": "BDI-Code",
   "titleText": "Interessent",
   "tollFreeText": "Gebührenfrei",
   "webText": "Web",
-  "workText": "Tel.",
+  "workText": "Telefon",
   "actionsText": "Schnellaktionen",
-  "callWorkNumberText": "Hauptnr. anrufen",
+  "callWorkNumberText": "Festnetz anrufen",
   "scheduleActivityText": "Aktivität planen",
-  "addNoteText": "Notiz hinzuf",
+  "addNoteText": "Notiz hinzufügen",
   "sendEmailText": "E-Mail senden",
-  "viewAddressText": "Adresse anz.",
+  "viewAddressText": "Adresse anzeigen",
   "moreDetailsText": "Mehr Details",
   "calledText": "${0} angerufen",
   "emailedText": "E-Mail an ${0}"
@@ -865,7 +878,7 @@ localize("Mobile.SalesLogix.Views.Lead.Edit", {
   "contactTitleText": "Titel",
   "emailText": "E-Mail",
   "faxText": "Fax",
-  "importSourceText": "Int.quelle",
+  "importSourceText": "Interessentenquelle",
   "industryText": "Branche",
   "industryTitleText": "Branche",
   "interestsText": "Interessen",
@@ -879,7 +892,7 @@ localize("Mobile.SalesLogix.Views.Lead.Edit", {
   "titleTitleText": "Titel",
   "tollFreeText": "Gebührenfrei",
   "webText": "Web",
-  "workText": "Tel."
+  "workText": "Telefon"
 });
 
 localize("Mobile.SalesLogix.Views.Lead.List", {
@@ -890,7 +903,7 @@ localize("Mobile.SalesLogix.Views.Lead.List", {
   "emailedText": "Gesendet per E-Mail ${0}",
   "calledText": "${0} angerufen",
   "editActionText": "Bearbeiten",
-  "callMainActionText": "Hauptnr. anrufen",
+  "callMainActionText": "Festnetz anrufen",
   "sendEmailActionText": "E-Mail",
   "addNoteActionText": "Notiz hinzufügen",
   "addActivityActionText": "Aktivität hinzufügen"
@@ -906,7 +919,7 @@ localize("Mobile.SalesLogix.Views.Login", {
   "passText": "Passwort",
   "rememberText": "Speichern",
   "titleText": "Sage SalesLogix",
-  "userText": "Ben.name",
+  "userText": "Benutzername",
   "invalidUserText": "Benutzername/Passwort ist ungültig.",
   "missingUserText": "Benutzerdatensatz nicht gefund",
   "serverProblemText": "Problem auf dem Server.",
@@ -931,10 +944,10 @@ localize("Mobile.SalesLogix.Views.NameEdit", {
 localize("Mobile.SalesLogix.Views.Opportunity.Detail", {
   "accountText": "Firma",
   "acctMgrText": "Acct Mgr",
-  "estCloseText": "Vor. Abschl.",
+  "estCloseText": "Vor. Abschluss",
   "fbarHomeTitleText": "Home",
   "fbarScheduleTitleText": "Planen",
-  "importSourceText": "Int.quelle",
+  "importSourceText": "Interessentenquelle",
   "opportunityText": "Verk.chance",
   "ownerText": "Eigentümer",
   "actionsText": "Schnellaktionen",
@@ -943,31 +956,31 @@ localize("Mobile.SalesLogix.Views.Opportunity.Detail", {
   "relatedActivitiesText": "Aktivitäten",
   "relatedContactsText": "Kontakte für Verkaufschance",
   "relatedHistoriesText": "Notizen/Historie",
-  "relatedItemsText": "Zugeh. Elemente",
+  "relatedItemsText": "Zugehörige Elemente",
   "relatedNotesText": "Notizen",
   "relatedProductsText": "Produkte",
-  "resellerText": "Wiederverk.",
+  "resellerText": "Wiederverkäufer",
   "statusText": "Status",
   "titleText": "Verkaufschance",
   "typeText": "Typ",
   "scheduleActivityText": "Aktivität planen",
-  "addNoteText": "Notiz hinzuf",
+  "addNoteText": "Notiz hinzufügen",
   "moreDetailsText": "Mehr Details"
 });
 
 localize("Mobile.SalesLogix.Views.Opportunity.Edit", {
   "accountText": "Firma",
   "acctMgrText": "Acct Mgr",
-  "estCloseText": "Vor. Abschl.",
-  "importSourceText": "Int.quelle",
+  "estCloseText": "Vor. Abschluss",
+  "importSourceText": "Interessentenquelle",
   "opportunityStatusTitleText": "Status der Verkaufschance",
   "opportunityText": "Verk.chance",
   "opportunityTypeTitleText": "Verkaufschancentyp",
   "ownerText": "Eigentümer",
   "potentialText": "VK-Potenzial",
   "probabilityText": "Abschl.wahrsch.",
-  "probabilityTitleText": "VK-Chancen-Wahrscheinlichk.",
-  "resellerText": "Wiederverk.",
+  "probabilityTitleText": "Wahrscheinlichkeit",
+  "resellerText": "Wiederverkäufer",
   "statusText": "Status",
   "titleText": "Verkaufschance",
   "typeText": "Typ"
@@ -986,9 +999,9 @@ localize("Mobile.SalesLogix.Views.Opportunity.List", {
   "addActivityActionText": "Aktivität hinzufügen",
   "hashTagQueriesText": {
     "open": "offen",
-    "closed": "abgeschl.",
-    "won": "erfolgr.",
-    "lost": "verlor."
+    "closed": "abgeschlossen",
+    "won": "erfolgreich",
+    "lost": "verloren"
   }
 });
 
@@ -1010,7 +1023,7 @@ localize("Mobile.SalesLogix.Views.OpportunityContact.Detail", {
 });
 
 localize("Mobile.SalesLogix.Views.OpportunityContact.Edit", {
-  "titleText": "VK-Chancenkont. bearb.",
+  "titleText": "Kontakt bearbeiten",
   "nameText": "Name",
   "accountNameText": "Firma",
   "contactTitleText": "Titel",
@@ -1044,9 +1057,9 @@ localize("Mobile.SalesLogix.Views.Owner.List", {
 localize("Mobile.SalesLogix.Views.Settings", {
   "clearLocalStorageTitleText": "Speich. löschen",
   "clearAuthenticationTitleText": "Gesp. Anm.daten löschen",
-  "errorLogTitleText": "Fehlerprot. anz.",
+  "errorLogTitleText": "Fehlerprotokoll",
   "localStorageClearedText": "Lokaler Speicher erfolgr. gelöscht.",
-  "credentialsClearedText": "Gesp. Anmeldedaten erfolgr. gelöscht.",
+  "credentialsClearedText": "Gespeicherte Anmeldedaten gelöscht",
   "titleText": "Einstell"
 });
 
@@ -1058,25 +1071,25 @@ localize("Mobile.SalesLogix.Views.Ticket.Detail", {
   "accountText": "Firma",
   "areaText": "Bereich",
   "assignedDateText": "Zugewiesen am",
-  "assignedToText": "Zugewiesen zu",
+  "assignedToText": "Zugewiesen an",
   "categoryText": "Kategorie",
   "contactText": "Kontakt",
   "contractText": "Vertrag",
   "descriptionText": "Beschr.",
   "issueText": "Problem",
-  "needByText": "Fälligk.datum",
+  "needByText": "Fälligkeitsdatum",
   "notesText": "Kommentare",
-  "phoneText": "Tel.",
+  "phoneText": "Telefon",
   "actionsText": "Schnellaktionen",
   "relatedActivitiesText": "Aktivitäten",
-  "relatedItemsText": "Zugeh. Elemente",
+  "relatedItemsText": "Zugehörige Elemente",
   "resolutionText": "Lösung",
   "sourceText": "Quelle",
   "statusText": "Status",
   "subjectText": "Betreff",
-  "ticketIdText": "Ticket-Nr.",
+  "ticketIdText": "Ticket-Nummer",
   "titleText": "Ticket",
-  "urgencyText": "Dringlichk.",
+  "urgencyText": "Dringlichkeit",
   "scheduleActivityText": "Aktivität planen",
   "moreDetailsText": "Mehr Details",
   "relatedTicketActivitiesText": "Ticket-Aktivitäten",
@@ -1087,19 +1100,19 @@ localize("Mobile.SalesLogix.Views.Ticket.Edit", {
   "accountText": "Firma",
   "areaText": "Bereich",
   "assignedDateText": "Zugewiesen am",
-  "assignedToText": "Zugewiesen zu",
+  "assignedToText": "Zugewiesen an",
   "categoryText": "Kategorie",
   "contactText": "Kontakt",
   "contractText": "Vertrag",
   "descriptionText": "Beschr.",
   "descriptionTitleText": "Beschreibung",
   "issueText": "Problem",
-  "needByText": "Fälligk.datum",
+  "needByText": "Fälligkeitsdatum",
   "notesText": "Kommentare",
   "notesTitleText": "Kommentare",
-  "phoneText": "Tel.",
+  "phoneText": "Telefon",
   "relatedActivitiesText": "Aktivitäten",
-  "relatedItemsText": "Zugeh. Elemente",
+  "relatedItemsText": "Zugehörige Elemente",
   "resolutionText": "Lösung",
   "resolutionTitleText": "Lösung",
   "sourceText": "Quelle",
@@ -1108,12 +1121,12 @@ localize("Mobile.SalesLogix.Views.Ticket.Edit", {
   "subjectText": "Betreff",
   "ticketAreaTitleText": "Ticket-Bereich",
   "ticketCategoryTitleText": "Ticket-Kategorie",
-  "ticketIdText": "Ticket-Nr.",
+  "ticketIdText": "Ticket-Nummer",
   "ticketIssueTitleText": "Ticket-Probl.",
   "ticketStatusTitleText": "Ticket-Status",
   "ticketUrgencyTitleText": "Ticket-Dringlichk.",
   "titleText": "Ticket",
-  "urgencyText": "Dringlichk."
+  "urgencyText": "Dringlichkeit"
 });
 
 localize("Mobile.SalesLogix.Views.Ticket.List", {
@@ -1137,10 +1150,10 @@ localize("Mobile.SalesLogix.Views.TicketActivity.Detail", {
   "accountText": "Firma",
   "contactText": "Kontakt",
   "typeText": "Typ",
-  "publicAccessText": "Öff. Zugriff",
+  "publicAccessText": "öffentl. Zugriff",
   "assignedDateText": "Startdatum",
   "completedDateText": "Enddatum",
-  "followUpText": "Folgeakt.",
+  "followUpText": "Folgeaktivität",
   "unitsText": "Zeiteinh.",
   "elapsedUnitsText": "Verstrichene Einheiten",
   "rateTypeDescriptionText": "Gebührentyp",
@@ -1149,24 +1162,12 @@ localize("Mobile.SalesLogix.Views.TicketActivity.Detail", {
   "totalPartsText": "Teile gesamt",
   "totalFeeText": "Gebühr gesamt",
   "activityDescriptionText": "Kommentare",
-  "ticketNumberText": "Ticket-Nr.",
+  "ticketNumberText": "Ticket-Nummer",
   "userText": "Benutzer",
   "completeTicketText": "Ticket-Aktivität abschließen",
   "moreDetailsText": "Mehr Details",
-  "relatedItemsText": "Zugeh. Elemente",
+  "relatedItemsText": "Zugehörige Elemente",
   "relatedTicketActivityItemText": "Ticket-Aktivität (Teile)"
-});
-
-localize("Mobile.SalesLogix.Views.TicketActivity.Edit", {
-  "titleText": "Ticket-Aktivität bearbeiten",
-  "activityTypeText": "Typ",
-  "activityTypeTitleText": "Typ",
-  "publicAccessText": "Öff. Zugriff",
-  "publicAccessTitleText": "Öffentlicher Zugriff",
-  "userText": "Benutzer",
-  "startDateText": "Startdatum",
-  "endDateText": "Enddatum",
-  "commentsText": "Kommentare"
 });
 
 localize("Mobile.SalesLogix.Views.TicketActivity.RateLookup", {
@@ -1179,7 +1180,7 @@ localize("Mobile.SalesLogix.Views.TicketActivityItem.Detail", {
   "skuText": "SKU",
   "serialNumberText": "Seriennr.",
   "itemAmountText": "Preis",
-  "itemDescriptionText": "Beschreib."
+  "itemDescriptionText": "Beschreibung"
 });
 
 localize("Mobile.SalesLogix.Views.TicketActivityItem.List", {

--- a/localization/saleslogix/fr.js
+++ b/localization/saleslogix/fr.js
@@ -335,6 +335,19 @@ localize("Mobile.SalesLogix.Views.History.List", {
   "viewContactActionText": "Contact"
 });
 
+localize("Mobile.SalesLogix.Views.TicketActivity.Edit", {
+  "startingFormatText": "d/M/yyyy h:mm tt",
+  "titleText": "Modifier l'activité du ticket",
+  "activityTypeText": "type",
+  "activityTypeTitleText": "Type",
+  "publicAccessText": "accès public",
+  "publicAccessTitleText": "Accès public",
+  "userText": "utilisateur",
+  "startDateText": "date début",
+  "endDateText": "date de fin",
+  "commentsText": "comm."
+});
+
 localize("Mobile.SalesLogix.Views.TicketActivity.List", {
   "startDateFormatText": "dd/MM/yyyy h:mmtt",
   "titleText": "Activités du ticket"
@@ -464,11 +477,11 @@ localize("Mobile.SalesLogix.Action", {
 
 localize("Mobile.SalesLogix.Fields.AddressField", {
   "lookupLabelText": "modif",
-  "emptyText": "aucune adr"
+  "emptyText": ""
 });
 
 localize("Mobile.SalesLogix.Fields.NameField", {
-  "emptyText": "0 nom"
+  "emptyText": ""
 });
 
 localize("Mobile.SalesLogix.Fields.RecurrencesField", {
@@ -1155,18 +1168,6 @@ localize("Mobile.SalesLogix.Views.TicketActivity.Detail", {
   "moreDetailsText": "Plus détails",
   "relatedItemsText": "Élém. assoc.",
   "relatedTicketActivityItemText": "Parties de l'activité du ticket"
-});
-
-localize("Mobile.SalesLogix.Views.TicketActivity.Edit", {
-  "titleText": "Modifier l'activité du ticket",
-  "activityTypeText": "type",
-  "activityTypeTitleText": "Type",
-  "publicAccessText": "accès public",
-  "publicAccessTitleText": "Accès public",
-  "userText": "utilisateur",
-  "startDateText": "date début",
-  "endDateText": "date de fin",
-  "commentsText": "comm."
 });
 
 localize("Mobile.SalesLogix.Views.TicketActivity.RateLookup", {

--- a/localization/saleslogix/it.js
+++ b/localization/saleslogix/it.js
@@ -335,6 +335,19 @@ localize("Mobile.SalesLogix.Views.History.List", {
   "viewContactActionText": "Contat."
 });
 
+localize("Mobile.SalesLogix.Views.TicketActivity.Edit", {
+  "startingFormatText": "d/M/yyyy h:mm tt",
+  "titleText": "Modifica Attività Ticket",
+  "activityTypeText": "tipo",
+  "activityTypeTitleText": "Tipo",
+  "publicAccessText": "acc. pubblico",
+  "publicAccessTitleText": "Acc. pubblico",
+  "userText": "utente",
+  "startDateText": "data iniz.",
+  "endDateText": "data fin",
+  "commentsText": "commenti"
+});
+
 localize("Mobile.SalesLogix.Views.TicketActivity.List", {
   "startDateFormatText": "dd/MM/yyyy h:mmtt",
   "titleText": "Attività Ticket"
@@ -459,16 +472,16 @@ localize("Sage.Platform.Mobile.Views.Signature", {
 
 localize("Mobile.SalesLogix.Action", {
   "calledText": "Chiam. ${0}",
-  "emailedText": "E-mailed ${0}"
+  "emailedText": "Inviato per email ${0}"
 });
 
 localize("Mobile.SalesLogix.Fields.AddressField", {
   "lookupLabelText": "mod.",
-  "emptyText": "nessun ind"
+  "emptyText": ""
 });
 
 localize("Mobile.SalesLogix.Fields.NameField", {
-  "emptyText": "no nome"
+  "emptyText": ""
 });
 
 localize("Mobile.SalesLogix.Fields.RecurrencesField", {
@@ -887,7 +900,7 @@ localize("Mobile.SalesLogix.Views.Lead.List", {
   "activitiesText": "Attività",
   "notesText": "Note",
   "scheduleText": "Pianif.",
-  "emailedText": "E-mailed ${0}",
+  "emailedText": "Inviato per email ${0}",
   "calledText": "Chiam. ${0}",
   "editActionText": "Mod.",
   "callMainActionText": "Chiama Principale",
@@ -1155,18 +1168,6 @@ localize("Mobile.SalesLogix.Views.TicketActivity.Detail", {
   "moreDetailsText": "Più Dettagli",
   "relatedItemsText": "VociCorrelate",
   "relatedTicketActivityItemText": "Ricambi"
-});
-
-localize("Mobile.SalesLogix.Views.TicketActivity.Edit", {
-  "titleText": "Modifica Attività Ticket",
-  "activityTypeText": "tipo",
-  "activityTypeTitleText": "Tipo",
-  "publicAccessText": "acc. pubblico",
-  "publicAccessTitleText": "Acc. pubblico",
-  "userText": "utente",
-  "startDateText": "data iniz.",
-  "endDateText": "data fin",
-  "commentsText": "commenti"
 });
 
 localize("Mobile.SalesLogix.Views.TicketActivity.RateLookup", {

--- a/localization/saleslogix/ru.js
+++ b/localization/saleslogix/ru.js
@@ -335,6 +335,19 @@ localize("Mobile.SalesLogix.Views.History.List", {
   "viewContactActionText": "Контакт"
 });
 
+localize("Mobile.SalesLogix.Views.TicketActivity.Edit", {
+  "startingFormatText": "dd.MM.yyyy hh:mm tt",
+  "titleText": "Измен. дело по заявке",
+  "activityTypeText": "тип",
+  "activityTypeTitleText": "Тип",
+  "publicAccessText": "публичный доступ",
+  "publicAccessTitleText": "Публичный доступ",
+  "userText": "пользователь",
+  "startDateText": "дата начала",
+  "endDateText": "дата окончания",
+  "commentsText": "комментарии"
+});
+
 localize("Mobile.SalesLogix.Views.TicketActivity.List", {
   "startDateFormatText": "dd.MM.yyyy hh:mm tt",
   "titleText": "Дела по заявке"
@@ -464,11 +477,11 @@ localize("Mobile.SalesLogix.Action", {
 
 localize("Mobile.SalesLogix.Fields.AddressField", {
   "lookupLabelText": "редактировать",
-  "emptyText": "нет адреса"
+  "emptyText": ""
 });
 
 localize("Mobile.SalesLogix.Fields.NameField", {
-  "emptyText": "нет имени"
+  "emptyText": ""
 });
 
 localize("Mobile.SalesLogix.Fields.RecurrencesField", {
@@ -1155,18 +1168,6 @@ localize("Mobile.SalesLogix.Views.TicketActivity.Detail", {
   "moreDetailsText": "Подробнее",
   "relatedItemsText": "Связанные записи",
   "relatedTicketActivityItemText": "Компоненты дела по заявке"
-});
-
-localize("Mobile.SalesLogix.Views.TicketActivity.Edit", {
-  "titleText": "Измен. дело по заявке",
-  "activityTypeText": "тип",
-  "activityTypeTitleText": "Тип",
-  "publicAccessText": "публичный доступ",
-  "publicAccessTitleText": "Публичный доступ",
-  "userText": "пользователь",
-  "startDateText": "дата начала",
-  "endDateText": "дата окончания",
-  "commentsText": "комментарии"
 });
 
 localize("Mobile.SalesLogix.Views.TicketActivity.RateLookup", {


### PR DESCRIPTION
@CHenrie Please review. John sent me XML files the LC team sent him for the mobile 2.0 release. I ran these through the argos localizer and updated our out of the box translations. 

https://www.sageslx.com/SlxClient/Defect.aspx?entityid=fYV3MA001YOL&modeid=Detail
