### PR TITLE
[13091666] Call disable() on the exchange rate date field instead of set...

### DIFF
--- a/src/Views/Opportunity/Edit.js
+++ b/src/Views/Opportunity/Edit.js
@@ -104,9 +104,9 @@ define('Mobile/SalesLogix/Views/Opportunity/Edit', [
                 this.fields['ExchangeRate'].disable();
                 this.fields['ExchangeRateCode'].disable();
                 this.fields['ExchangeRateLocked'].disable();
-                this.fields['ExchangeRateDate'].disable();
             }
 
+            this.fields['ExchangeRateDate'].disable();
             this.fields['SalesPotential'].setCurrencyCode(App.getBaseExchangeRate().code);
         },
         getValues: function() {
@@ -316,7 +316,7 @@ define('Mobile/SalesLogix/Views/Opportunity/Edit', [
                         name: 'ExchangeRateDate',
                         property: 'ExchangeRateDate',
                         type: 'date',
-                        disabled: true
+                        disabled: true // TODO: Create an SDK issue for this (NOT WORKING!!!)
                     }
                 ]
             };


### PR DESCRIPTION
...ting the disabled flag which is not working 100% in the SDK.

@CHenrie Please review. It looks like we need to fix the "disabled" flag in the SDK to set the input node to disabled as well. The disable function does this, so instead of setting the attribute, the work around is to call disable() on that field.
