### PR TITLE
Add a few application configuration to hide/disable remember me on login

### DIFF
--- a/configuration/development.default.js
+++ b/configuration/development.default.js
@@ -44,6 +44,7 @@ define('configuration/development.default', [
         "pu": "https://mingleinteg01-sso.mingledev.infor.com/ICRMMIG2_TST/as/",
         "oa": "authorization.oauth2", "ot": "token.oauth2", "or": "revoke_token.oauth2", "ev": "M1448056811"
     },
-    mingleRedirectUrl: 'http://test.infor.com:8000/products/argos-saleslogix/index-dev.html'
+    mingleRedirectUrl: 'http://test.infor.com:8000/products/argos-saleslogix/index-dev.html',
+    enableRememberMe: true
   };
 });

--- a/src-out/Application.js
+++ b/src-out/Application.js
@@ -166,6 +166,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
         maxUploadFileSize: 40000000,
         enableConcurrencyCheck: false,
         enableOfflineSupport: false,
+        enableRememberMe: true,
         warehouseDiscovery: 'auto',
         enableMingle: false,
         mingleEnabled: false, // Backwards compatibility

--- a/src-out/Views/Login.js
+++ b/src-out/Views/Login.js
@@ -84,6 +84,11 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
       if (state && state.app && state.app.config.endpoint) {
         this.fields['url-display'].setValue(state.app.config.endpoint);
       }
+
+      if (App.enableRememberMe !== true) {
+        this.fields.remember.disable();
+        this.fields.remember.hide();
+      }
     },
     _disable: function _disable() {
       this.fields['username-display'].disable();

--- a/src/Application.js
+++ b/src/Application.js
@@ -51,6 +51,7 @@ class Application extends SDKApplication {
     maxUploadFileSize: 40000000,
     enableConcurrencyCheck: false,
     enableOfflineSupport: false,
+    enableRememberMe: true,
     warehouseDiscovery: 'auto',
     enableMingle: false,
     mingleEnabled: false, // Backwards compatibility

--- a/src/Views/Login.js
+++ b/src/Views/Login.js
@@ -89,6 +89,11 @@ const __class = declare('crm.Views.Login', [Edit], {
     if (state && state.app && state.app.config.endpoint) {
       this.fields['url-display'].setValue(state.app.config.endpoint);
     }
+
+    if (App.enableRememberMe !== true) {
+      this.fields.remember.disable();
+      this.fields.remember.hide();
+    }
   },
   _disable: function _disable() {
     this.fields['username-display'].disable();


### PR DESCRIPTION
This will allow administrators to configure mobile so that the end users
cannot select the remember me checkbox on login. If not configured, the
option will default to enabled to match prior behavior.

Fixes: INFORCRM-3403