### PR TITLE
Keep the left nav/drawer search widget in sync with the list

### DIFF
--- a/build/release.jsb2
+++ b/build/release.jsb2
@@ -190,6 +190,9 @@
           "text": "config.js",
           "path": "../src-out/actions/"
         }, {
+          "text": "speedsearch.js",
+          "path": "../src-out/actions/"
+        }, {
           "text": "user.js",
           "path": "../src-out/actions/"
         }, {
@@ -393,6 +396,9 @@
         }, {
           "text": "Login.js",
           "path": "../src-out/Views/"
+        }, {
+          "text": "speedsearch.js",
+          "path": "../src-out/reducers/"
         }, {
           "text": "user.js",
           "path": "../src-out/reducers/"

--- a/src-out/Views/LeftDrawer.js
+++ b/src-out/Views/LeftDrawer.js
@@ -361,6 +361,14 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
         }, 10);
         this.closeAppMenu();
       }
+    },
+    onStateChange: function onStateChange(state) {
+      if (typeof state === 'undefined') {
+        return;
+      }
+      var searchTerm = state.app.speedsearch.searchTerm;
+
+      this.searchWidget.set('queryValue', searchTerm);
     }
   });
 

--- a/src-out/Views/SpeedSearchList.js
+++ b/src-out/Views/SpeedSearchList.js
@@ -1,4 +1,4 @@
-define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base/lang', 'dojo/string', '../SpeedSearchWidget', 'argos/List', 'argos/_LegacySDataListMixin', './_SpeedSearchRightDrawerListMixin', 'argos/I18n'], function (module, exports, _declare, _lang, _string, _SpeedSearchWidget, _List, _LegacySDataListMixin2, _SpeedSearchRightDrawerListMixin2, _I18n) {
+define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base/lang', 'dojo/string', '../SpeedSearchWidget', 'argos/List', 'argos/_LegacySDataListMixin', './_SpeedSearchRightDrawerListMixin', '../actions/speedsearch', 'argos/I18n'], function (module, exports, _declare, _lang, _string, _SpeedSearchWidget, _List, _LegacySDataListMixin2, _SpeedSearchRightDrawerListMixin2, _speedsearch, _I18n) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
@@ -25,22 +25,20 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
     };
   }
 
-  /* Copyright 2017 Infor
-   *
-   * Licensed under the Apache License, Version 2.0 (the "License");
-   * you may not use this file except in compliance with the License.
-   * You may obtain a copy of the License at
-   *
-   *    http://www.apache.org/licenses/LICENSE-2.0
-   *
-   * Unless required by applicable law or agreed to in writing, software
-   * distributed under the License is distributed on an "AS IS" BASIS,
-   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   * See the License for the specific language governing permissions and
-   * limitations under the License.
-   */
-
-  var resource = (0, _I18n2.default)('speedSearchList');
+  var resource = (0, _I18n2.default)('speedSearchList'); /* Copyright 2017 Infor
+                                                          *
+                                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                                          * you may not use this file except in compliance with the License.
+                                                          * You may obtain a copy of the License at
+                                                          *
+                                                          *    http://www.apache.org/licenses/LICENSE-2.0
+                                                          *
+                                                          * Unless required by applicable law or agreed to in writing, software
+                                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                          * See the License for the specific language governing permissions and
+                                                          * limitations under the License.
+                                                          */
 
   var __class = (0, _declare2.default)('crm.Views.SpeedSearchList', [_List2.default, _LegacySDataListMixin3.default, _SpeedSearchRightDrawerListMixin3.default], {
     // Templates
@@ -111,6 +109,9 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
     clear: function clear() {
       this.inherited(clear, arguments);
       this.currentPage = 0;
+      if (this.appStore) {
+        this.appStore.dispatch((0, _speedsearch.setSearchTerm)(''));
+      }
     },
     _formatFieldName: function _formatFieldName() {},
     getItemIconClass: function getItemIconClass(entry) {
@@ -211,6 +212,7 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       return request;
     },
     createSearchEntry: function createSearchEntry() {
+      this.appStore.dispatch((0, _speedsearch.setSearchTerm)(this.query));
       var entry = {
         request: {
           docTextItem: -1,

--- a/src-out/actions/speedsearch.js
+++ b/src-out/actions/speedsearch.js
@@ -1,0 +1,50 @@
+define('crm/actions/speedsearch', ['exports'], function (exports) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.setSearchTerm = setSearchTerm;
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  // action Types
+  var SET_SEARCHTERM = exports.SET_SEARCHTERM = 'SET_SEARCHTERM';
+
+  /*
+  
+  See: https://github.com/acdlite/flux-standard-action
+  
+  An action MUST
+  + be a plain JavaScript object.
+  + have a type property.
+  
+   An action MAY
+  + have an error property.
+  + have a payload property.
+  + have a meta property.
+  
+  An action MUST NOT
+  + include properties other than type, payload, error, and meta.
+  */
+
+  // creators
+  function setSearchTerm(searchTerm) {
+    return {
+      type: SET_SEARCHTERM,
+      payload: {
+        searchTerm: searchTerm
+      }
+    };
+  }
+});

--- a/src-out/reducers/index.js
+++ b/src-out/reducers/index.js
@@ -1,25 +1,24 @@
-define('crm/reducers/index', ['exports', './config', './user'], function (exports, _config, _user) {
+define('crm/reducers/index', ['exports', './config', './user', './speedsearch'], function (exports, _config, _user, _speedsearch) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
   exports.app = undefined;
-  /* Copyright 2017 Infor
-   *
-   * Licensed under the Apache License, Version 2.0 (the "License");
-   * you may not use this file except in compliance with the License.
-   * You may obtain a copy of the License at
-   *
-   *    http://www.apache.org/licenses/LICENSE-2.0
-   *
-   * Unless required by applicable law or agreed to in writing, software
-   * distributed under the License is distributed on an "AS IS" BASIS,
-   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   * See the License for the specific language governing permissions and
-   * limitations under the License.
-   */
-
   var app = exports.app = Redux.combineReducers({
     user: _user.user,
-    config: _config.config
-  });
+    config: _config.config,
+    speedsearch: _speedsearch.speedsearch
+  }); /* Copyright 2017 Infor
+       *
+       * Licensed under the Apache License, Version 2.0 (the "License");
+       * you may not use this file except in compliance with the License.
+       * You may obtain a copy of the License at
+       *
+       *    http://www.apache.org/licenses/LICENSE-2.0
+       *
+       * Unless required by applicable law or agreed to in writing, software
+       * distributed under the License is distributed on an "AS IS" BASIS,
+       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       * See the License for the specific language governing permissions and
+       * limitations under the License.
+       */
 });

--- a/src-out/reducers/speedsearch.js
+++ b/src-out/reducers/speedsearch.js
@@ -1,0 +1,42 @@
+define('crm/reducers/speedsearch', ['exports', '../actions/speedsearch'], function (exports, _speedsearch) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.speedsearch = speedsearch;
+
+
+  var initialUserState = {
+    searchTerm: ''
+  }; /* Copyright 2020 Infor
+      *
+      * Licensed under the Apache License, Version 2.0 (the "License");
+      * you may not use this file except in compliance with the License.
+      * You may obtain a copy of the License at
+      *
+      *    http://www.apache.org/licenses/LICENSE-2.0
+      *
+      * Unless required by applicable law or agreed to in writing, software
+      * distributed under the License is distributed on an "AS IS" BASIS,
+      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      * See the License for the specific language governing permissions and
+      * limitations under the License.
+      */
+
+  function speedsearch() {
+    var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialUserState;
+    var action = arguments[1];
+    var type = action.type,
+        payload = action.payload,
+        error = action.error,
+        meta = action.meta;
+    // eslint-disable-line
+    switch (type) {
+      case _speedsearch.SET_SEARCHTERM:
+        return Object.assign({}, state, {
+          searchTerm: payload.searchTerm
+        });
+      default:
+        return state;
+    }
+  }
+});

--- a/src/Views/LeftDrawer.js
+++ b/src/Views/LeftDrawer.js
@@ -356,6 +356,13 @@ const __class = declare('crm.Views.LeftDrawer', [GroupedList], {
       this.closeAppMenu();
     }
   },
+  onStateChange: function onStateChange(state) {
+    if (typeof state === 'undefined') {
+      return;
+    }
+    const { app: { speedsearch: { searchTerm } } } = state;
+    this.searchWidget.set('queryValue', searchTerm);
+  },
 });
 
 export default __class;

--- a/src/Views/SpeedSearchList.js
+++ b/src/Views/SpeedSearchList.js
@@ -20,6 +20,7 @@ import SpeedSearchWidget from '../SpeedSearchWidget';
 import List from 'argos/List';
 import _LegacySDataListMixin from 'argos/_LegacySDataListMixin';
 import _SpeedSearchRightDrawerListMixin from './_SpeedSearchRightDrawerListMixin';
+import { setSearchTerm } from '../actions/speedsearch';
 import getResource from 'argos/I18n';
 
 const resource = getResource('speedSearchList');
@@ -102,6 +103,9 @@ const __class = declare('crm.Views.SpeedSearchList', [List, _LegacySDataListMixi
   clear: function clear() {
     this.inherited(clear, arguments);
     this.currentPage = 0;
+    if (this.appStore) {
+      this.appStore.dispatch(setSearchTerm(''));
+    }
   },
   _formatFieldName: function _formatFieldName() {},
   getItemIconClass: function getItemIconClass(entry) {
@@ -204,6 +208,7 @@ const __class = declare('crm.Views.SpeedSearchList', [List, _LegacySDataListMixi
     return request;
   },
   createSearchEntry: function createSearchEntry() {
+    this.appStore.dispatch(setSearchTerm(this.query));
     const entry = {
       request: {
         docTextItem: -1,

--- a/src/actions/speedsearch.js
+++ b/src/actions/speedsearch.js
@@ -1,4 +1,4 @@
-/* Copyright 2017 Infor
+/* Copyright 2020 Infor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,32 @@
  * limitations under the License.
  */
 
-import { config } from './config';
-import { user } from './user';
-import { speedsearch } from './speedsearch';
+// action Types
+export const SET_SEARCHTERM = 'SET_SEARCHTERM';
 
-export const app = Redux.combineReducers({
-  user,
-  config,
-  speedsearch,
-});
+/*
+
+See: https://github.com/acdlite/flux-standard-action
+
+An action MUST
++ be a plain JavaScript object.
++ have a type property.
+
+ An action MAY
++ have an error property.
++ have a payload property.
++ have a meta property.
+
+An action MUST NOT
++ include properties other than type, payload, error, and meta.
+*/
+
+// creators
+export function setSearchTerm(searchTerm) {
+  return {
+    type: SET_SEARCHTERM,
+    payload: {
+      searchTerm,
+    },
+  };
+}

--- a/src/reducers/speedsearch.js
+++ b/src/reducers/speedsearch.js
@@ -1,4 +1,4 @@
-/* Copyright 2017 Infor
+/* Copyright 2020 Infor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,20 @@
  * limitations under the License.
  */
 
-import { config } from './config';
-import { user } from './user';
-import { speedsearch } from './speedsearch';
+import { SET_SEARCHTERM } from '../actions/speedsearch';
 
-export const app = Redux.combineReducers({
-  user,
-  config,
-  speedsearch,
-});
+const initialUserState = {
+  searchTerm: '',
+};
+
+export function speedsearch(state = initialUserState, action) {
+  const { type, payload, error, meta } = action; // eslint-disable-line
+  switch (type) {
+    case SET_SEARCHTERM:
+      return Object.assign({}, state, {
+        searchTerm: payload.searchTerm,
+      });
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
If you initiate a speedsearch from the left drawer, the speedsearch list
will open and the search input at the top will match what the user input
on the left drawer. However, if you change the search term at the top
of the list view and do another search, the left drawer/nav becomes out
of sync and displays the previous search term instead. Moving the search
term to the redux store added in 4.0 to keep this state in sync.

Fixes: INFORCRM-2909