### PR TITLE
Error handling for service worker registration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 *.css    text
 *.js     text
 *.sql    text
-*.l20n   text diff=astextplain
+*.l20n   text=auto
 
 *.csproj text merge=union
 *.sln    text merge=union eol=crlf

--- a/src-out/Application.js
+++ b/src-out/Application.js
@@ -274,7 +274,12 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'isServiceWorkerEnabled',
       value: function isServiceWorkerEnabled() {
-        return (this.enableOfflineSupport || this.enableServiceWorker) && 'serviceWorker' in navigator;
+        try {
+          return (this.enableOfflineSupport || this.enableServiceWorker) && 'serviceWorker' in navigator;
+        } catch (err) {
+          _ErrorManager2.default.addSimpleError('Error in isServiceWorkerEnabled()', err);
+          this.showServiceWorkerError();
+        }
       }
     }, {
       key: 'registerCacheUrl',

--- a/src/Application.js
+++ b/src/Application.js
@@ -192,7 +192,12 @@ class Application extends SDKApplication {
   }
 
   isServiceWorkerEnabled() {
-    return (this.enableOfflineSupport || this.enableServiceWorker) && 'serviceWorker' in navigator;
+    try {
+      return (this.enableOfflineSupport || this.enableServiceWorker) && 'serviceWorker' in navigator;
+    } catch (err) {
+      ErrorManager.addSimpleError('Error in isServiceWorkerEnabled()', err);
+      this.showServiceWorkerError();
+    }
   }
 
   registerCacheUrl(url) {


### PR DESCRIPTION
Add error handling for when an exception could be thrown registering
a service worker. Right now it blocks mobile from loading if an
error occurs.

Refs: INFORCRM-25868