### PR TITLE
Topic activity associations

### DIFF
--- a/build/release.jsb2
+++ b/build/release.jsb2
@@ -583,8 +583,14 @@
           "text": "Base.js",
           "path": "../src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/"
         }, {
+          "text": "Base.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/"
+        }, {
           "text": "List.js",
-          "path": "../src-out/Integrations/ActivityAssociations/Views/"
+          "path": "../src-out/Integrations/ActivityAssociations/Views/ActivityAssociation/"
+        }, {
+          "text": "List.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Views/HistoryAssociation/"
         }, {
           "text": "Base.js",
           "path": "../src-out/Integrations/BOE/Models/BackOffice/"
@@ -948,6 +954,12 @@
         }, {
           "text": "SData.js",
           "path": "../src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/"
+        }, {
+          "text": "Offline.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/"
+        }, {
+          "text": "SData.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/"
         }, {
           "text": "Offline.js",
           "path": "../src-out/Integrations/BOE/Models/BackOffice/"

--- a/build/release.jsb2
+++ b/build/release.jsb2
@@ -349,6 +349,9 @@
           "text": "Bootstrap.localization.js",
           "path": "../src-out/"
         }, {
+          "text": "Names.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Models/"
+        }, {
           "text": "DateRangeWidget.js",
           "path": "../src-out/Integrations/BOE/"
         }, {
@@ -576,6 +579,12 @@
         }, {
           "text": "AttachmentManager.js",
           "path": "../src-out/"
+        }, {
+          "text": "Base.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/"
+        }, {
+          "text": "List.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Views/"
         }, {
           "text": "Base.js",
           "path": "../src-out/Integrations/BOE/Models/BackOffice/"
@@ -935,6 +944,12 @@
           "path": "../src-out/Views/Attachment/"
         }, {
           "text": "Offline.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/"
+        }, {
+          "text": "SData.js",
+          "path": "../src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/"
+        }, {
+          "text": "Offline.js",
           "path": "../src-out/Integrations/BOE/Models/BackOffice/"
         }, {
           "text": "SData.js",
@@ -1242,6 +1257,9 @@
         }, {
           "text": "List.js",
           "path": "../src-out/Views/RecentlyViewed/"
+        }, {
+          "text": "ApplicationModule.js",
+          "path": "../src-out/Integrations/ActivityAssociations/"
         }, {
           "text": "ContactAssociationModule.js",
           "path": "../src-out/Integrations/BOE/Modules/"

--- a/configuration/development.default.js
+++ b/configuration/development.default.js
@@ -1,12 +1,14 @@
 /* eslint-disable */
 define('configuration/development.default', [
   'crm/ApplicationModule',
+  'crm/Integrations/ActivityAssociations/ApplicationModule',
   'crm/Integrations/BOE/ApplicationModule',
   'crm/Integrations/Contour/ApplicationModule',
-], function cb(ApplicationModule, BOEApplicationModule, ContourApplicationModule) {
+], function cb(ApplicationModule, ActivityAssociationsModule, BOEApplicationModule, ContourApplicationModule) {
   return {
     modules: [
       new ApplicationModule(),
+      new ActivityAssociationsModule(),
       new BOEApplicationModule({
         enableDashboards: true,
       }),

--- a/configuration/production.default.js
+++ b/configuration/production.default.js
@@ -7,12 +7,14 @@
  */
 define('configuration/production.default', [
   'crm/ApplicationModule',
+  'crm/Integrations/ActivityAssociations/ApplicationModule',
   'crm/Integrations/BOE/ApplicationModule',
   'crm/Integrations/Contour/ApplicationModule',
-], function cb(ApplicationModule, BOEApplicationModule, ContourApplicationModule) {
+], function cb(ApplicationModule, ActivityAssociationsModule, BOEApplicationModule, ContourApplicationModule) {
   return {
     modules: [
       new ApplicationModule(),
+      new ActivityAssociationsModule(),
       new BOEApplicationModule({
         enableDashboards: true,
       }),

--- a/localization/locales/crm/en/strings.l20n
+++ b/localization/locales/crm/en/strings.l20n
@@ -249,6 +249,11 @@
   confirmDeleteText: "Are you sure you want to remove this attendee?"
 >
 
+<activityAssociationList ""
+  titleText: "Activity Associations"
+  primaryText: "Primary?"
+>
+
 <historyAttendeeList ""
   titleText: "History Attendees"
   callPhoneActionText: "Call Phone"
@@ -1380,6 +1385,11 @@
   retrievingPicklistsText: "Retrieving Picklists"
 >
 
+<activityAssociationModule ""
+  relatedAssociationText: "Associations"
+  relatedAssociationTitleText: "Activity Associations"
+>
+
 <defaultMetrics ""
   totalRevenue: "Total Revenue"
   averageTime: "Avg Time as Customer"
@@ -1485,6 +1495,11 @@
 <activityAttendeeModel ""
   entityDisplayName: "Activity Attendee"
   entityDisplayNamePlural : "Activity Attendees"
+>
+
+<activityAssociationModel ""
+  entityDisplayName: "Activity Association"
+  entityDisplayNamePlural : "Activity Associations"
 >
 
 <historyAttendeeModel ""

--- a/localization/locales/crm/en/strings.l20n
+++ b/localization/locales/crm/en/strings.l20n
@@ -254,6 +254,11 @@
   primaryText: "Primary?"
 >
 
+<historyAssociationList ""
+  titleText: "History Associations"
+  primaryText: "Primary?"
+>
+
 <historyAttendeeList ""
   titleText: "History Attendees"
   callPhoneActionText: "Call Phone"
@@ -1388,6 +1393,7 @@
 <activityAssociationModule ""
   relatedAssociationText: "Associations"
   relatedAssociationTitleText: "Activity Associations"
+  relatedHistoryAssociationTitleText: "History Associations"
 >
 
 <defaultMetrics ""
@@ -1500,6 +1506,11 @@
 <activityAssociationModel ""
   entityDisplayName: "Activity Association"
   entityDisplayNamePlural : "Activity Associations"
+>
+
+<historyAssociationModel ""
+  entityDisplayName: "History Association"
+  entityDisplayNamePlural : "History Associations"
 >
 
 <historyAttendeeModel ""

--- a/src-out/Application.js
+++ b/src-out/Application.js
@@ -785,6 +785,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
       value: function onInitAppStateFailed(error) {
         var _this6 = this;
 
+        console.error(error); // eslint-disable-line
         var message = resource.appStateInitErrorText;
         this.hideApplicationMenu();
         _ErrorManager2.default.addSimpleError(message, error);

--- a/src-out/Integrations/ActivityAssociations/ApplicationModule.js
+++ b/src-out/Integrations/ActivityAssociations/ApplicationModule.js
@@ -88,6 +88,31 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
           title: resource.relatedHistoryAssociationTitleText
         }
       });
+
+      // Remove "for lead" toggle on activity edit, along with company, always show lead lookup
+      crm.Views.Activity.Edit.prototype.fieldsForLeads = [];
+      crm.Views.Activity.Edit.prototype.fieldsForStandard = [];
+      crm.Views.Activity.Edit.prototype.onLeadChange = function () {};
+      this.registerCustomization('edit', 'activity_edit', {
+        at: function at(row) {
+          return row.name === 'IsLead';
+        },
+
+        type: 'remove'
+      });
+      this.registerCustomization('edit', 'activity_edit', {
+        at: function at(row) {
+          return row.name === 'AccountName' && row.type === 'text';
+        },
+
+        type: 'modify',
+        value: {
+          name: 'AccountName',
+          property: 'AccountName',
+          type: 'hidden',
+          include: false
+        }
+      });
     },
     loadAppStatePromises: function loadAppStatePromises() {
       var app = this.application;

--- a/src-out/Integrations/ActivityAssociations/ApplicationModule.js
+++ b/src-out/Integrations/ActivityAssociations/ApplicationModule.js
@@ -1,4 +1,4 @@
-define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'argos/ApplicationModule', 'argos/I18n', './Views/List', './Models/ActivityAssociation/Offline', './Models/ActivityAssociation/SData'], function (module, exports, _declare, _ApplicationModule, _I18n, _List) {
+define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'argos/ApplicationModule', 'argos/I18n', './Views/ActivityAssociation/List', './Views/HistoryAssociation/List', './Models/ActivityAssociation/Offline', './Models/ActivityAssociation/SData', './Models/HistoryAssociation/Offline', './Models/HistoryAssociation/SData'], function (module, exports, _declare, _ApplicationModule, _I18n, _List, _List3) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
@@ -11,28 +11,28 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
 
   var _List2 = _interopRequireDefault(_List);
 
+  var _List4 = _interopRequireDefault(_List3);
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : {
       default: obj
     };
   }
 
-  /* Copyright 2020 Infor
-   *
-   * Licensed under the Apache License, Version 2.0 (the "License");
-   * you may not use this file except in compliance with the License.
-   * You may obtain a copy of the License at
-   *
-   *    http://www.apache.org/licenses/LICENSE-2.0
-   *
-   * Unless required by applicable law or agreed to in writing, software
-   * distributed under the License is distributed on an "AS IS" BASIS,
-   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   * See the License for the specific language governing permissions and
-   * limitations under the License.
-   */
-
-  var resource = (0, _I18n2.default)('activityAssociationModule');
+  var resource = (0, _I18n2.default)('activityAssociationModule'); /* Copyright 2020 Infor
+                                                                    *
+                                                                    * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                    * you may not use this file except in compliance with the License.
+                                                                    * You may obtain a copy of the License at
+                                                                    *
+                                                                    *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                    *
+                                                                    * Unless required by applicable law or agreed to in writing, software
+                                                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                    * See the License for the specific language governing permissions and
+                                                                    * limitations under the License.
+                                                                    */
 
   var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.ApplicationModule', [_ApplicationModule2.default], {
     hasNewActivityAssociations: function hasNewActivityAssociations() {
@@ -46,51 +46,14 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
       this.registerView(new _List2.default({
         id: 'activity_association_related'
       }));
+      this.registerView(new _List4.default({
+        id: 'history_association_related'
+      }));
     },
     loadCustomizationsDynamic: function loadCustomizations() {
       if (!this.hasNewActivityAssociations()) {
         return;
       }
-
-      this.registerCustomization('detail', 'activity_detail', {
-        at: function at(row) {
-          return row.name === 'AccountName';
-        },
-
-        type: 'remove'
-      });
-
-      this.registerCustomization('detail', 'activity_detail', {
-        at: function at(row) {
-          return row.name === 'ContactName';
-        },
-
-        type: 'remove'
-      });
-
-      this.registerCustomization('detail', 'activity_detail', {
-        at: function at(row) {
-          return row.name === 'OpportunityName';
-        },
-
-        type: 'remove'
-      });
-
-      this.registerCustomization('detail', 'activity_detail', {
-        at: function at(row) {
-          return row.name === 'TicketNumber';
-        },
-
-        type: 'remove'
-      });
-
-      this.registerCustomization('detail', 'activity_detail', {
-        at: function at(row) {
-          return row.name === 'LeadName';
-        },
-
-        type: 'remove'
-      });
 
       this.registerCustomization('detail', 'activity_detail', {
         at: function at(row) {
@@ -106,6 +69,23 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
           },
           view: 'activity_association_related',
           title: resource.relatedAssociationTitleText
+        }
+      });
+
+      this.registerCustomization('detail', 'history_detail', {
+        at: function at(row) {
+          return row.name === 'AttendeeRelated';
+        },
+
+        type: 'insert',
+        value: {
+          name: 'AssociationRelated',
+          label: resource.relatedAssociationText,
+          where: function where(entry) {
+            return 'HistoryId eq "' + entry.$key + '"';
+          },
+          view: 'history_association_related',
+          title: resource.relatedHistoryAssociationTitleText
         }
       });
     },

--- a/src-out/Integrations/ActivityAssociations/ApplicationModule.js
+++ b/src-out/Integrations/ActivityAssociations/ApplicationModule.js
@@ -1,0 +1,137 @@
+define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'argos/ApplicationModule', 'argos/I18n', './Views/List', './Models/ActivityAssociation/Offline', './Models/ActivityAssociation/SData'], function (module, exports, _declare, _ApplicationModule, _I18n, _List) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _ApplicationModule2 = _interopRequireDefault(_ApplicationModule);
+
+  var _I18n2 = _interopRequireDefault(_I18n);
+
+  var _List2 = _interopRequireDefault(_List);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var resource = (0, _I18n2.default)('activityAssociationModule');
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.ApplicationModule', [_ApplicationModule2.default], {
+    hasNewActivityAssociations: function hasNewActivityAssociations() {
+      return this.application.context.enableActivityAssociations === true;
+    },
+    loadViewsDynamic: function loadViews() {
+      if (!this.hasNewActivityAssociations()) {
+        return;
+      }
+
+      this.registerView(new _List2.default({
+        id: 'activity_association_related'
+      }));
+    },
+    loadCustomizationsDynamic: function loadCustomizations() {
+      if (!this.hasNewActivityAssociations()) {
+        return;
+      }
+
+      this.registerCustomization('detail', 'activity_detail', {
+        at: function at(row) {
+          return row.name === 'AccountName';
+        },
+
+        type: 'remove'
+      });
+
+      this.registerCustomization('detail', 'activity_detail', {
+        at: function at(row) {
+          return row.name === 'ContactName';
+        },
+
+        type: 'remove'
+      });
+
+      this.registerCustomization('detail', 'activity_detail', {
+        at: function at(row) {
+          return row.name === 'OpportunityName';
+        },
+
+        type: 'remove'
+      });
+
+      this.registerCustomization('detail', 'activity_detail', {
+        at: function at(row) {
+          return row.name === 'TicketNumber';
+        },
+
+        type: 'remove'
+      });
+
+      this.registerCustomization('detail', 'activity_detail', {
+        at: function at(row) {
+          return row.name === 'LeadName';
+        },
+
+        type: 'remove'
+      });
+
+      this.registerCustomization('detail', 'activity_detail', {
+        at: function at(row) {
+          return row.name === 'AttendeeRelated';
+        },
+
+        type: 'insert',
+        value: {
+          name: 'AssociationRelated',
+          label: resource.relatedAssociationText,
+          where: function where(entry) {
+            return 'ActivityId eq "' + entry.$key + '"';
+          },
+          view: 'activity_association_related',
+          title: resource.relatedAssociationTitleText
+        }
+      });
+    },
+    loadAppStatePromises: function loadAppStatePromises() {
+      var app = this.application;
+      this.registerAppStatePromise(function () {
+        return new Promise(function (resolve) {
+          // We are going to query the new activityAssociation endpoint to see if it 404 errors.
+          // This will tell us what the server supports for activity associations, which started in 8.4.0.4
+          var request = new Sage.SData.Client.SDataResourceCollectionRequest(app.getService()).setContractName('dynamic').setResourceKind('activityAssociations').setQueryArg('select', '$key').setQueryArg('count', 1);
+
+          request.read({
+            success: function success() {
+              resolve(true);
+              app.context.enableActivityAssociations = true;
+            },
+            failure: function failure() {
+              resolve(false);
+              app.context.enableActivityAssociations = false;
+            }
+          });
+        });
+      });
+    }
+  });
+
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/Base.js
+++ b/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/Base.js
@@ -1,0 +1,51 @@
+define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/Base', ['module', 'exports', 'dojo/_base/declare', 'argos/Models/_ModelBase', '../Names', 'argos/I18n'], function (module, exports, _declare, _ModelBase2, _Names, _I18n) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _ModelBase3 = _interopRequireDefault(_ModelBase2);
+
+  var _Names2 = _interopRequireDefault(_Names);
+
+  var _I18n2 = _interopRequireDefault(_I18n);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var resource = (0, _I18n2.default)('activityAssociationModel'); // eslint-disable-line
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.Base', [_ModelBase3.default], {
+    resourceKind: 'activityAssociations',
+    entityName: 'ActivityAssociation',
+    entityDisplayName: resource.entityDisplayName,
+    entityDisplayNamePlural: resource.entityDisplayNamePlural,
+    modelName: _Names2.default.ACTIVITYASSOCIATION,
+    listViewId: 'activity_association_list',
+    createRelationships: function createRelationships() {
+      var rel = this.relationships || (this.relationships = []);
+      return rel;
+    }
+  });
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/Offline.js
+++ b/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/Offline.js
@@ -1,0 +1,46 @@
+define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/Offline', ['module', 'exports', 'dojo/_base/declare', './Base', 'argos/Models/_OfflineModelBase', 'argos/Models/Manager', 'argos/Models/Types', '../Names'], function (module, exports, _declare, _Base, _OfflineModelBase2, _Manager, _Types, _Names) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _Base2 = _interopRequireDefault(_Base);
+
+  var _OfflineModelBase3 = _interopRequireDefault(_OfflineModelBase2);
+
+  var _Manager2 = _interopRequireDefault(_Manager);
+
+  var _Types2 = _interopRequireDefault(_Types);
+
+  var _Names2 = _interopRequireDefault(_Names);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.Offline', [_Base2.default, _OfflineModelBase3.default], {
+    id: 'activity_association_offline_model'
+  });
+
+  _Manager2.default.register(_Names2.default.ACTIVITYASSOCIATION, _Types2.default.OFFLINE, __class);
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/SData.js
+++ b/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/SData.js
@@ -1,0 +1,61 @@
+define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/SData', ['module', 'exports', 'dojo/_base/declare', './Base', 'argos/Models/_SDataModelBase', 'argos/Models/Manager', 'argos/Models/Types', '../Names'], function (module, exports, _declare, _Base, _SDataModelBase2, _Manager, _Types, _Names) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _Base2 = _interopRequireDefault(_Base);
+
+  var _SDataModelBase3 = _interopRequireDefault(_SDataModelBase2);
+
+  var _Manager2 = _interopRequireDefault(_Manager);
+
+  var _Types2 = _interopRequireDefault(_Types);
+
+  var _Names2 = _interopRequireDefault(_Names);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.SData', [_Base2.default, _SDataModelBase3.default], {
+    id: 'activity_association_sdata_model',
+    createQueryModels: function createQueryModels() {
+      return [{
+        name: 'list',
+        queryOrderBy: 'EntityName',
+        querySelect: ['EntityType', 'EntityId', 'EntityName', 'IsPrimary', 'ActivityId']
+      }, {
+        name: 'detail',
+        querySelect: ['EntityType', 'EntityId', 'EntityName', 'IsPrimary', 'ActivityId'],
+        queryInclude: ['$permissions']
+      }, {
+        name: 'edit',
+        querySelect: ['EntityType', 'EntityId', 'EntityName', 'IsPrimary', 'ActivityId'],
+        queryInclude: ['$permissions']
+      }];
+    }
+  });
+
+  _Manager2.default.register(_Names2.default.ACTIVITYASSOCIATION, _Types2.default.SDATA, __class);
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/Base.js
+++ b/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/Base.js
@@ -1,0 +1,51 @@
+define('crm/Integrations/ActivityAssociations/Models/HistoryAssociation/Base', ['module', 'exports', 'dojo/_base/declare', 'argos/Models/_ModelBase', '../Names', 'argos/I18n'], function (module, exports, _declare, _ModelBase2, _Names, _I18n) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _ModelBase3 = _interopRequireDefault(_ModelBase2);
+
+  var _Names2 = _interopRequireDefault(_Names);
+
+  var _I18n2 = _interopRequireDefault(_I18n);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var resource = (0, _I18n2.default)('historyAssociationModel'); // eslint-disable-line
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.Base', [_ModelBase3.default], {
+    resourceKind: 'historyAssociations',
+    entityName: 'HistoryAssociation',
+    entityDisplayName: resource.entityDisplayName,
+    entityDisplayNamePlural: resource.entityDisplayNamePlural,
+    modelName: _Names2.default.ACTIVITYASSOCIATION,
+    listViewId: 'history_association_list',
+    createRelationships: function createRelationships() {
+      var rel = this.relationships || (this.relationships = []);
+      return rel;
+    }
+  });
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/Offline.js
+++ b/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/Offline.js
@@ -1,0 +1,46 @@
+define('crm/Integrations/ActivityAssociations/Models/HistoryAssociation/Offline', ['module', 'exports', 'dojo/_base/declare', './Base', 'argos/Models/_OfflineModelBase', 'argos/Models/Manager', 'argos/Models/Types', '../Names'], function (module, exports, _declare, _Base, _OfflineModelBase2, _Manager, _Types, _Names) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _Base2 = _interopRequireDefault(_Base);
+
+  var _OfflineModelBase3 = _interopRequireDefault(_OfflineModelBase2);
+
+  var _Manager2 = _interopRequireDefault(_Manager);
+
+  var _Types2 = _interopRequireDefault(_Types);
+
+  var _Names2 = _interopRequireDefault(_Names);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.Offline', [_Base2.default, _OfflineModelBase3.default], {
+    id: 'history_association_offline_model'
+  });
+
+  _Manager2.default.register(_Names2.default.HISTORYASSOCIATION, _Types2.default.OFFLINE, __class);
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/SData.js
+++ b/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/SData.js
@@ -1,0 +1,61 @@
+define('crm/Integrations/ActivityAssociations/Models/HistoryAssociation/SData', ['module', 'exports', 'dojo/_base/declare', './Base', 'argos/Models/_SDataModelBase', 'argos/Models/Manager', 'argos/Models/Types', '../Names'], function (module, exports, _declare, _Base, _SDataModelBase2, _Manager, _Types, _Names) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _Base2 = _interopRequireDefault(_Base);
+
+  var _SDataModelBase3 = _interopRequireDefault(_SDataModelBase2);
+
+  var _Manager2 = _interopRequireDefault(_Manager);
+
+  var _Types2 = _interopRequireDefault(_Types);
+
+  var _Names2 = _interopRequireDefault(_Names);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.SData', [_Base2.default, _SDataModelBase3.default], {
+    id: 'history_association_sdata_model',
+    createQueryModels: function createQueryModels() {
+      return [{
+        name: 'list',
+        queryOrderBy: 'EntityName',
+        querySelect: ['EntityType', 'EntityId', 'EntityName', 'IsPrimary', 'HistoryId']
+      }, {
+        name: 'detail',
+        querySelect: ['EntityType', 'EntityId', 'EntityName', 'IsPrimary', 'HistoryId'],
+        queryInclude: ['$permissions']
+      }, {
+        name: 'edit',
+        querySelect: ['EntityType', 'EntityId', 'EntityName', 'IsPrimary', 'HistoryId'],
+        queryInclude: ['$permissions']
+      }];
+    }
+  });
+
+  _Manager2.default.register(_Names2.default.HISTORYASSOCIATION, _Types2.default.SDATA, __class);
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Models/Names.js
+++ b/src-out/Integrations/ActivityAssociations/Models/Names.js
@@ -3,7 +3,8 @@ define('crm/Integrations/ActivityAssociations/Models/Names', ['module', 'exports
     value: true
   });
   exports.default = {
-    ACTIVITYASSOCIATION: 'ActivityAssociation'
+    ACTIVITYASSOCIATION: 'ActivityAssociation',
+    HISTORYASSOCIATION: 'HistoryAssociation'
   };
   module.exports = exports['default'];
 });

--- a/src-out/Integrations/ActivityAssociations/Models/Names.js
+++ b/src-out/Integrations/ActivityAssociations/Models/Names.js
@@ -1,0 +1,9 @@
+define('crm/Integrations/ActivityAssociations/Models/Names', ['module', 'exports'], function (module, exports) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.default = {
+    ACTIVITYASSOCIATION: 'ActivityAssociation'
+  };
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Views/ActivityAssociation/List.js
+++ b/src-out/Integrations/ActivityAssociations/Views/ActivityAssociation/List.js
@@ -1,0 +1,73 @@
+define('crm/Integrations/ActivityAssociations/Views/ActivityAssociation/List', ['module', 'exports', 'dojo/_base/declare', 'argos/List', '../../Models/Names', 'argos/I18n'], function (module, exports, _declare, _List, _Names, _I18n) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _List2 = _interopRequireDefault(_List);
+
+  var _Names2 = _interopRequireDefault(_Names);
+
+  var _I18n2 = _interopRequireDefault(_I18n);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var resource = (0, _I18n2.default)('activityAssociationList');
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Views.ActivityAssociation.List', [_List2.default], {
+    // Localization
+    titleText: resource.titleText,
+    primaryText: resource.primaryText,
+
+    // Templates
+    itemTemplate: new Simplate(['<p class="micro-text">{%: $.EntityType %} | {%: $.EntityName %}</p>', '<p class="micro-text">{%: $$.primaryText %} {%: $.IsPrimary %}</p>']),
+
+    // View Properties
+    id: 'activity_association_list',
+    security: null,
+    detailView: 'activity_association_detail',
+    enableActions: true,
+    pageSize: 105,
+    resourceKind: 'activityAssociations',
+    modelName: _Names2.default.ACTIVITYASSOCIATION,
+
+    formatSearchQuery: function formatSearchQuery(searchQuery) {
+      return 'upper(EntityName) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+    },
+    getTitle: function getTitle(entry) {
+      if (!entry) {
+        return '';
+      }
+
+      return this._model && this._model.getEntityDescription(entry) || entry.EntityName;
+    },
+    createToolLayout: function createToolLayout() {
+      return this.tools || (this.tools = {
+        tbar: []
+      });
+    }
+  });
+
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Integrations/ActivityAssociations/Views/HistoryAssociation/List.js
+++ b/src-out/Integrations/ActivityAssociations/Views/HistoryAssociation/List.js
@@ -1,4 +1,4 @@
-define('crm/Integrations/ActivityAssociations/Views/List', ['module', 'exports', 'dojo/_base/declare', 'argos/List', '../Models/Names', 'argos/I18n'], function (module, exports, _declare, _List, _Names, _I18n) {
+define('crm/Integrations/ActivityAssociations/Views/HistoryAssociation/List', ['module', 'exports', 'dojo/_base/declare', 'argos/List', '../../Models/Names', 'argos/I18n'], function (module, exports, _declare, _List, _Names, _I18n) {
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
@@ -32,9 +32,9 @@ define('crm/Integrations/ActivityAssociations/Views/List', ['module', 'exports',
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityAssociationList');
+  var resource = (0, _I18n2.default)('historyAssociationList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Views.List', [_List2.default], {
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Views.HistoryAssociation.List', [_List2.default], {
     // Localization
     titleText: resource.titleText,
     primaryText: resource.primaryText,
@@ -43,13 +43,12 @@ define('crm/Integrations/ActivityAssociations/Views/List', ['module', 'exports',
     itemTemplate: new Simplate(['<p class="micro-text">{%: $.EntityType %} | {%: $.EntityName %}</p>', '<p class="micro-text">{%: $$.primaryText %} {%: $.IsPrimary %}</p>']),
 
     // View Properties
-    id: 'activity_association_list',
+    id: 'history_association_list',
     security: null,
-    detailView: 'activity_association_detail',
     enableActions: true,
     pageSize: 105,
-    resourceKind: 'activityAssociations',
-    modelName: _Names2.default.ACTIVITYASSOCIATION,
+    resourceKind: 'historyAssociations',
+    modelName: _Names2.default.HISTORYASSOCIATION,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
       return 'upper(EntityName) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
@@ -60,6 +59,11 @@ define('crm/Integrations/ActivityAssociations/Views/List', ['module', 'exports',
       }
 
       return this._model && this._model.getEntityDescription(entry) || entry.EntityName;
+    },
+    createToolLayout: function createToolLayout() {
+      return this.tools || (this.tools = {
+        tbar: []
+      });
     }
   });
 

--- a/src-out/Integrations/ActivityAssociations/Views/List.js
+++ b/src-out/Integrations/ActivityAssociations/Views/List.js
@@ -1,0 +1,68 @@
+define('crm/Integrations/ActivityAssociations/Views/List', ['module', 'exports', 'dojo/_base/declare', 'argos/List', '../Models/Names', 'argos/I18n'], function (module, exports, _declare, _List, _Names, _I18n) {
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  var _declare2 = _interopRequireDefault(_declare);
+
+  var _List2 = _interopRequireDefault(_List);
+
+  var _Names2 = _interopRequireDefault(_Names);
+
+  var _I18n2 = _interopRequireDefault(_I18n);
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : {
+      default: obj
+    };
+  }
+
+  /* Copyright 2020 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  var resource = (0, _I18n2.default)('activityAssociationList');
+
+  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Views.List', [_List2.default], {
+    // Localization
+    titleText: resource.titleText,
+    primaryText: resource.primaryText,
+
+    // Templates
+    itemTemplate: new Simplate(['<p class="micro-text">{%: $.EntityType %} | {%: $.EntityName %}</p>', '<p class="micro-text">{%: $$.primaryText %} {%: $.IsPrimary %}</p>']),
+
+    // View Properties
+    id: 'activity_association_list',
+    security: null,
+    detailView: 'activity_association_detail',
+    enableActions: true,
+    pageSize: 105,
+    resourceKind: 'activityAssociations',
+    modelName: _Names2.default.ACTIVITYASSOCIATION,
+
+    formatSearchQuery: function formatSearchQuery(searchQuery) {
+      return 'upper(EntityName) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+    },
+    getTitle: function getTitle(entry) {
+      if (!entry) {
+        return '';
+      }
+
+      return this._model && this._model.getEntityDescription(entry) || entry.EntityName;
+    }
+  });
+
+  exports.default = __class;
+  module.exports = exports['default'];
+});

--- a/src-out/Views/Activity/Edit.js
+++ b/src-out/Views/Activity/Edit.js
@@ -384,7 +384,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
     onLeadChange: function onLeadChange(value, field) {
       var selection = field.getSelection();
 
-      if (selection && this.insert) {
+      if (selection && this.options && this.options.insert) {
         this.fields.AccountName.setValue(_Utility2.default.getValue(selection, 'Company'));
       }
 
@@ -782,8 +782,10 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       this.fields.AccountName.setValue(entry.Company);
 
       var isLeadField = this.fields.IsLead;
-      isLeadField.setValue(context.resourceKind === 'leads');
-      this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+      if (isLeadField) {
+        isLeadField.setValue(context.resourceKind === 'leads');
+        this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+      }
 
       if (entry.WorkPhone) {
         var phoneField = this.fields.PhoneNumber;
@@ -822,8 +824,11 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
 
       if (this.isInLeadContext()) {
         var isLeadField = this.fields.IsLead;
-        isLeadField.setValue(true);
-        this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+        if (isLeadField) {
+          isLeadField.setValue(true);
+          this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+        }
+
         this.fields.Lead.setValue(values, true);
         this.fields.AccountName.setValue(values.AccountName);
       }
@@ -912,7 +917,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
         values.AlarmTime = alarmTime;
       }
 
-      if (this.fields.IsLead.getValue() === false) {
+      if (this.fields.IsLead && this.fields.IsLead.getValue() === false) {
         values.LeadId = null;
         values.LeadName = null;
       }

--- a/src-out/Views/Activity/Edit.js
+++ b/src-out/Views/Activity/Edit.js
@@ -1213,8 +1213,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
         valueKeyProperty: 'ContactId',
         valueTextProperty: 'ContactName',
         view: 'contact_related',
-        where: this.formatDependentQuery.bindDelegate(this, 'Account.Id eq "${0}"', 'AccountId'),
-        requireSelection: false
+        where: this.formatDependentQuery.bindDelegate(this, 'Account.Id eq "${0}"', 'AccountId')
       }, {
         dependsOn: 'Account',
         label: this.opportunityText,

--- a/src-out/Views/History/Edit.js
+++ b/src-out/Views/History/Edit.js
@@ -280,8 +280,10 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       this.fields.AccountName.setValue(entry.Company);
 
       var isLeadField = this.fields.IsLead;
-      isLeadField.setValue(context.resourceKind === 'leads');
-      this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+      if (isLeadField) {
+        isLeadField.setValue(context.resourceKind === 'leads');
+        this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+      }
     },
     applyOpportunityContext: function applyOpportunityContext(context) {
       var opportunityField = this.fields.Opportunity;
@@ -390,8 +392,11 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       this.inherited(setValues, arguments);
       var isLeadField = this.fields.IsLead;
       if (this.isInLeadContext()) {
-        isLeadField.setValue(true);
-        this.onIsLeadChange(true, isLeadField);
+        if (isLeadField) {
+          isLeadField.setValue(true);
+          this.onIsLeadChange(true, isLeadField);
+        }
+
         var field = this.fields.Lead;
         var value = _Utility2.default.getValue(values, field.applyTo, {});
         field.setValue(value, !this.inserting);
@@ -399,7 +404,7 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
         if (leadCompany) {
           this.fields.AccountName.setValue(leadCompany);
         }
-      } else {
+      } else if (isLeadField) {
         isLeadField.setValue(false);
       }
 
@@ -471,7 +476,7 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
         values.Notes = text && text.length > 250 ? text.substr(0, 250) : text;
       }
 
-      if (this.fields.IsLead.getValue() === false) {
+      if (this.fields.IsLead && this.fields.IsLead.getValue() === false) {
         values.LeadId = null;
         values.LeadName = null;
       }

--- a/src/Application.js
+++ b/src/Application.js
@@ -643,6 +643,7 @@ class Application extends SDKApplication {
     }
   }
   onInitAppStateFailed(error) {
+    console.error(error); // eslint-disable-line
     const message = resource.appStateInitErrorText;
     this.hideApplicationMenu();
     ErrorManager.addSimpleError(message, error);

--- a/src/Integrations/ActivityAssociations/ApplicationModule.js
+++ b/src/Integrations/ActivityAssociations/ApplicationModule.js
@@ -47,7 +47,7 @@ const __class = declare('crm.Integrations.ActivityAssociations.ApplicationModule
     }
 
     this.registerCustomization('detail', 'activity_detail', {
-      at(row) {
+      at: function at(row) {
         return row.name === 'AttendeeRelated';
       },
       type: 'insert',
@@ -63,7 +63,7 @@ const __class = declare('crm.Integrations.ActivityAssociations.ApplicationModule
     });
 
     this.registerCustomization('detail', 'history_detail', {
-      at(row) {
+      at: function at(row) {
         return row.name === 'AttendeeRelated';
       },
       type: 'insert',
@@ -82,16 +82,15 @@ const __class = declare('crm.Integrations.ActivityAssociations.ApplicationModule
     crm.Views.Activity.Edit.prototype.fieldsForLeads = [];
     crm.Views.Activity.Edit.prototype.fieldsForStandard = [];
     crm.Views.Activity.Edit.prototype.onLeadChange = () => {};
+    const companyEditAt = row => row.name === 'AccountName' && row.type === 'text';
     this.registerCustomization('edit', 'activity_edit', {
-      at(row) {
+      at: function at(row) {
         return row.name === 'IsLead';
       },
       type: 'remove',
     });
     this.registerCustomization('edit', 'activity_edit', {
-      at(row) {
-        return row.name === 'AccountName' && row.type === 'text';
-      },
+      at: companyEditAt,
       type: 'modify',
       value: {
         name: 'AccountName',
@@ -99,6 +98,58 @@ const __class = declare('crm.Integrations.ActivityAssociations.ApplicationModule
         type: 'hidden',
         include: false,
       },
+    });
+
+    // Remove "for lead" toggle on history edit, along with company, always show lead lookup
+    crm.Views.History.Edit.prototype.fieldsForLeads = [];
+    crm.Views.History.Edit.prototype.fieldsForStandard = [];
+    crm.Views.History.Edit.prototype.onLeadChange = () => {};
+    this.registerCustomization('edit', 'history_edit', {
+      at: function at(row) {
+        return row.name === 'IsLead';
+      },
+      type: 'remove',
+    });
+    this.registerCustomization('edit', 'history_edit', {
+      at: companyEditAt,
+      type: 'modify',
+      value: {
+        name: 'AccountName',
+        property: 'AccountName',
+        type: 'hidden',
+        include: false,
+      },
+    });
+
+    // Remove the "company" field, which is the second AccountName binding
+    const companyAt = row => row.name === 'AccountName' && typeof row.view === 'undefined';
+    this.registerCustomization('detail', 'activity_detail', {
+      at: companyAt,
+      type: 'remove',
+    });
+
+    this.registerCustomization('detail', 'history_detail', {
+      at: companyAt,
+      type: 'remove',
+    });
+
+    const removeExcludedProperty = ['AccountName', 'ContactName', 'OpportunityName', 'TicketNumber'];
+    removeExcludedProperty.forEach((prop) => {
+      const at = row => row.name === prop;
+      this.registerCustomization('detail', 'activity_detail', {
+        at,
+        type: 'modify',
+        value: {
+          exclude: null,
+        },
+      });
+      this.registerCustomization('detail', 'history_detail', {
+        at,
+        type: 'modify',
+        value: {
+          exclude: null,
+        },
+      });
     });
   },
   loadAppStatePromises: function loadAppStatePromises() {

--- a/src/Integrations/ActivityAssociations/ApplicationModule.js
+++ b/src/Integrations/ActivityAssociations/ApplicationModule.js
@@ -16,9 +16,12 @@
 import declare from 'dojo/_base/declare';
 import ApplicationModule from 'argos/ApplicationModule';
 import getResource from 'argos/I18n';
-import AssociationList from './Views/List';
+import ActivityAssociationList from './Views/ActivityAssociation/List';
+import HistoryAssociationList from './Views/HistoryAssociation/List';
 import './Models/ActivityAssociation/Offline';
 import './Models/ActivityAssociation/SData';
+import './Models/HistoryAssociation/Offline';
+import './Models/HistoryAssociation/SData';
 
 const resource = getResource('activityAssociationModule');
 
@@ -31,49 +34,17 @@ const __class = declare('crm.Integrations.ActivityAssociations.ApplicationModule
       return;
     }
 
-    this.registerView(new AssociationList({
+    this.registerView(new ActivityAssociationList({
       id: 'activity_association_related',
+    }));
+    this.registerView(new HistoryAssociationList({
+      id: 'history_association_related',
     }));
   },
   loadCustomizationsDynamic: function loadCustomizations() {
     if (!this.hasNewActivityAssociations()) {
       return;
     }
-
-    this.registerCustomization('detail', 'activity_detail', {
-      at(row) {
-        return row.name === 'AccountName';
-      },
-      type: 'remove',
-    });
-
-    this.registerCustomization('detail', 'activity_detail', {
-      at(row) {
-        return row.name === 'ContactName';
-      },
-      type: 'remove',
-    });
-
-    this.registerCustomization('detail', 'activity_detail', {
-      at(row) {
-        return row.name === 'OpportunityName';
-      },
-      type: 'remove',
-    });
-
-    this.registerCustomization('detail', 'activity_detail', {
-      at(row) {
-        return row.name === 'TicketNumber';
-      },
-      type: 'remove',
-    });
-
-    this.registerCustomization('detail', 'activity_detail', {
-      at(row) {
-        return row.name === 'LeadName';
-      },
-      type: 'remove',
-    });
 
     this.registerCustomization('detail', 'activity_detail', {
       at(row) {
@@ -88,6 +59,22 @@ const __class = declare('crm.Integrations.ActivityAssociations.ApplicationModule
         },
         view: 'activity_association_related',
         title: resource.relatedAssociationTitleText,
+      },
+    });
+
+    this.registerCustomization('detail', 'history_detail', {
+      at(row) {
+        return row.name === 'AttendeeRelated';
+      },
+      type: 'insert',
+      value: {
+        name: 'AssociationRelated',
+        label: resource.relatedAssociationText,
+        where: (entry) => {
+          return `HistoryId eq "${entry.$key}"`;
+        },
+        view: 'history_association_related',
+        title: resource.relatedHistoryAssociationTitleText,
       },
     });
   },

--- a/src/Integrations/ActivityAssociations/ApplicationModule.js
+++ b/src/Integrations/ActivityAssociations/ApplicationModule.js
@@ -77,6 +77,29 @@ const __class = declare('crm.Integrations.ActivityAssociations.ApplicationModule
         title: resource.relatedHistoryAssociationTitleText,
       },
     });
+
+    // Remove "for lead" toggle on activity edit, along with company, always show lead lookup
+    crm.Views.Activity.Edit.prototype.fieldsForLeads = [];
+    crm.Views.Activity.Edit.prototype.fieldsForStandard = [];
+    crm.Views.Activity.Edit.prototype.onLeadChange = () => {};
+    this.registerCustomization('edit', 'activity_edit', {
+      at(row) {
+        return row.name === 'IsLead';
+      },
+      type: 'remove',
+    });
+    this.registerCustomization('edit', 'activity_edit', {
+      at(row) {
+        return row.name === 'AccountName' && row.type === 'text';
+      },
+      type: 'modify',
+      value: {
+        name: 'AccountName',
+        property: 'AccountName',
+        type: 'hidden',
+        include: false,
+      },
+    });
   },
   loadAppStatePromises: function loadAppStatePromises() {
     const app = this.application;

--- a/src/Integrations/ActivityAssociations/ApplicationModule.js
+++ b/src/Integrations/ActivityAssociations/ApplicationModule.js
@@ -1,0 +1,121 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import declare from 'dojo/_base/declare';
+import ApplicationModule from 'argos/ApplicationModule';
+import getResource from 'argos/I18n';
+import AssociationList from './Views/List';
+import './Models/ActivityAssociation/Offline';
+import './Models/ActivityAssociation/SData';
+
+const resource = getResource('activityAssociationModule');
+
+const __class = declare('crm.Integrations.ActivityAssociations.ApplicationModule', [ApplicationModule], {
+  hasNewActivityAssociations: function hasNewActivityAssociations() {
+    return this.application.context.enableActivityAssociations === true;
+  },
+  loadViewsDynamic: function loadViews() {
+    if (!this.hasNewActivityAssociations()) {
+      return;
+    }
+
+    this.registerView(new AssociationList({
+      id: 'activity_association_related',
+    }));
+  },
+  loadCustomizationsDynamic: function loadCustomizations() {
+    if (!this.hasNewActivityAssociations()) {
+      return;
+    }
+
+    this.registerCustomization('detail', 'activity_detail', {
+      at(row) {
+        return row.name === 'AccountName';
+      },
+      type: 'remove',
+    });
+
+    this.registerCustomization('detail', 'activity_detail', {
+      at(row) {
+        return row.name === 'ContactName';
+      },
+      type: 'remove',
+    });
+
+    this.registerCustomization('detail', 'activity_detail', {
+      at(row) {
+        return row.name === 'OpportunityName';
+      },
+      type: 'remove',
+    });
+
+    this.registerCustomization('detail', 'activity_detail', {
+      at(row) {
+        return row.name === 'TicketNumber';
+      },
+      type: 'remove',
+    });
+
+    this.registerCustomization('detail', 'activity_detail', {
+      at(row) {
+        return row.name === 'LeadName';
+      },
+      type: 'remove',
+    });
+
+    this.registerCustomization('detail', 'activity_detail', {
+      at(row) {
+        return row.name === 'AttendeeRelated';
+      },
+      type: 'insert',
+      value: {
+        name: 'AssociationRelated',
+        label: resource.relatedAssociationText,
+        where: (entry) => {
+          return `ActivityId eq "${entry.$key}"`;
+        },
+        view: 'activity_association_related',
+        title: resource.relatedAssociationTitleText,
+      },
+    });
+  },
+  loadAppStatePromises: function loadAppStatePromises() {
+    const app = this.application;
+    this.registerAppStatePromise(() => {
+      return new Promise((resolve) => {
+        // We are going to query the new activityAssociation endpoint to see if it 404 errors.
+        // This will tell us what the server supports for activity associations, which started in 8.4.0.4
+        const request = new Sage.SData.Client.SDataResourceCollectionRequest(app.getService())
+          .setContractName('dynamic')
+          .setResourceKind('activityAssociations')
+          .setQueryArg('select', '$key')
+          .setQueryArg('count', 1);
+
+        request.read({
+          success: () => {
+            resolve(true);
+            app.context.enableActivityAssociations = true;
+          },
+          failure: () => {
+            resolve(false);
+            app.context.enableActivityAssociations = false;
+          },
+        });
+      });
+    });
+  },
+});
+
+export default __class;

--- a/src/Integrations/ActivityAssociations/Models/ActivityAssociation/Base.js
+++ b/src/Integrations/ActivityAssociations/Models/ActivityAssociation/Base.js
@@ -1,0 +1,35 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import declare from 'dojo/_base/declare';
+import _ModelBase from 'argos/Models/_ModelBase';
+import MODEL_NAMES from '../Names';
+import getResource from 'argos/I18n';
+
+const resource = getResource('activityAssociationModel'); // eslint-disable-line
+
+const __class = declare('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.Base', [_ModelBase], {
+  resourceKind: 'activityAssociations',
+  entityName: 'ActivityAssociation',
+  entityDisplayName: resource.entityDisplayName,
+  entityDisplayNamePlural: resource.entityDisplayNamePlural,
+  modelName: MODEL_NAMES.ACTIVITYASSOCIATION,
+  listViewId: 'activity_association_list',
+  createRelationships: function createRelationships() {
+    const rel = this.relationships || (this.relationships = []);
+    return rel;
+  },
+});
+export default __class;

--- a/src/Integrations/ActivityAssociations/Models/ActivityAssociation/Offline.js
+++ b/src/Integrations/ActivityAssociations/Models/ActivityAssociation/Offline.js
@@ -1,0 +1,28 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import declare from 'dojo/_base/declare';
+import Base from './Base';
+import _OfflineModelBase from 'argos/Models/_OfflineModelBase';
+import Manager from 'argos/Models/Manager';
+import MODEL_TYPES from 'argos/Models/Types';
+import MODEL_NAMES from '../Names';
+
+const __class = declare('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.Offline', [Base, _OfflineModelBase], {
+  id: 'activity_association_offline_model',
+});
+
+Manager.register(MODEL_NAMES.ACTIVITYASSOCIATION, MODEL_TYPES.OFFLINE, __class);
+export default __class;

--- a/src/Integrations/ActivityAssociations/Models/ActivityAssociation/SData.js
+++ b/src/Integrations/ActivityAssociations/Models/ActivityAssociation/SData.js
@@ -1,0 +1,65 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import declare from 'dojo/_base/declare';
+import Base from './Base';
+import _SDataModelBase from 'argos/Models/_SDataModelBase';
+import Manager from 'argos/Models/Manager';
+import MODEL_TYPES from 'argos/Models/Types';
+import MODEL_NAMES from '../Names';
+
+const __class = declare('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.SData', [Base, _SDataModelBase], {
+  id: 'activity_association_sdata_model',
+  createQueryModels: function createQueryModels() {
+    return [{
+      name: 'list',
+      queryOrderBy: 'EntityName',
+      querySelect: [
+        'EntityType',
+        'EntityId',
+        'EntityName',
+        'IsPrimary',
+        'ActivityId',
+      ],
+    }, {
+      name: 'detail',
+      querySelect: [
+        'EntityType',
+        'EntityId',
+        'EntityName',
+        'IsPrimary',
+        'ActivityId',
+      ],
+      queryInclude: [
+        '$permissions',
+      ],
+    }, {
+      name: 'edit',
+      querySelect: [
+        'EntityType',
+        'EntityId',
+        'EntityName',
+        'IsPrimary',
+        'ActivityId',
+      ],
+      queryInclude: [
+        '$permissions',
+      ],
+    }];
+  },
+});
+
+Manager.register(MODEL_NAMES.ACTIVITYASSOCIATION, MODEL_TYPES.SDATA, __class);
+export default __class;

--- a/src/Integrations/ActivityAssociations/Models/HistoryAssociation/Base.js
+++ b/src/Integrations/ActivityAssociations/Models/HistoryAssociation/Base.js
@@ -1,0 +1,35 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import declare from 'dojo/_base/declare';
+import _ModelBase from 'argos/Models/_ModelBase';
+import MODEL_NAMES from '../Names';
+import getResource from 'argos/I18n';
+
+const resource = getResource('historyAssociationModel'); // eslint-disable-line
+
+const __class = declare('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.Base', [_ModelBase], {
+  resourceKind: 'historyAssociations',
+  entityName: 'HistoryAssociation',
+  entityDisplayName: resource.entityDisplayName,
+  entityDisplayNamePlural: resource.entityDisplayNamePlural,
+  modelName: MODEL_NAMES.ACTIVITYASSOCIATION,
+  listViewId: 'history_association_list',
+  createRelationships: function createRelationships() {
+    const rel = this.relationships || (this.relationships = []);
+    return rel;
+  },
+});
+export default __class;

--- a/src/Integrations/ActivityAssociations/Models/HistoryAssociation/Offline.js
+++ b/src/Integrations/ActivityAssociations/Models/HistoryAssociation/Offline.js
@@ -13,7 +13,16 @@
  * limitations under the License.
  */
 
-export default {
-  ACTIVITYASSOCIATION: 'ActivityAssociation',
-  HISTORYASSOCIATION: 'HistoryAssociation',
-};
+import declare from 'dojo/_base/declare';
+import Base from './Base';
+import _OfflineModelBase from 'argos/Models/_OfflineModelBase';
+import Manager from 'argos/Models/Manager';
+import MODEL_TYPES from 'argos/Models/Types';
+import MODEL_NAMES from '../Names';
+
+const __class = declare('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.Offline', [Base, _OfflineModelBase], {
+  id: 'history_association_offline_model',
+});
+
+Manager.register(MODEL_NAMES.HISTORYASSOCIATION, MODEL_TYPES.OFFLINE, __class);
+export default __class;

--- a/src/Integrations/ActivityAssociations/Models/HistoryAssociation/SData.js
+++ b/src/Integrations/ActivityAssociations/Models/HistoryAssociation/SData.js
@@ -1,0 +1,65 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import declare from 'dojo/_base/declare';
+import Base from './Base';
+import _SDataModelBase from 'argos/Models/_SDataModelBase';
+import Manager from 'argos/Models/Manager';
+import MODEL_TYPES from 'argos/Models/Types';
+import MODEL_NAMES from '../Names';
+
+const __class = declare('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.SData', [Base, _SDataModelBase], {
+  id: 'history_association_sdata_model',
+  createQueryModels: function createQueryModels() {
+    return [{
+      name: 'list',
+      queryOrderBy: 'EntityName',
+      querySelect: [
+        'EntityType',
+        'EntityId',
+        'EntityName',
+        'IsPrimary',
+        'HistoryId',
+      ],
+    }, {
+      name: 'detail',
+      querySelect: [
+        'EntityType',
+        'EntityId',
+        'EntityName',
+        'IsPrimary',
+        'HistoryId',
+      ],
+      queryInclude: [
+        '$permissions',
+      ],
+    }, {
+      name: 'edit',
+      querySelect: [
+        'EntityType',
+        'EntityId',
+        'EntityName',
+        'IsPrimary',
+        'HistoryId',
+      ],
+      queryInclude: [
+        '$permissions',
+      ],
+    }];
+  },
+});
+
+Manager.register(MODEL_NAMES.HISTORYASSOCIATION, MODEL_TYPES.SDATA, __class);
+export default __class;

--- a/src/Integrations/ActivityAssociations/Models/Names.js
+++ b/src/Integrations/ActivityAssociations/Models/Names.js
@@ -1,0 +1,18 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default {
+  ACTIVITYASSOCIATION: 'ActivityAssociation',
+};

--- a/src/Integrations/ActivityAssociations/Views/ActivityAssociation/List.js
+++ b/src/Integrations/ActivityAssociations/Views/ActivityAssociation/List.js
@@ -15,12 +15,12 @@
 
 import declare from 'dojo/_base/declare';
 import List from 'argos/List';
-import MODEL_NAMES from '../Models/Names';
+import MODEL_NAMES from '../../Models/Names';
 import getResource from 'argos/I18n';
 
 const resource = getResource('activityAssociationList');
 
-const __class = declare('crm.Integrations.ActivityAssociations.Views.List', [List], {
+const __class = declare('crm.Integrations.ActivityAssociations.Views.ActivityAssociation.List', [List], {
   // Localization
   titleText: resource.titleText,
   primaryText: resource.primaryText,
@@ -49,6 +49,11 @@ const __class = declare('crm.Integrations.ActivityAssociations.Views.List', [Lis
     }
 
     return (this._model && this._model.getEntityDescription(entry)) || entry.EntityName;
+  },
+  createToolLayout: function createToolLayout() {
+    return this.tools || (this.tools = {
+      tbar: [],
+    });
   },
 });
 

--- a/src/Integrations/ActivityAssociations/Views/HistoryAssociation/List.js
+++ b/src/Integrations/ActivityAssociations/Views/HistoryAssociation/List.js
@@ -1,0 +1,59 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import declare from 'dojo/_base/declare';
+import List from 'argos/List';
+import MODEL_NAMES from '../../Models/Names';
+import getResource from 'argos/I18n';
+
+const resource = getResource('historyAssociationList');
+
+const __class = declare('crm.Integrations.ActivityAssociations.Views.HistoryAssociation.List', [List], {
+  // Localization
+  titleText: resource.titleText,
+  primaryText: resource.primaryText,
+
+  // Templates
+  itemTemplate: new Simplate([
+    '<p class="micro-text">{%: $.EntityType %} | {%: $.EntityName %}</p>',
+    '<p class="micro-text">{%: $$.primaryText %} {%: $.IsPrimary %}</p>',
+  ]),
+
+  // View Properties
+  id: 'history_association_list',
+  security: null,
+  enableActions: true,
+  pageSize: 105,
+  resourceKind: 'historyAssociations',
+  modelName: MODEL_NAMES.HISTORYASSOCIATION,
+
+  formatSearchQuery: function formatSearchQuery(searchQuery) {
+    return `upper(EntityName) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
+  },
+  getTitle: function getTitle(entry) {
+    if (!entry) {
+      return '';
+    }
+
+    return (this._model && this._model.getEntityDescription(entry)) || entry.EntityName;
+  },
+  createToolLayout: function createToolLayout() {
+    return this.tools || (this.tools = {
+      tbar: [],
+    });
+  },
+});
+
+export default __class;

--- a/src/Integrations/ActivityAssociations/Views/List.js
+++ b/src/Integrations/ActivityAssociations/Views/List.js
@@ -1,0 +1,55 @@
+/* Copyright 2020 Infor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import declare from 'dojo/_base/declare';
+import List from 'argos/List';
+import MODEL_NAMES from '../Models/Names';
+import getResource from 'argos/I18n';
+
+const resource = getResource('activityAssociationList');
+
+const __class = declare('crm.Integrations.ActivityAssociations.Views.List', [List], {
+  // Localization
+  titleText: resource.titleText,
+  primaryText: resource.primaryText,
+
+  // Templates
+  itemTemplate: new Simplate([
+    '<p class="micro-text">{%: $.EntityType %} | {%: $.EntityName %}</p>',
+    '<p class="micro-text">{%: $$.primaryText %} {%: $.IsPrimary %}</p>',
+  ]),
+
+  // View Properties
+  id: 'activity_association_list',
+  security: null,
+  detailView: 'activity_association_detail',
+  enableActions: true,
+  pageSize: 105,
+  resourceKind: 'activityAssociations',
+  modelName: MODEL_NAMES.ACTIVITYASSOCIATION,
+
+  formatSearchQuery: function formatSearchQuery(searchQuery) {
+    return `upper(EntityName) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
+  },
+  getTitle: function getTitle(entry) {
+    if (!entry) {
+      return '';
+    }
+
+    return (this._model && this._model.getEntityDescription(entry)) || entry.EntityName;
+  },
+});
+
+export default __class;

--- a/src/Views/Activity/Edit.js
+++ b/src/Views/Activity/Edit.js
@@ -365,7 +365,7 @@ const __class = declare('crm.Views.Activity.Edit', [Edit], {
   onLeadChange: function onLeadChange(value, field) {
     const selection = field.getSelection();
 
-    if (selection && this.insert) {
+    if (selection && this.options && this.options.insert) {
       this.fields.AccountName.setValue(utility.getValue(selection, 'Company'));
     }
 
@@ -770,8 +770,10 @@ const __class = declare('crm.Views.Activity.Edit', [Edit], {
     this.fields.AccountName.setValue(entry.Company);
 
     const isLeadField = this.fields.IsLead;
-    isLeadField.setValue(context.resourceKind === 'leads');
-    this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+    if (isLeadField) {
+      isLeadField.setValue(context.resourceKind === 'leads');
+      this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+    }
 
     if (entry.WorkPhone) {
       const phoneField = this.fields.PhoneNumber;
@@ -813,8 +815,11 @@ const __class = declare('crm.Views.Activity.Edit', [Edit], {
 
     if (this.isInLeadContext()) {
       const isLeadField = this.fields.IsLead;
-      isLeadField.setValue(true);
-      this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+      if (isLeadField) {
+        isLeadField.setValue(true);
+        this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+      }
+
       this.fields.Lead.setValue(values, true);
       this.fields.AccountName.setValue(values.AccountName);
     }
@@ -903,7 +908,7 @@ const __class = declare('crm.Views.Activity.Edit', [Edit], {
       values.AlarmTime = alarmTime;
     }
 
-    if (this.fields.IsLead.getValue() === false) {
+    if (this.fields.IsLead && this.fields.IsLead.getValue() === false) {
       values.LeadId = null;
       values.LeadName = null;
     }

--- a/src/Views/Activity/Edit.js
+++ b/src/Views/Activity/Edit.js
@@ -1217,7 +1217,6 @@ const __class = declare('crm.Views.Activity.Edit', [Edit], {
       where: this.formatDependentQuery.bindDelegate(
         this, 'Account.Id eq "${0}"', 'AccountId'
       ),
-      requireSelection: false,
     }, {
       dependsOn: 'Account',
       label: this.opportunityText,

--- a/src/Views/History/Edit.js
+++ b/src/Views/History/Edit.js
@@ -286,8 +286,10 @@ const __class = declare('crm.Views.History.Edit', [Edit], {
     this.fields.AccountName.setValue(entry.Company);
 
     const isLeadField = this.fields.IsLead;
-    isLeadField.setValue(context.resourceKind === 'leads');
-    this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+    if (isLeadField) {
+      isLeadField.setValue(context.resourceKind === 'leads');
+      this.onIsLeadChange(isLeadField.getValue(), isLeadField);
+    }
   },
   applyOpportunityContext: function applyOpportunityContext(context) {
     const opportunityField = this.fields.Opportunity;
@@ -396,8 +398,11 @@ const __class = declare('crm.Views.History.Edit', [Edit], {
     this.inherited(setValues, arguments);
     const isLeadField = this.fields.IsLead;
     if (this.isInLeadContext()) {
-      isLeadField.setValue(true);
-      this.onIsLeadChange(true, isLeadField);
+      if (isLeadField) {
+        isLeadField.setValue(true);
+        this.onIsLeadChange(true, isLeadField);
+      }
+
       const field = this.fields.Lead;
       const value = utility.getValue(values, field.applyTo, {});
       field.setValue(value, !this.inserting);
@@ -405,7 +410,7 @@ const __class = declare('crm.Views.History.Edit', [Edit], {
       if (leadCompany) {
         this.fields.AccountName.setValue(leadCompany);
       }
-    } else {
+    } else if (isLeadField) {
       isLeadField.setValue(false);
     }
 
@@ -477,7 +482,7 @@ const __class = declare('crm.Views.History.Edit', [Edit], {
       values.Notes = text && text.length > 250 ? text.substr(0, 250) : text;
     }
 
-    if (this.fields.IsLead.getValue() === false) {
+    if (this.fields.IsLead && this.fields.IsLead.getValue() === false) {
       values.LeadId = null;
       values.LeadName = null;
     }


### PR DESCRIPTION
This PR adds a conditional application module that will only run if an activiyAssociations endpoint exists (8.4.0.4)

- Adds a new related item to activity and history detail for associations
- Association lists to show activity associations and history associations
- Remove the "for lead" toggle on activity and history edit
- Always show lead on activity and history edit
- Remove company free text on both edits (was bound to AccountName)
- Always show primary associations on detail


Refs: INFORCRM-24768, INFORCRM-24769