### PR TITLE
Use picklist code for Contour account type search query

### DIFF
--- a/src-out/Integrations/Contour/Views/PxSearch/AccountPxSearch.js
+++ b/src-out/Integrations/Contour/Views/PxSearch/AccountPxSearch.js
@@ -268,7 +268,7 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
       }
 
       for (var i = 0; i < data.$resources.length; i++) {
-        this.queryTypeEl.options[i] = new Option(data.$resources[i].text, data.$resources[i].text, true, false);
+        this.queryTypeEl.options[i] = new Option(data.$resources[i].text, data.$resources[i].code, true, false);
         if (this.queryTypeEl.options[i].value === 'Customer') {
           this.queryTypeEl.options[i].selected = 'True';
         }

--- a/src/Integrations/Contour/Views/PxSearch/AccountPxSearch.js
+++ b/src/Integrations/Contour/Views/PxSearch/AccountPxSearch.js
@@ -275,7 +275,7 @@ const __class = declare('crm.Integrations.Contour.Views.PxSearch.AccountPxSearch
     }
 
     for (let i = 0; i < data.$resources.length; i++) {
-      this.queryTypeEl.options[i] = new Option(data.$resources[i].text, data.$resources[i].text, true, false);
+      this.queryTypeEl.options[i] = new Option(data.$resources[i].text, data.$resources[i].code, true, false);
       if (this.queryTypeEl.options[i].value === 'Customer') {
         this.queryTypeEl.options[i].selected = 'True';
       }


### PR DESCRIPTION
The Contour account search was using the account type picklist text
value. If a customer localizes this picklist, the search will no longer
work unless the English version is selected.