### PR TITLE
Filter dropdowns in settings->language settings

### DIFF
--- a/src-out/Views/LanguageOptions/UsageWidget.js
+++ b/src-out/Views/LanguageOptions/UsageWidget.js
@@ -74,12 +74,22 @@ define('crm/Views/LanguageOptions/UsageWidget', ['module', 'exports', 'dojo/_bas
       this.initUI(language || 'en', region || 'en');
     },
     initUI: function initUI(lang, region) {
-      var locales = [];
-      for (var key in window.languages) {
-        if (window.languages.hasOwnProperty(key)) {
-          locales.push({ value: key, text: window.languages[key], key: key });
-        }
-      }
+      var dropDownMap = function dropDownMap(key) {
+        return {
+          value: key,
+          text: window.languages[key],
+          key: key
+        };
+      };
+
+      var locales = Object.keys(window.languages).filter(function (key) {
+        return window.localeContext.supportedLocales.indexOf(key) > -1;
+      }).map(dropDownMap);
+
+      var regions = Object.keys(window.languages).filter(function (key) {
+        return window.regionalContext.supportedLocales.indexOf(key) > -1;
+      }).map(dropDownMap);
+
       if (!this._languageDropdown) {
         this._languageDropdown = new _Dropdown2.default({
           id: 'language-dropdown',
@@ -107,7 +117,7 @@ define('crm/Views/LanguageOptions/UsageWidget', ['module', 'exports', 'dojo/_bas
           label: this.regionText
         });
         this._regionDropdown.createList({
-          items: locales
+          items: regions
         });
         $(this._regionThanNode).append(this._regionDropdown.domNode);
         this._regionDropdown.setValue(region);

--- a/src/Views/LanguageOptions/UsageWidget.js
+++ b/src/Views/LanguageOptions/UsageWidget.js
@@ -59,12 +59,26 @@ const __class = declare('crm.Views.LanguageOptions.UsageWidget', [_RelatedViewWi
     this.initUI(language || 'en', region || 'en');
   },
   initUI: function initUI(lang, region) {
-    const locales = [];
-    for (const key in window.languages) {
-      if (window.languages.hasOwnProperty(key)) {
-        locales.push({ value: key, text: window.languages[key], key });
-      }
-    }
+    const dropDownMap = (key) => {
+      return {
+        value: key,
+        text: window.languages[key],
+        key,
+      };
+    };
+
+    const locales = Object.keys(window.languages)
+      .filter((key) => {
+        return window.localeContext.supportedLocales.indexOf(key) > -1;
+      })
+      .map(dropDownMap);
+
+    const regions = Object.keys(window.languages)
+      .filter((key) => {
+        return window.regionalContext.supportedLocales.indexOf(key) > -1;
+      })
+      .map(dropDownMap);
+
     if (!this._languageDropdown) {
       this._languageDropdown = new Dropdown({
         id: 'language-dropdown',
@@ -92,7 +106,7 @@ const __class = declare('crm.Views.LanguageOptions.UsageWidget', [_RelatedViewWi
         label: this.regionText,
       });
       this._regionDropdown.createList({
-        items: locales,
+        items: regions,
       });
       $(this._regionThanNode).append(this._regionDropdown.domNode);
       this._regionDropdown.setValue(region);


### PR DESCRIPTION
The current language and regional dropdowns in language settings
are just loading based on the global languages available. This
currently is OK since we have available language strings and
regions in sync. However, if we were to go ahead and add regions
without strings, the mismatch will allow the user to select a
language that will not have strings translated. This changeset will
filter down the available list based on what the L20N context has
loaded.