### PR TITLE
The current selected date from the calendar now gets passed through as a...

### DIFF
--- a/src/Views/Activity/Edit.js
+++ b/src/Views/Activity/Edit.js
@@ -620,31 +620,24 @@ define('crm/Views/Activity/Edit', [
 
             return recur.toString(recurrence, true);
         },
-        applyUserActivityContext: function(context) {
-            var view = App.getView(context.id);
-            if (view && view.currentDate)
-            {
-                var currentDate = view.currentDate.startOf('day'),
-                    userOptions = App.context['userOptions'],
-                    startTimeOption = userOptions && userOptions['Calendar:DayStartTime'],
-                    startTime = startTimeOption && moment(startTimeOption, 'h:mma'),
-                    startDate;
+        applyUserActivityContext: function(optionsDate) {
+            var currentDate = optionsDate.startOf('day'),
+                userOptions = App.context['userOptions'],
+                startTimeOption = userOptions && userOptions['Calendar:DayStartTime'],
+                startTime = startTimeOption && moment(startTimeOption, 'h:mma'),
+                startDate;
 
-                if (startTime && (currentDate.valueOf() == moment().startOf('day').valueOf()))
-                {
-                    startDate = currentDate.clone()
-                        .hours(startTime.hours())
-                        .minutes(startTime.minutes());
-                }
-                else
-                {
-                    startTime = moment();
-                    startDate = currentDate.startOf('day').hours(startTime.hours())
-                        .add({'minutes': (Math.floor(startTime.minutes() / 15) * 15) + 15});
-                }
-
-                this.fields['StartDate'].setValue(startDate.toDate());
+            if (startTime && (currentDate.valueOf() == moment().startOf('day').valueOf())) {
+                startDate = currentDate.clone()
+                    .hours(startTime.hours())
+                    .minutes(startTime.minutes());
+            } else {
+                startTime = moment();
+                startDate = currentDate.startOf('day').hours(startTime.hours())
+                    .add({'minutes': (Math.floor(startTime.minutes() / 15) * 15) + 15});
             }
+
+            this.fields['StartDate'].setValue(startDate.toDate());
         },
         applyContext: function() {
             this.inherited(arguments);
@@ -658,6 +651,11 @@ define('crm/Views/Activity/Edit', [
                 activityDuration = App.context.userOptions && App.context.userOptions[activityGroup + ':Duration'] || 15,
                 alarmEnabled = App.context.userOptions && App.context.userOptions[activityGroup + ':AlarmEnabled'] || true,
                 alarmDuration = App.context.userOptions && App.context.userOptions[activityGroup + ':AlarmLead'] || 15;
+
+            if (this.options && this.options.currentDate) {
+                startDate = moment(this.options.currentDate);
+                this.applyUserActivityContext(startDate);
+            }
 
             this.fields['StartDate'].setValue(startDate.toDate());
             this.fields['Type'].setValue(activityType);
@@ -685,9 +683,7 @@ define('crm/Views/Activity/Edit', [
                     'contacts': this.applyContactContext,
                     'opportunities': this.applyOpportunityContext,
                     'tickets': this.applyTicketContext,
-                    'leads': this.applyLeadContext,
-                    'useractivities': this.applyUserActivityContext,
-                    'activities': this.applyUserActivityContext
+                    'leads': this.applyLeadContext
                 };
 
             if (context && lookup[context.resourceKind]) {
@@ -699,14 +695,6 @@ define('crm/Views/Activity/Edit', [
                 var context = (o.options && o.options.source) || o;
 
                 if (/^(accounts|contacts|opportunities|tickets|leads)$/.test(context.resourceKind) && context.key) {
-                    return true;
-                }
-
-                if (/^(useractivities)$/.test(context.resourceKind)) {
-                    return true;
-                }
-
-                if (/^(activities)$/.test(context.resourceKind) && context.options['currentDate']) {
                     return true;
                 }
 

--- a/src/Views/Activity/TypesList.js
+++ b/src/Views/Activity/TypesList.js
@@ -92,7 +92,8 @@ define('crm/Views/Activity/TypesList', [
                             source: source,
                             activityType: params.key,
                             title: this.activityTypeText[params.key],
-                            returnTo: this.options && this.options.returnTo
+                            returnTo: this.options && this.options.returnTo,
+                            currentDate: this.options && this.options.currentDate
                         },{
                             returnTo: -1
                     });

--- a/src/Views/Calendar/DayView.js
+++ b/src/Views/Calendar/DayView.js
@@ -494,7 +494,8 @@ define('crm/Views/Calendar/DayView', [
                 view.show({
                     negateHistory: true,
                     returnTo: this.id,
-                    insert: true
+                    insert: true,
+                    currentDate: this.options.currentDate.valueOf()
                 });
             }
         },

--- a/src/Views/Calendar/MonthView.js
+++ b/src/Views/Calendar/MonthView.js
@@ -883,7 +883,8 @@ define('crm/Views/Calendar/MonthView', [
                 view.show({
                     negateHistory: true,
                     returnTo: this.id,
-                    insert: true
+                    insert: true,
+                    currentDate: this.options.currentDate.valueOf()
                 });
             }
         },

--- a/src/Views/Calendar/WeekView.js
+++ b/src/Views/Calendar/WeekView.js
@@ -592,7 +592,8 @@ define('crm/Views/Calendar/WeekView', [
                 view.show({
                     negateHistory: true,
                     returnTo: this.id,
-                    insert: true
+                    insert: true,
+                    currentDate: this.options.currentDate.valueOf()
                 });
             }
         },


### PR DESCRIPTION
... show option. This frees up searching the history context for the last account, contact, opp, ticket, or lead the user was on.
# MBL-10853

@CHenrie Please review. This fixes the issue where the calendar was taking up an entry slot in the query nav context.
