### PR TITLE
Fix removing the lead on a note when toggling "for lead"

### DIFF
--- a/src-out/Views/Activity/Edit.js
+++ b/src-out/Views/Activity/Edit.js
@@ -906,6 +906,11 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
         values.AlarmTime = alarmTime;
       }
 
+      if (this.fields.IsLead.getValue() === false) {
+        values.LeadId = null;
+        values.LeadName = null;
+      }
+
       return values;
     },
     createReminderData: function createReminderData() {

--- a/src-out/Views/History/Edit.js
+++ b/src-out/Views/History/Edit.js
@@ -471,6 +471,11 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
         values.Notes = text && text.length > 250 ? text.substr(0, 250) : text;
       }
 
+      if (this.fields.IsLead.getValue() === false) {
+        values.LeadId = null;
+        values.LeadName = null;
+      }
+
       return values;
     },
     _lookupApplyTo: function _lookupApplyTo(payload, value) {

--- a/src/Views/Activity/Edit.js
+++ b/src/Views/Activity/Edit.js
@@ -897,6 +897,11 @@ const __class = declare('crm.Views.Activity.Edit', [Edit], {
       values.AlarmTime = alarmTime;
     }
 
+    if (this.fields.IsLead.getValue() === false) {
+      values.LeadId = null;
+      values.LeadName = null;
+    }
+
     return values;
   },
   createReminderData: function createReminderData() {

--- a/src/Views/History/Edit.js
+++ b/src/Views/History/Edit.js
@@ -477,6 +477,11 @@ const __class = declare('crm.Views.History.Edit', [Edit], {
       values.Notes = text && text.length > 250 ? text.substr(0, 250) : text;
     }
 
+    if (this.fields.IsLead.getValue() === false) {
+      values.LeadId = null;
+      values.LeadName = null;
+    }
+
     return values;
   },
   _lookupApplyTo: function _lookupApplyTo(payload, value) {


### PR DESCRIPTION
Toggling the UI element would just hide the fields for lead. When
creating the PUT request to do the update, the form calls getValues to
collect dirty values for the payload. Since only the UI was toggled, the
underlying field is not dirty. In this case, we can null them out by
overriding getValues in the history/activity edit form.

Fixes: INFORCRM-15723