### PR TITLE
Match web client functionality when editing history

### DIFF
--- a/src-out/Views/History/Edit.js
+++ b/src-out/Views/History/Edit.js
@@ -66,6 +66,8 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
     id: 'history_edit',
     fieldsForLeads: ['AccountName', 'Lead'],
     fieldsForStandard: ['Account', 'Contact', 'Opportunity', 'Ticket'],
+    // Fields that will get disabled when editing
+    restrictedFields: ['StartDate', 'IsLead', 'Account', 'AccountName', 'Contact', 'Opportunity', 'Ticket', 'Lead'],
     entityName: 'History',
     resourceKind: 'history',
     insertSecurity: null, // 'Entities/History/Add',
@@ -118,6 +120,33 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       } else {
         this.showFieldsForStandard();
       }
+    },
+    _setRestrictedFieldState: function _setRestrictedFieldState() {
+      var _this = this;
+
+      if (this.inserting) {
+        this.restrictedFields.forEach(function (f) {
+          return _this._enableField(_this.fields[f]);
+        });
+      } else {
+        this.restrictedFields.forEach(function (f) {
+          return _this._disableField(_this.fields[f]);
+        });
+      }
+    },
+    _disableField: function _disableField(field) {
+      if (!field) {
+        return;
+      }
+
+      field.disable();
+    },
+    _enableField: function _enableField(field) {
+      if (!field) {
+        return;
+      }
+
+      field.enable();
     },
     setOfflineNoteData: function setOfflineNoteData() {
       var entry = this.options && this.options.selectedEntry;
@@ -183,32 +212,32 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       }
     },
     showFieldsForLead: function showFieldsForLead() {
-      var _this = this;
-
-      this.fieldsForStandard.concat(this.fieldsForStandard).forEach(function (item) {
-        if (_this.fields[item]) {
-          _this.fields[item].hide();
-        }
-      }, this);
-
-      this.fieldsForLeads.forEach(function (item) {
-        if (_this.fields[item]) {
-          _this.fields[item].show();
-        }
-      }, this);
-    },
-    showFieldsForStandard: function showFieldsForStandard() {
       var _this2 = this;
 
-      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(function (item) {
+      this.fieldsForStandard.concat(this.fieldsForStandard).forEach(function (item) {
         if (_this2.fields[item]) {
           _this2.fields[item].hide();
         }
       }, this);
 
-      this.fieldsForStandard.forEach(function (item) {
+      this.fieldsForLeads.forEach(function (item) {
         if (_this2.fields[item]) {
           _this2.fields[item].show();
+        }
+      }, this);
+    },
+    showFieldsForStandard: function showFieldsForStandard() {
+      var _this3 = this;
+
+      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(function (item) {
+        if (_this3.fields[item]) {
+          _this3.fields[item].hide();
+        }
+      }, this);
+
+      this.fieldsForStandard.forEach(function (item) {
+        if (_this3.fields[item]) {
+          _this3.fields[item].show();
         }
       }, this);
     },
@@ -431,6 +460,8 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       if (denyEdit) {
         this.disableFields();
       }
+
+      this._setRestrictedFieldState();
     },
     disableFields: function disableFields(predicate) {
       for (var name in this.fields) {

--- a/src/Views/History/Edit.js
+++ b/src/Views/History/Edit.js
@@ -50,6 +50,17 @@ const __class = declare('crm.Views.History.Edit', [Edit], {
   id: 'history_edit',
   fieldsForLeads: ['AccountName', 'Lead'],
   fieldsForStandard: ['Account', 'Contact', 'Opportunity', 'Ticket'],
+  // Fields that will get disabled when editing
+  restrictedFields: [
+    'StartDate',
+    'IsLead',
+    'Account',
+    'AccountName',
+    'Contact',
+    'Opportunity',
+    'Ticket',
+    'Lead',
+  ],
   entityName: 'History',
   resourceKind: 'history',
   insertSecurity: null, // 'Entities/History/Add',
@@ -129,6 +140,27 @@ const __class = declare('crm.Views.History.Edit', [Edit], {
     } else {
       this.showFieldsForStandard();
     }
+  },
+  _setRestrictedFieldState: function _setRestrictedFieldState() {
+    if (this.inserting) {
+      this.restrictedFields.forEach(f => this._enableField(this.fields[f]));
+    } else {
+      this.restrictedFields.forEach(f => this._disableField(this.fields[f]));
+    }
+  },
+  _disableField: function _disableField(field) {
+    if (!field) {
+      return;
+    }
+
+    field.disable();
+  },
+  _enableField: function _enableField(field) {
+    if (!field) {
+      return;
+    }
+
+    field.enable();
   },
   setOfflineNoteData: function setOfflineNoteData() {
     const entry = this.options && this.options.selectedEntry;
@@ -437,6 +469,8 @@ const __class = declare('crm.Views.History.Edit', [Edit], {
     if (denyEdit) {
       this.disableFields();
     }
+
+    this._setRestrictedFieldState();
   },
   disableFields: function disableFields(predicate) {
     for (const name in this.fields) {


### PR DESCRIPTION
Don't allow the user to update the associations or startdate when
editing an existing record.

Refs: INFORCRM-24803