### PR TITLE
Ensure the 5 second rule is set when saving a timeless activity. 8.1 Upd...

### DIFF
--- a/src/Views/Activity/Edit.js
+++ b/src/Views/Activity/Edit.js
@@ -955,6 +955,11 @@ define('Mobile/SalesLogix/Views/Activity/Edit', [
                 timeless = this.fields['Timeless'].getValue(),
                 alarmTime;
 
+            // Fix timeless if necessary (The date picker won't add 5 seconds)
+            if (timeless) {
+                values['StartDate'] = startDate = this._getNewStartDate(startDate, true);
+            }
+
             // if StartDate is dirty, always update AlarmTime
             if (startDate && (isStartDateDirty || isReminderDirty)) {
                 values = values || {};


### PR DESCRIPTION
...ate 05 changed this behavior and will convert the activity to not timeless otherwise.
# MBL-10838

@CHenrie Please review
