### PR TITLE
Remove es2015, es2016, and es2017 babel transforms

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,17 +1,12 @@
 {
   "presets": [
-    ["es2015", {
-      "modules": false
-    }],
-    "es2016",
-    "es2017"
   ],
   "plugins": [
+    "transform-es2015-classes",
     "add-module-exports",
     ["transform-es2015-modules-amd", {
       "strict": false
-    }],
-    "transform-object-rest-spread"
+    }]
   ],
   "sourceRoot": "src",
   "moduleRoot": "crm",

--- a/build/release.jsb2
+++ b/build/release.jsb2
@@ -422,6 +422,9 @@
           "path": "../src-out/Models/Address/"
         }, {
           "text": "Base.js",
+          "path": "../src-out/Models/AreaCategoryIssue/"
+        }, {
+          "text": "Base.js",
           "path": "../src-out/Models/Contact/"
         }, {
           "text": "Base.js",
@@ -480,6 +483,15 @@
         }, {
           "text": "List.js",
           "path": "../src-out/Views/Address/"
+        }, {
+          "text": "AreaLookup.js",
+          "path": "../src-out/Views/AreaCategoryIssue/"
+        }, {
+          "text": "CategoryLookup.js",
+          "path": "../src-out/Views/AreaCategoryIssue/"
+        }, {
+          "text": "IssueLookup.js",
+          "path": "../src-out/Views/AreaCategoryIssue/"
         }, {
           "text": "Detail.js",
           "path": "../src-out/Views/ErrorLog/"
@@ -852,6 +864,9 @@
         }, {
           "text": "SData.js",
           "path": "../src-out/Models/Address/"
+        }, {
+          "text": "SData.js",
+          "path": "../src-out/Models/AreaCategoryIssue/"
         }, {
           "text": "Offline.js",
           "path": "../src-out/Models/Contact/"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.1.0",
     "babel-plugin-add-module-exports": "0.2.1",
+    "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-polyfill": "^6.26.0",

--- a/src-out/Action.js
+++ b/src-out/Action.js
@@ -35,32 +35,32 @@ define('crm/Action', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
   /**
    * @module crm/Action
    */
-  var resource = (0, _I18n2.default)('action');
+  const resource = (0, _I18n2.default)('action');
 
   /**
    * @class
    * @alias module:crm/Action
    * @static
    */
-  var __class = _lang2.default.setObject('crm.Action', /** @lends module:crm/Action */{
+  const __class = _lang2.default.setObject('crm.Action', /** @lends module:crm/Action */{
     calledText: resource.calledText,
     emailedText: resource.emailedText,
 
     navigateToHistoryInsert: function navigateToHistoryInsert(entry, complete, title) {
-      var view = App.getView('history_edit');
+      const view = App.getView('history_edit');
       if (view) {
         view.show({
-          title: title,
+          title,
           template: {},
-          entry: entry,
+          entry,
           insert: true
         }, {
-          complete: complete
+          complete
         });
       }
     },
     recordToHistory: function recordToHistory(complete, o, title) {
-      var entry = {
+      const entry = {
         UserId: App.context && App.context.user.$key,
         UserName: App.context && App.context.user.$descriptor,
         Duration: 15,
@@ -75,7 +75,7 @@ define('crm/Action', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
         return;
       }
 
-      var actionInitiated = false;
+      let actionInitiated = false;
       this.setSource({
         entry: selection.data,
         descriptor: selection.data.$descriptor,
@@ -87,8 +87,8 @@ define('crm/Action', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
         Description: _string2.default.substitute(crm.Action.calledText, [selection.data.$descriptor])
       });
 
-      var value = _Utility2.default.getValue(selection.data, phoneProperty, '');
-      crm.Action.recordToHistory(function () {
+      const value = _Utility2.default.getValue(selection.data, phoneProperty, '');
+      crm.Action.recordToHistory(() => {
         if (!actionInitiated) {
           App.initiateCall(value);
           actionInitiated = true;
@@ -111,23 +111,23 @@ define('crm/Action', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
         Description: _string2.default.substitute(crm.Action.emailedText, [selection.data.$descriptor])
       });
 
-      var value = _Utility2.default.getValue(selection.data, emailProperty, '');
-      crm.Action.recordToHistory(function () {
+      const value = _Utility2.default.getValue(selection.data, emailProperty, '');
+      crm.Action.recordToHistory(() => {
         App.initiateEmail(value);
       }, selection.data);
     },
     addNote: function addNote(action, selection) {
-      var entry = selection.data;
-      var key = selection.data.$key;
-      var desc = selection.data.$descriptor;
+      const entry = selection.data;
+      const key = selection.data.$key;
+      const desc = selection.data.$descriptor;
 
       this.setSource({
-        entry: entry,
+        entry,
         descriptor: desc,
-        key: key
+        key
       });
 
-      var view = App.getView('history_edit');
+      const view = App.getView('history_edit');
 
       if (view) {
         view.show({
@@ -144,12 +144,12 @@ define('crm/Action', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
       App.navigateToActivityInsertView();
     },
     navigateToEntity: function navigateToEntity(action, selection, o) {
-      var options = {
+      const options = {
         key: _Utility2.default.getValue(selection.data, o.keyProperty),
         descriptor: _Utility2.default.getValue(selection.data, o.textProperty)
       };
 
-      var view = App.getView(o.view);
+      const view = App.getView(o.view);
 
       if (view && options.key) {
         view.show(options);
@@ -165,7 +165,7 @@ define('crm/Action', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
         key: selection.data.$key
       });
 
-      var view = App.getView('attachment_Add');
+      const view = App.getView('attachment_Add');
 
       if (view) {
         view.show({

--- a/src-out/Aggregate.js
+++ b/src-out/Aggregate.js
@@ -17,15 +17,15 @@ define('crm/Aggregate', ['module', 'exports', 'dojo/_base/lang'], function (modu
    * @classdesc Aggregate functions. Currently used in metric widgets.
    * @static
    */
-  var __class = _lang2.default.setObject('crm.Aggregate', /** @lends module:crm/Aggregate */{
+  const __class = _lang2.default.setObject('crm.Aggregate', /** @lends module:crm/Aggregate */{
     /**
      * Average
      * @param {Array} data Array of objects that contain a value property
      * @return {Number}
      */
     avg: function avg(data) {
-      var aggr = window.crm.Aggregate;
-      var average = aggr.sum(data) / aggr.count(data);
+      const aggr = window.crm.Aggregate;
+      const average = aggr.sum(data) / aggr.count(data);
       return isNaN(average) ? 0 : average;
     },
     /**
@@ -60,7 +60,7 @@ define('crm/Aggregate', ['module', 'exports', 'dojo/_base/lang'], function (modu
      * @return {Number}
      */
     max: function max(data) {
-      var flatten = data.map(function (item) {
+      const flatten = data.map(item => {
         return item.value;
       });
 
@@ -72,7 +72,7 @@ define('crm/Aggregate', ['module', 'exports', 'dojo/_base/lang'], function (modu
      * @return {Number}
      */
     min: function min(data) {
-      var flatten = data.map(function (item) {
+      const flatten = data.map(item => {
         return item.value;
       });
 
@@ -84,12 +84,12 @@ define('crm/Aggregate', ['module', 'exports', 'dojo/_base/lang'], function (modu
      * @return {Number}
      */
     sum: function sum(data) {
-      var total = 0;
+      let total = 0;
       if (!Array.isArray(data)) {
         return total;
       }
 
-      total = data.reduce(function (p, c) {
+      total = data.reduce((p, c) => {
         return p + c.value;
       }, 0);
 

--- a/src-out/Application.js
+++ b/src-out/Application.js
@@ -33,44 +33,6 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     };
   }
 
-  var _slicedToArray = function () {
-    function sliceIterator(arr, i) {
-      var _arr = [];
-      var _n = true;
-      var _d = false;
-      var _e = undefined;
-
-      try {
-        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-          _arr.push(_s.value);
-
-          if (i && _arr.length === i) break;
-        }
-      } catch (err) {
-        _d = true;
-        _e = err;
-      } finally {
-        try {
-          if (!_n && _i["return"]) _i["return"]();
-        } finally {
-          if (_d) throw _e;
-        }
-      }
-
-      return _arr;
-    }
-
-    return function (arr, i) {
-      if (Array.isArray(arr)) {
-        return arr;
-      } else if (Symbol.iterator in Object(arr)) {
-        return sliceIterator(arr, i);
-      } else {
-        throw new TypeError("Invalid attempt to destructure non-iterable instance");
-      }
-    };
-  }();
-
   function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
       throw new TypeError("Cannot call a class as a function");
@@ -144,36 +106,34 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
   }
 
-  var resource = (0, _I18n2.default)('application');
+  const resource = (0, _I18n2.default)('application');
 
   /**
    * @alias module:crm/Application
    * @extends module:argos/Application
    */
 
-  var Application = function (_SDKApplication) {
+  let Application = function (_SDKApplication) {
     _inherits(Application, _SDKApplication);
 
-    function Application() {
-      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {
-        connections: null,
-        defaultLocale: 'en',
-        enableMultiCurrency: false,
-        multiCurrency: false, // Backwards compatibility
-        enableGroups: true,
-        enableHashTags: true,
-        maxUploadFileSize: 40000000,
-        enableConcurrencyCheck: false,
-        enableOfflineSupport: false,
-        enableServiceWorker: false,
-        enableRememberMe: true,
-        warehouseDiscovery: 'auto',
-        enableMingle: false,
-        mingleEnabled: false, // Backwards compatibility
-        mingleSettings: null,
-        mingleRedirectUrl: ''
-      };
-
+    function Application(options = {
+      connections: null,
+      defaultLocale: 'en',
+      enableMultiCurrency: false,
+      multiCurrency: false, // Backwards compatibility
+      enableGroups: true,
+      enableHashTags: true,
+      maxUploadFileSize: 40000000,
+      enableConcurrencyCheck: false,
+      enableOfflineSupport: false,
+      enableServiceWorker: false,
+      enableRememberMe: true,
+      warehouseDiscovery: 'auto',
+      enableMingle: false,
+      mingleEnabled: false, // Backwards compatibility
+      mingleSettings: null,
+      mingleRedirectUrl: ''
+    }) {
       _classCallCheck(this, Application);
 
       var _this = _possibleConstructorReturn(this, (Application.__proto__ || Object.getPrototypeOf(Application)).call(this));
@@ -243,24 +203,24 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
         this._config = null;
         this._loadNavigationState();
 
-        var accessToken = null;
+        let accessToken = null;
         if (this.isMingleEnabled()) {
           accessToken = this.mingleAuthResults.access_token;
         }
 
         this.UID = new Date().getTime();
-        var original = Sage.SData.Client.SDataService.prototype.executeRequest;
-        var self = this;
+        const original = Sage.SData.Client.SDataService.prototype.executeRequest;
+        const self = this;
         Sage.SData.Client.SDataService.prototype.executeRequest = function executeRequest(request) {
           if (accessToken) {
-            request.setRequestHeader('Authorization', 'Bearer ' + accessToken);
-            request.setRequestHeader('X-Authorization', 'Bearer ' + accessToken);
+            request.setRequestHeader('Authorization', `Bearer ${accessToken}`);
+            request.setRequestHeader('X-Authorization', `Bearer ${accessToken}`);
           }
 
           request.setRequestHeader('X-Application-Name', self.appName);
-          var version = self.mobileVersion;
-          var id = self.UID;
-          request.setRequestHeader('X-Application-Version', version.major + '.' + version.minor + '.' + version.revision + ';' + id);
+          const version = self.mobileVersion;
+          const id = self.UID;
+          request.setRequestHeader('X-Application-Version', `${version.major}.${version.minor}.${version.revision};${id}`);
           return original.apply(this, arguments);
         };
       }
@@ -285,7 +245,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
       key: 'registerCacheUrl',
       value: function registerCacheUrl(url) {
         if (this.isServiceWorkerEnabled()) {
-          return this.sendServiceWorkerMessage({ command: 'add', url: url });
+          return this.sendServiceWorkerMessage({ command: 'add', url });
         }
 
         return Promise.resolve(true);
@@ -293,12 +253,10 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'registerCacheUrls',
       value: function registerCacheUrls(urls) {
-        var _this2 = this;
-
         if (this.isServiceWorkerEnabled()) {
-          return this.sendServiceWorkerMessage({ command: 'addall', urls: urls }).then(function (data) {
+          return this.sendServiceWorkerMessage({ command: 'addall', urls }).then(data => {
             if (data.results === 'added' || data.results === 'skipped') {
-              _this2.toast.add({ message: _this2.fileCacheText, title: _this2.fileCacheTitle, toastTime: 20000 });
+              this.toast.add({ message: this.fileCacheText, title: this.fileCacheTitle, toastTime: 20000 });
             }
 
             return data;
@@ -311,10 +269,8 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
       key: 'clearServiceWorkerCaches',
       value: function clearServiceWorkerCaches() {
         if (this.isServiceWorkerEnabled()) {
-          return caches.keys().then(function (keys) {
-            return Promise.all(keys.map(function (key) {
-              return caches.delete(key);
-            }));
+          return caches.keys().then(keys => {
+            return Promise.all(keys.map(key => caches.delete(key)));
           });
         }
 
@@ -334,9 +290,9 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'getReducer',
       value: function getReducer() {
-        var sdk = _get(Application.prototype.__proto__ || Object.getPrototypeOf(Application.prototype), 'getReducer', this).apply(this, arguments);
+        const sdk = _get(Application.prototype.__proto__ || Object.getPrototypeOf(Application.prototype), 'getReducer', this).apply(this, arguments);
         return Redux.combineReducers({
-          sdk: sdk,
+          sdk,
           app: _index.app
         });
       }
@@ -358,11 +314,11 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'isOnFirstView',
       value: function isOnFirstView() {
-        var history = this.context.history;
-        var length = history.length;
-        var current = history[length - 1];
-        var previous = history[length - 2];
-        var isFirstView = false;
+        const history = this.context.history;
+        const length = history.length;
+        const current = history[length - 1];
+        const previous = history[length - 2];
+        let isFirstView = false;
 
         if (current && current.page === this.loginViewId || current && current.page === this.logOffViewId) {
           isFirstView = true;
@@ -443,14 +399,14 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'getMyExchangeRate',
       value: function getMyExchangeRate() {
-        var results = {
+        const results = {
           code: '',
           rate: 1
         };
 
         if (this.hasMultiCurrency() && this.context && this.context.exchangeRates && this.context.userOptions && this.context.userOptions['General:Currency']) {
-          var myCode = this.context.userOptions['General:Currency'];
-          var myRate = this.context.exchangeRates[myCode];
+          const myCode = this.context.userOptions['General:Currency'];
+          const myRate = this.context.exchangeRates[myCode];
           Object.assign(results, {
             code: myCode,
             rate: myRate
@@ -462,14 +418,14 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'getBaseExchangeRate',
       value: function getBaseExchangeRate() {
-        var results = {
+        const results = {
           code: '',
           rate: 1
         };
 
         if (this.hasMultiCurrency() && this.context && this.context.exchangeRates && this.context.systemOptions && this.context.systemOptions.BaseCurrency) {
-          var baseCode = this.context.systemOptions.BaseCurrency;
-          var baseRate = this.context.exchangeRates[baseCode];
+          const baseCode = this.context.systemOptions.BaseCurrency;
+          const baseRate = this.context.exchangeRates[baseCode];
           Object.assign(results, {
             code: baseCode,
             rate: baseRate
@@ -481,12 +437,12 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'getCurrentOpportunityExchangeRate',
       value: function getCurrentOpportunityExchangeRate() {
-        var results = {
+        const results = {
           code: '',
           rate: 1
         };
 
-        var found = this.queryNavigationContext(function (o) {
+        let found = this.queryNavigationContext(o => {
           return (/^(opportunities)$/.test(o.resourceKind) && o.key
           );
         });
@@ -494,11 +450,11 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
         found = found && found.options;
 
         if (found) {
-          var rate = found.ExchangeRate;
-          var code = found.ExchangeRateCode;
+          const rate = found.ExchangeRate;
+          const code = found.ExchangeRateCode;
           Object.assign(results, {
-            code: code,
-            rate: rate
+            code,
+            rate
           });
         }
 
@@ -528,9 +484,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'onAuthenticateUserSuccess',
       value: function onAuthenticateUserSuccess(credentials, callback, scope, result) {
-        var _this3 = this;
-
-        var user = {
+        const user = {
           $key: result.response.userId.trim(),
           $descriptor: result.response.prettyName,
           UserName: result.response.userName
@@ -542,8 +496,8 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
 
         if (this.context.securedActions) {
           this.context.userSecurity = {};
-          this.context.securedActions.forEach(function (item) {
-            _this3.context.userSecurity[item] = true;
+          this.context.securedActions.forEach(item => {
+            this.context.userSecurity[item] = true;
           });
         } else {
           // downgrade server version as only 8.0 has `securedActions` as part of the
@@ -568,33 +522,33 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
 
         if (callback) {
           callback.call(scope || this, {
-            user: user
+            user
           });
         }
       }
     }, {
       key: 'onAuthenticateUserFailure',
       value: function onAuthenticateUserFailure(callback, scope, response) {
-        var service = this.getService();
+        const service = this.getService();
         if (service) {
           service.setUserName(false).setPassword(false);
         }
 
         if (callback) {
           callback.call(scope || this, {
-            response: response
+            response
           });
         }
       }
     }, {
       key: 'authenticateUser',
       value: function authenticateUser(credentials, options) {
-        var service = this.getService();
+        const service = this.getService();
         if (credentials) {
           service.setUserName(credentials.username).setPassword(credentials.password || '');
         }
 
-        var request = new Sage.SData.Client.SDataServiceOperationRequest(service).setContractName('system').setOperationName('getCurrentUser');
+        const request = new Sage.SData.Client.SDataServiceOperationRequest(service).setContractName('system').setOperationName('getCurrentUser');
 
         request.execute({}, {
           success: this.onAuthenticateUserSuccess.bind(this, credentials, options.success, options.scope),
@@ -609,9 +563,9 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
           return true;
         }
 
-        var user = this.context.user;
-        var userId = user && user.$key;
-        var userSecurity = this.context.userSecurity;
+        const user = this.context.user;
+        const userId = user && user.$key;
+        const userSecurity = this.context.userSecurity;
 
         if (/^ADMIN\s*/i.test(userId)) {
           return true;
@@ -633,7 +587,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
       key: 'resetModuleAppStatePromises',
       value: function resetModuleAppStatePromises() {
         this.clearAppStatePromises();
-        for (var i = 0; i < this.modules.length; i++) {
+        for (let i = 0; i < this.modules.length; i++) {
           this.modules[i].loadAppStatePromises(this);
         }
       }
@@ -643,7 +597,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
         this.removeCredentials();
         this._clearNavigationState();
 
-        var service = this.getService();
+        const service = this.getService();
         this.isAuthenticated = false;
         this.context = {
           history: []
@@ -655,7 +609,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
           service.setUserName(false).setPassword(false);
         }
 
-        var view = this.getView(this.logOffViewId);
+        const view = this.getView(this.logOffViewId);
 
         if (view) {
           view.show();
@@ -664,11 +618,11 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'getCredentials',
       value: function getCredentials() {
-        var credentials = null;
+        let credentials = null;
         try {
           if (window.localStorage) {
-            var stored = window.localStorage.getItem('credentials');
-            var encoded = stored && Base64.decode(stored);
+            const stored = window.localStorage.getItem('credentials');
+            const encoded = stored && Base64.decode(stored);
             credentials = encoded && JSON.parse(encoded);
           }
         } catch (e) {} //eslint-disable-line
@@ -687,7 +641,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'handleAuthentication',
       value: function handleAuthentication() {
-        var credentials = this.getCredentials();
+        const credentials = this.getCredentials();
 
         if (credentials) {
           this.setPrimaryTitle(this.authText);
@@ -719,28 +673,26 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'onHandleAuthenticationSuccess',
       value: function onHandleAuthenticationSuccess() {
-        var _this4 = this;
-
         this.isAuthenticated = true;
         this.setPrimaryTitle(this.loadingText);
         this.showHeader();
-        this.initAppState().then(function () {
-          _this4.onInitAppStateSuccess();
-        }, function (err) {
-          _this4.hideHeader();
-          _this4.onInitAppStateFailed(err);
+        this.initAppState().then(() => {
+          this.onInitAppStateSuccess();
+        }, err => {
+          this.hideHeader();
+          this.onInitAppStateFailed(err);
         });
       }
     }, {
       key: 'showHeader',
       value: function showHeader() {
-        var header = $('.header', this.getContainerNode());
+        const header = $('.header', this.getContainerNode());
         header.show();
       }
     }, {
       key: 'hideHeader',
       value: function hideHeader() {
-        var header = $('.header', this.getContainerNode());
+        const header = $('.header', this.getContainerNode());
         header.hide();
       }
     }, {
@@ -763,21 +715,19 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'onInitAppStateSuccess',
       value: function onInitAppStateSuccess() {
-        var _this5 = this;
-
         this.setDefaultMetricPreferences();
         this.showApplicationMenuOnLarge();
         if (this.enableOfflineSupport) {
-          this.initOfflineData().then(function () {
-            _this5.hasState = true;
-            _this5.navigateToInitialView();
-          }, function (error) {
-            _this5.hasState = true;
-            _this5.enableOfflineSupport = false;
-            var message = resource.offlineInitErrorText;
+          this.initOfflineData().then(() => {
+            this.hasState = true;
+            this.navigateToInitialView();
+          }, error => {
+            this.hasState = true;
+            this.enableOfflineSupport = false;
+            const message = resource.offlineInitErrorText;
             _ErrorManager2.default.addSimpleError(message, error);
-            _ErrorManager2.default.showErrorDialog(null, message, function () {
-              _this5.navigateToInitialView();
+            _ErrorManager2.default.showErrorDialog(null, message, () => {
+              this.navigateToInitialView();
             });
           });
         } else {
@@ -788,16 +738,14 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'onInitAppStateFailed',
       value: function onInitAppStateFailed(error) {
-        var _this6 = this;
-
         console.error(error); // eslint-disable-line
-        var message = resource.appStateInitErrorText;
+        const message = resource.appStateInitErrorText;
         this.hideApplicationMenu();
         _ErrorManager2.default.addSimpleError(message, error);
-        _ErrorManager2.default.showErrorDialog(null, message, function () {
-          _this6._clearNavigationState();
-          _this6.removeCredentials();
-          _this6.navigateToLoginView();
+        _ErrorManager2.default.showErrorDialog(null, message, () => {
+          this._clearNavigationState();
+          this.removeCredentials();
+          this.navigateToLoginView();
         });
       }
     }, {
@@ -835,7 +783,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
           return;
         }
 
-        var views = this.getDefaultViews();
+        const views = this.getDefaultViews();
 
         this.preferences = {
           home: {
@@ -849,11 +797,11 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'getMetricsByResourceKind',
       value: function getMetricsByResourceKind(resourceKind) {
-        var results = [];
-        var prefs = this.preferences && this.preferences.metrics && this.preferences.metrics;
+        let results = [];
+        let prefs = this.preferences && this.preferences.metrics && this.preferences.metrics;
 
         if (prefs) {
-          prefs = prefs.filter(function (item) {
+          prefs = prefs.filter(item => {
             return item.resourceKind === resourceKind;
           });
 
@@ -868,7 +816,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
       key: 'setDefaultMetricPreferences',
       value: function setDefaultMetricPreferences() {
         if (!this.preferences.metrics) {
-          var defaults = new _DefaultMetrics2.default();
+          const defaults = new _DefaultMetrics2.default();
           this.preferences.metrics = defaults.getDefinitions();
           this.persistPreferences();
         }
@@ -888,40 +836,34 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'requestAreaCategoryIssueServices',
       value: function requestAreaCategoryIssueServices() {
-        var _this7 = this;
-
         // In 8.5.0.1 three new business rules were added to AreaCategoryIssue to return distinct
         // values. Call a get on the $services endpoint for this entity to determine if they are there
         // or not so we can fall back to older views.
         this.context.areaCategoryIssueServices = [];
-        var request = new Sage.SData.Client.SDataResourcePropertyRequest(this.getService()).setContractName('dynamic').setResourceKind('areaCategoryIssues').setResourceProperty('$service');
+        const request = new Sage.SData.Client.SDataResourcePropertyRequest(this.getService()).setContractName('dynamic').setResourceKind('areaCategoryIssues').setResourceProperty('$service');
 
-        return new Promise(function (resolve) {
+        return new Promise(resolve => {
           request.readFeed({
             success: function success(data) {
               if (data && Array.isArray(data.$resources)) {
-                this.context.areaCategoryIssueServices = data.$resources.map(function (s) {
-                  return s.$descriptor;
-                });
+                this.context.areaCategoryIssueServices = data.$resources.map(s => s.$descriptor);
               }
               resolve(true);
             },
             failure: function failure() {
               resolve(false);
             },
-            scope: _this7
+            scope: this
           });
         });
       }
     }, {
       key: 'requestUserDetails',
       value: function requestUserDetails() {
-        var _this8 = this;
+        const key = this.context.user.$key;
+        const request = new Sage.SData.Client.SDataSingleResourceRequest(this.getService()).setContractName('dynamic').setResourceKind('users').setResourceSelector(`"${key}"`).setQueryArg('select', this.userDetailsQuerySelect.join(','));
 
-        var key = this.context.user.$key;
-        var request = new Sage.SData.Client.SDataSingleResourceRequest(this.getService()).setContractName('dynamic').setResourceKind('users').setResourceSelector('"' + key + '"').setQueryArg('select', this.userDetailsQuerySelect.join(','));
-
-        return new Promise(function (resolve, reject) {
+        return new Promise((resolve, reject) => {
           request.read({
             success: function success(entry) {
               this.store.dispatch((0, _user.setUser)(entry));
@@ -932,32 +874,29 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
             failure: function failure(e) {
               reject(e);
             },
-            scope: _this8
+            scope: this
           });
         });
       }
     }, {
       key: 'requestUserOptions',
       value: function requestUserOptions() {
-        var _this9 = this;
-
-        var batch = new Sage.SData.Client.SDataBatchRequest(this.getService()).setContractName('system').setResourceKind('useroptions').setQueryArg('select', 'name,value,defaultValue').using(function using() {
-          var service = this.getService();
-          this.userOptionsToRequest.forEach(function (item) {
+        const batch = new Sage.SData.Client.SDataBatchRequest(this.getService()).setContractName('system').setResourceKind('useroptions').setQueryArg('select', 'name,value,defaultValue').using(function using() {
+          const service = this.getService();
+          this.userOptionsToRequest.forEach(item => {
             new Sage.SData.Client.SDataSingleResourceRequest(service).setContractName('system').setResourceKind('useroptions').setResourceKey(item).read();
           });
         }, this);
 
-        return new Promise(function (resolve, reject) {
+        return new Promise((resolve, reject) => {
           batch.commit({
             success: function success(feed) {
-              var userOptions = this.context.userOptions = this.context.userOptions || {};
+              const userOptions = this.context.userOptions = this.context.userOptions || {};
 
-              feed.$resources.forEach(function (item) {
-                var key = item && item.$descriptor;
-                var value = item.value;
-                var defaultValue = item.defaultValue;
-
+              feed.$resources.forEach(item => {
+                const key = item && item.$descriptor;
+                let { value } = item;
+                const { defaultValue } = item;
 
                 if (typeof value === 'undefined' || value === null) {
                   value = defaultValue;
@@ -968,8 +907,8 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
                 }
               });
 
-              var insertSecCode = userOptions['General:InsertSecCodeID'];
-              var currentDefaultOwner = this.context.defaultOwner && this.context.defaultOwner.$key;
+              const insertSecCode = userOptions['General:InsertSecCodeID'];
+              const currentDefaultOwner = this.context.defaultOwner && this.context.defaultOwner.$key;
 
               if (insertSecCode && (!currentDefaultOwner || currentDefaultOwner !== insertSecCode)) {
                 this.requestOwnerDescription(insertSecCode);
@@ -982,15 +921,15 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
               reject();
               _ErrorManager2.default.addError(response, o, {}, 'failure');
             },
-            scope: _this9
+            scope: this
           });
         });
       }
     }, {
       key: 'loadCustomizedMoment',
       value: function loadCustomizedMoment() {
-        var custom = this.buildCustomizedMoment();
-        var currentLang = moment.locale();
+        const custom = this.buildCustomizedMoment();
+        const currentLang = moment.locale();
 
         moment.updateLocale(currentLang, custom);
         this.moment = moment().locale(currentLang, custom);
@@ -1002,8 +941,8 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
           return null;
         }
 
-        var userWeekStartDay = parseInt(this.context.userOptions['Calendar:WeekStart'], 10);
-        var results = {}; // 0-6, Sun-Sat
+        const userWeekStartDay = parseInt(this.context.userOptions['Calendar:WeekStart'], 10);
+        let results = {}; // 0-6, Sun-Sat
 
         if (!isNaN(userWeekStartDay)) {
           results = {
@@ -1019,32 +958,26 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'requestSystemOptions',
       value: function requestSystemOptions() {
-        var _this11 = this;
+        const request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setContractName('system').setResourceKind('systemoptions').setQueryArg('select', 'name,value');
 
-        var request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setContractName('system').setResourceKind('systemoptions').setQueryArg('select', 'name,value');
-
-        return new Promise(function (resolve, reject) {
+        return new Promise((resolve, reject) => {
           request.read({
             success: function succes(feed) {
-              var _this10 = this;
+              const systemOptions = this.context.systemOptions = this.context.systemOptions || {};
 
-              var systemOptions = this.context.systemOptions = this.context.systemOptions || {};
-
-              feed.$resources.forEach(function (item) {
-                var name = item.name,
-                    value = item.value;
-
-                if (value && name && _this10.systemOptionsToRequest.indexOf(name) > -1) {
+              feed.$resources.forEach(item => {
+                const { name, value } = item;
+                if (value && name && this.systemOptionsToRequest.indexOf(name) > -1) {
                   systemOptions[name] = value;
                 }
               }, this);
 
-              var multiCurrency = systemOptions.MultiCurrency;
+              const multiCurrency = systemOptions.MultiCurrency;
 
               if (multiCurrency && multiCurrency === 'True') {
-                this.requestExchangeRates().then(function () {
+                this.requestExchangeRates().then(() => {
                   resolve(feed);
-                }, function () {
+                }, () => {
                   reject();
                 });
               } else {
@@ -1055,25 +988,23 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
               _ErrorManager2.default.addError(response, o, {}, 'failure');
               reject();
             },
-            scope: _this11
+            scope: this
           });
         });
       }
     }, {
       key: 'requestExchangeRates',
       value: function requestExchangeRates() {
-        var _this12 = this;
+        const request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setContractName('dynamic').setResourceKind('exchangeRates').setQueryArg('select', 'Rate');
 
-        var request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setContractName('dynamic').setResourceKind('exchangeRates').setQueryArg('select', 'Rate');
-
-        return new Promise(function (resolve, reject) {
+        return new Promise((resolve, reject) => {
           request.read({
             success: function success(feed) {
-              var exchangeRates = this.context.exchangeRates = this.context.exchangeRates || {};
+              const exchangeRates = this.context.exchangeRates = this.context.exchangeRates || {};
 
-              feed.$resources.forEach(function (item) {
-                var key = item && item.$descriptor;
-                var value = item && item.Rate;
+              feed.$resources.forEach(item => {
+                const key = item && item.$descriptor;
+                const value = item && item.Rate;
 
                 if (value && key) {
                   exchangeRates[key] = value;
@@ -1086,14 +1017,14 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
               reject();
               _ErrorManager2.default.addError(response, o, {}, 'failure');
             },
-            scope: _this12
+            scope: this
           });
         });
       }
     }, {
       key: 'requestOwnerDescription',
       value: function requestOwnerDescription(key) {
-        var request = new Sage.SData.Client.SDataSingleResourceRequest(this.getService()).setContractName('dynamic').setResourceKind('owners').setResourceSelector('"' + key + '"').setQueryArg('select', 'OwnerDescription');
+        const request = new Sage.SData.Client.SDataSingleResourceRequest(this.getService()).setContractName('dynamic').setResourceKind('owners').setResourceSelector(`"${key}"`).setQueryArg('select', 'OwnerDescription');
 
         request.read({
           success: this.onRequestOwnerDescriptionSuccess,
@@ -1121,20 +1052,18 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'getExposedViews',
       value: function getExposedViews() {
-        var _this13 = this;
-
-        return Object.keys(this.views).filter(function (id) {
-          var view = _this13.getViewDetailOnly(id);
+        return Object.keys(this.views).filter(id => {
+          const view = this.getViewDetailOnly(id);
           return view && view.id !== 'home' && view.expose;
         });
       }
     }, {
       key: 'cleanRestoredHistory',
       value: function cleanRestoredHistory(restoredHistory) {
-        var result = [];
-        var hasRoot = false;
+        let result = [];
+        let hasRoot = false;
 
-        for (var i = restoredHistory.length - 1; i >= 0 && !hasRoot; i--) {
+        for (let i = restoredHistory.length - 1; i >= 0 && !hasRoot; i--) {
           if (restoredHistory[i].data.options && restoredHistory[i].data.options.negateHistory) {
             result = [];
             continue;
@@ -1152,39 +1081,37 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'requestIntegrationSettings',
       value: function requestIntegrationSettings(integration) {
-        var _this14 = this;
-
         if (!this.context.integrationSettings) {
           this.context.integrationSettings = {};
         }
-        var request = new Sage.SData.Client.SDataBaseRequest(App.getService());
-        var pageSize = this.pageSize;
-        var startIndex = this.feed && this.feed.$startIndex > 0 && this.feed.$itemsPerPage > 0 ? this.feed.$startIndex + this.feed.$itemsPerPage : 1;
+        const request = new Sage.SData.Client.SDataBaseRequest(App.getService());
+        const pageSize = this.pageSize;
+        const startIndex = this.feed && this.feed.$startIndex > 0 && this.feed.$itemsPerPage > 0 ? this.feed.$startIndex + this.feed.$itemsPerPage : 1;
         request.uri.setPathSegment(0, 'slx');
         request.uri.setPathSegment(1, 'dynamic');
         request.uri.setPathSegment(2, '-');
         request.uri.setPathSegment(3, 'customsettings');
         request.uri.setQueryArg('format', 'JSON');
         request.uri.setQueryArg('select', 'Description,DataValue,DataType');
-        request.uri.setQueryArg('where', 'Category eq "' + integration + '"');
+        request.uri.setQueryArg('where', `Category eq "${integration}"`);
         request.uri.setStartIndex(startIndex);
         request.uri.setCount(pageSize);
         request.service.readFeed(request, {
-          success: function success(feed) {
-            var integrationSettings = {};
-            feed.$resources.forEach(function (item) {
-              var key = item && item.$descriptor;
-              var value = item && item.DataValue;
+          success: feed => {
+            const integrationSettings = {};
+            feed.$resources.forEach(item => {
+              const key = item && item.$descriptor;
+              let value = item && item.DataValue;
               if (typeof value === 'undefined' || value === null) {
                 value = '';
               }
               if (key) {
-                integrationSettings['' + key] = value;
+                integrationSettings[`${key}`] = value;
               }
-              _this14.context.integrationSettings['' + integration] = integrationSettings;
+              this.context.integrationSettings[`${integration}`] = integrationSettings;
             });
           },
-          failure: function failure(response, o) {
+          failure: (response, o) => {
             _ErrorManager2.default.addError(response, o, '', 'failure');
           }
         });
@@ -1195,9 +1122,9 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
         this.showLeftDrawer();
         this.showHeader();
         try {
-          var restoredState = this.navigationState;
-          var restoredHistory = restoredState && JSON.parse(restoredState);
-          var cleanedHistory = this.cleanRestoredHistory(restoredHistory);
+          const restoredState = this.navigationState;
+          const restoredHistory = restoredState && JSON.parse(restoredState);
+          const cleanedHistory = this.cleanRestoredHistory(restoredHistory);
 
           this._clearNavigationState();
 
@@ -1205,15 +1132,15 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
             ReUI.context.transitioning = true;
             ReUI.context.history = ReUI.context.history.concat(cleanedHistory.slice(0, cleanedHistory.length - 1));
 
-            for (var i = 0; i < cleanedHistory.length - 1; i++) {
+            for (let i = 0; i < cleanedHistory.length - 1; i++) {
               window.location.hash = cleanedHistory[i].hash;
             }
 
             ReUI.context.transitioning = false;
 
-            var last = cleanedHistory[cleanedHistory.length - 1];
-            var view = this.getView(last.page);
-            var options = last.data && last.data.options;
+            const last = cleanedHistory[cleanedHistory.length - 1];
+            const view = this.getView(last.page);
+            const options = last.data && last.data.options;
 
             view.show(options);
           } else {
@@ -1227,12 +1154,12 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'setupRedirectHash',
       value: function setupRedirectHash() {
-        var isMingleRefresh = false;
+        let isMingleRefresh = false;
         if (this._hasValidRedirect()) {
           if (this.isMingleEnabled()) {
-            var vars = this.redirectHash.split('&');
-            for (var i = 0; i < vars.length; i++) {
-              var pair = vars[i].split('=');
+            const vars = this.redirectHash.split('&');
+            for (let i = 0; i < vars.length; i++) {
+              const pair = vars[i].split('=');
               if (pair[0] === 'state') {
                 if (pair[1] === 'mingleRefresh') {
                   // show default view
@@ -1245,13 +1172,13 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
             }
           }
           if (isMingleRefresh) {
-            var view = this.getView(App.getDefaultViews()[0]);
+            const view = this.getView(App.getDefaultViews()[0]);
             if (view) {
               view.show();
             }
           } else {
             // Split by "/redirectTo/"
-            var split = this.redirectHash.split(/\/redirectTo\//gi);
+            const split = this.redirectHash.split(/\/redirectTo\//gi);
             if (split.length === 2) {
               this.redirectHash = split[1];
             }
@@ -1261,7 +1188,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'onConnectionChange',
       value: function onConnectionChange(online) {
-        var view = this.getView('left_drawer');
+        const view = this.getView('left_drawer');
         if (!this.enableOfflineSupport) {
           return;
         }
@@ -1294,7 +1221,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
       value: function navigateToLoginView() {
         this.setupRedirectHash();
 
-        var view = this.getView(this.loginViewId);
+        const view = this.getView(this.loginViewId);
         if (view) {
           view.show();
         }
@@ -1302,13 +1229,13 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: '_hasValidRedirect',
       value: function _hasValidRedirect() {
-        var hashValue = decodeURIComponent(this.redirectHash);
+        const hashValue = decodeURIComponent(this.redirectHash);
         return hashValue !== '' && hashValue.indexOf('/redirectTo/') > 0;
       }
     }, {
       key: 'showLeftDrawer',
       value: function showLeftDrawer() {
-        var view = this.getView('left_drawer');
+        const view = this.getView('left_drawer');
         if (view) {
           view.show();
         }
@@ -1326,26 +1253,22 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
         this.setupRedirectHash();
         this.showLeftDrawer();
 
-        var visible = this.preferences && this.preferences.home && this.preferences.home.visible;
+        const visible = this.preferences && this.preferences.home && this.preferences.home.visible;
         if (visible && visible.length > 0) {
           this.homeViewId = visible[0];
         }
 
         // Default view will be the home view, overwritten below if a redirect hash is supplied
-        var view = this.getView(this.homeViewId);
+        let view = this.getView(this.homeViewId);
 
         if (this.redirectHash) {
-          var split = this.redirectHash.split(';');
+          let split = this.redirectHash.split(';');
           if (split.length === 1) {
             split = this.redirectHash.split(':');
           }
           if (split.length > 0) {
-            var _split = split,
-                _split2 = _slicedToArray(_split, 2),
-                viewId = _split2[0],
-                key = _split2[1];
-
-            var redirectView = this.getView(viewId);
+            const [viewId, key] = split;
+            const redirectView = this.getView(viewId);
             if (redirectView) {
               if (!redirectView.canRedirectTo) {
                 // The user will go to the default view instead
@@ -1354,7 +1277,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
                 view = redirectView;
                 if (key) {
                   redirectView.show({
-                    key: key
+                    key
                   });
                 }
               }
@@ -1374,7 +1297,7 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'navigateToActivityInsertView',
       value: function navigateToActivityInsertView() {
-        var view = this.getView('activity_types_list');
+        const view = this.getView('activity_types_list');
         if (view) {
           view.show();
         }
@@ -1400,49 +1323,47 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
     }, {
       key: 'getVersionInfo',
       value: function getVersionInfo() {
-        var info = _string2.default.substitute(this.versionInfoText, [this.mobileVersion.major, this.mobileVersion.minor, this.mobileVersion.revision, this.serverVersion.major]);
+        const info = _string2.default.substitute(this.versionInfoText, [this.mobileVersion.major, this.mobileVersion.minor, this.mobileVersion.revision, this.serverVersion.major]);
         return info;
       }
     }, {
       key: 'initOfflineData',
       value: function initOfflineData() {
-        var _this15 = this;
-
-        return new Promise(function (resolve, reject) {
-          var model = _this15.ModelManager.getModel(_Names2.default.AUTHENTICATION, _Types2.default.OFFLINE);
+        return new Promise((resolve, reject) => {
+          const model = this.ModelManager.getModel(_Names2.default.AUTHENTICATION, _Types2.default.OFFLINE);
           if (model) {
-            var indicator = new _BusyIndicator2.default({
+            const indicator = new _BusyIndicator2.default({
               id: 'busyIndicator__offlineData',
               label: resource.offlineInitDataText
             });
-            _this15.modal.disableClose = true;
-            _this15.modal.showToolbar = false;
-            _this15.modal.add(indicator);
+            this.modal.disableClose = true;
+            this.modal.showToolbar = false;
+            this.modal.add(indicator);
             indicator.start();
 
-            model.initAuthentication(_this15.context.user.$key).then(function (result) {
+            model.initAuthentication(this.context.user.$key).then(result => {
               if (result.hasUserChanged || !result.hasAuthenticatedToday) {
-                _Manager2.default.clearAllData().then(function () {
+                _Manager2.default.clearAllData().then(() => {
                   model.updateEntry(result.entry);
                   indicator.complete(true);
-                  _this15.modal.disableClose = false;
-                  _this15.modal.hide();
+                  this.modal.disableClose = false;
+                  this.modal.hide();
                   resolve();
-                }, function (err) {
+                }, err => {
                   indicator.complete(true);
-                  _this15.modal.disableClose = false;
-                  _this15.modal.hide();
+                  this.modal.disableClose = false;
+                  this.modal.hide();
                   reject(err);
                 });
               } else {
                 result.entry.ModifyDate = moment().toDate();
                 model.updateEntry(result.entry);
                 indicator.complete(true);
-                _this15.modal.disableClose = false;
-                _this15.modal.hide();
+                this.modal.disableClose = false;
+                this.modal.hide();
                 resolve(); // Do nothing since this not the first time athuenticating.
               }
-            }, function (err) {
+            }, err => {
               reject(err);
             });
           } else {

--- a/src-out/ApplicationModule.js
+++ b/src-out/ApplicationModule.js
@@ -233,7 +233,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('applicationModule');
+  const resource = (0, _I18n2.default)('applicationModule');
 
   /**
    * @class
@@ -259,7 +259,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
   /**
   * @module crm/ApplicationModule
   */
-  var __class = (0, _declare2.default)('crm.ApplicationModule', [_ApplicationModule2.default], /** @lends module:crm/ApplicationModule.prototype */{
+  const __class = (0, _declare2.default)('crm.ApplicationModule', [_ApplicationModule2.default], /** @lends module:crm/ApplicationModule.prototype */{
     searchText: resource.searchText,
     loadCache: function loadCache() {
       /* index.aspx will cache everything under content/, help/, and localization/ automatically.
@@ -287,7 +287,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
 
       this.registerView(new _LeftDrawer2.default(), $('.application-menu', this.application.getContainerNode()).first().get(0), 'last');
 
-      var modalBody = $('.modal-body', this.application.viewSettingsModal.element);
+      const modalBody = $('.modal-body', this.application.viewSettingsModal.element);
       this.registerView(new _RightDrawer2.default(), modalBody.first().get(0));
 
       this.registerView(new _Detail2.default({
@@ -374,7 +374,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List14.default({
         id: 'competitor_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -390,7 +390,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
         id: 'contact_related',
         expose: false,
         groupsEnabled: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -398,7 +398,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List18.default({
         id: 'contract_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -418,7 +418,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List22.default({
         id: 'event_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -437,7 +437,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
         id: 'opportunity_related',
         expose: false,
         groupsEnabled: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -448,7 +448,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List30.default({
         id: 'opportunitycontact_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -456,7 +456,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List32.default({
         id: 'opportunityproduct_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -482,7 +482,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
         id: 'lead_related',
         expose: false,
         groupsEnabled: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -498,7 +498,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
         id: 'ticket_related',
         expose: false,
         groupsEnabled: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -510,7 +510,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List42.default({
         id: 'ticketactivity_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -520,7 +520,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List44.default({
         id: 'ticketactivityitem_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -542,7 +542,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List12.default({
         id: 'activity_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -560,7 +560,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
         id: 'history_related',
         expose: false,
         groupsEnabled: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -585,7 +585,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List36.default({
         id: 'product_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -593,7 +593,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List38.default({
         id: 'productprogram_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -612,49 +612,49 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.registerView(new _List52.default({
         id: 'account_attachment_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
       this.registerView(new _List52.default({
         id: 'contact_attachment_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
       this.registerView(new _List52.default({
         id: 'lead_attachment_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
       this.registerView(new _List52.default({
         id: 'ticket_attachment_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
       this.registerView(new _List52.default({
         id: 'opportunity_attachment_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
       this.registerView(new _List52.default({
         id: 'activity_attachment_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
       this.registerView(new _List52.default({
         id: 'history_attachment_related',
         expose: false,
-        defaultSearchTerm: function defaultSearchTerm() {
+        defaultSearchTerm: () => {
           return '';
         }
       }));
@@ -699,38 +699,30 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.loadAppStatePromises();
     },
     loadAppStatePromises: function loadAppStatePromises() {
-      var _this = this;
-
       this.registerAppStatePromise({
         seq: 1,
         description: resource.userContextAndOptionsText,
         items: [{
           name: 'user_detail',
           description: resource.userInformationText,
-          fn: function fn() {
-            return App.requestUserDetails();
-          }
+          fn: () => App.requestUserDetails()
         }, {
           name: 'user_options',
           description: resource.userOptionsText,
-          fn: function fn() {
-            return App.requestUserOptions();
-          }
+          fn: () => App.requestUserOptions()
         }, {
           name: 'system_options',
           description: resource.systemOptionsText,
-          fn: function fn() {
-            return App.requestSystemOptions();
-          }
+          fn: () => App.requestSystemOptions()
         }, {
           name: 'integrations',
           description: resource.integrationsText,
-          fn: function fn() {
-            var model = _this.application.ModelManager.getModel(_Names2.default.INTEGRATION, _Types2.default.SDATA);
-            return model.getEntries(null, { contractName: 'dynamic' }).then(function (results) {
-              _this.application.context.integrations = results;
+          fn: () => {
+            const model = this.application.ModelManager.getModel(_Names2.default.INTEGRATION, _Types2.default.SDATA);
+            return model.getEntries(null, { contractName: 'dynamic' }).then(results => {
+              this.application.context.integrations = results;
               if (results) {
-                results.forEach(function (integration) {
+                results.forEach(integration => {
                   App.requestIntegrationSettings(integration.$descriptor);
                 });
               }
@@ -739,9 +731,7 @@ define('crm/ApplicationModule', ['module', 'exports', 'dojo/_base/declare', 'doj
           }
         }, {
           name: 'distinct_areacategoryissues',
-          fn: function fn() {
-            return App.requestAreaCategoryIssueServices();
-          }
+          fn: () => App.requestAreaCategoryIssueServices()
         }]
       });
     }

--- a/src-out/AttachmentManager.js
+++ b/src-out/AttachmentManager.js
@@ -23,7 +23,7 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
    * @class
    * @alias module:crm/AttachmentManager
    */
-  var __class = (0, _declare2.default)('crm.AttachmentManager', null, /** @lends module:crm/AttachmentManager.prototype */{
+  const __class = (0, _declare2.default)('crm.AttachmentManager', null, /** @lends module:crm/AttachmentManager.prototype */{
     _fileManager: null,
     _entityContext: null,
     _uploadUrl: '',
@@ -46,11 +46,11 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       this._files = [];
       this._fileDescriptions = [];
       this._fileManager = new _FileManager2.default();
-      var service = App.getService(this.serviceName);
-      var oldContractName = service.getContractName();
+      const service = App.getService(this.serviceName);
+      const oldContractName = service.getContractName();
       service.setContractName(this.contractName);
       this._baseUrl = _Utility2.default.stripQueryArgs(service.getUri().toString());
-      this._uploadUrl = this._baseUrl + '/attachments/file';
+      this._uploadUrl = `${this._baseUrl}/attachments/file`;
       service.setContractName(oldContractName);
     },
     /**
@@ -82,22 +82,22 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       }, this.onRequestTemplateFailure);
     },
     getAttachmentUrl: function getAttachmentUrl(attachmentId) {
-      var fileUrl = this._baseUrl + '/attachments(\'' + attachmentId + '\')/file';
+      const fileUrl = `${this._baseUrl}/attachments('${attachmentId}')/file`;
       return fileUrl;
     },
     getAttachmenturlByEntity: function getAttachmenturlByEntity(attachment) {
-      var href = void 0;
+      let href;
       if (attachment.url) {
         href = attachment.url || '';
-        href = href.indexOf('http') < 0 ? 'http://' + href : href;
+        href = href.indexOf('http') < 0 ? `http://${href}` : href;
       } else {
-        href = this._baseUrl + '/attachments(\'' + attachment.$key + '\')/file';
+        href = `${this._baseUrl}/attachments('${attachment.$key}')/file`;
       }
       return href;
     },
     _getFileDescription: function _getFileDescription(fileName) {
-      var description = this._getDefaultDescription(fileName);
-      for (var i = 0; i < this._fileDescriptions.length; i++) {
+      let description = this._getDefaultDescription(fileName);
+      for (let i = 0; i < this._fileDescriptions.length; i++) {
         if (fileName === this._fileDescriptions[i].fileName) {
           description = this._fileDescriptions[i].description;
         }
@@ -108,23 +108,23 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       return description;
     },
     _getAttachmentContextMixin: function _getAttachmentContextMixin() {
-      var contextMixin = this._getAttachmentContext();
+      const contextMixin = this._getAttachmentContext();
       return contextMixin;
     },
     _getAttachmentContext: function _getAttachmentContext() {
-      var contextData = {};
-      var found = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      let contextData = {};
+      const found = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
         if (/^(accounts|contacts|opportunities|tickets|leads|activities|history|userActivities)$/.test(context.resourceKind) && context.key) {
           return true;
         }
         return false;
       });
 
-      var contextView = found && found.options && found.options.source || found;
+      const contextView = found && found.options && found.options.source || found;
       if (contextView) {
-        var view = App.getView(contextView.id);
-        var entry = contextView.entry || view && view.entry || contextView;
+        const view = App.getView(contextView.id);
+        const entry = contextView.entry || view && view.entry || contextView;
 
         if (!entry || !entry.$key) {
           return {};
@@ -220,7 +220,7 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       return App.getService(this.serviceName); /* if false is passed, the default service will be returned */
     },
     createTemplateRequest: function createTemplateRequest() {
-      var request = new Sage.SData.Client.SDataTemplateResourceRequest(this.getService());
+      const request = new Sage.SData.Client.SDataTemplateResourceRequest(this.getService());
       request.setResourceKind(this.resourceKind);
       request.setContractName(this.contractName);
       request.setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.querySelect.join(','));
@@ -228,7 +228,7 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       return request;
     },
     requestTemplate: function requestTemplate(onSucess, onFailure) {
-      var request = this.createTemplateRequest();
+      const request = this.createTemplateRequest();
       if (request) {
         request.read({
           success: onSucess,
@@ -242,10 +242,10 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       this.processTemplateEntry(entry);
     },
     createDataRequest: function createDataRequest(id) {
-      var request = new Sage.SData.Client.SDataSingleResourceRequest(this.getService());
+      const request = new Sage.SData.Client.SDataSingleResourceRequest(this.getService());
       request.setResourceKind(this.resourceKind);
       request.setContractName(this.contractName);
-      request.setResourceSelector('\'' + id + '\'');
+      request.setResourceSelector(`'${id}'`);
 
       request.setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.querySelect.join(','));
       request.setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Include, this.queryInclude.join(','));
@@ -253,7 +253,7 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       return request;
     },
     requestData: function requestData(attachmnetId, onSucess, onFailure) {
-      var request = this.createDataRequest(attachmnetId);
+      const request = this.createDataRequest(attachmnetId);
       if (request) {
         request.read({
           success: onSucess,
@@ -271,27 +271,27 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       this._isUploading = true;
       this._fileCount = this._files.length;
       while (this._files.length > 0) {
-        var file = this._files.pop();
+        const file = this._files.pop();
         this._fileManager.uploadFile(file, this._uploadUrl, this._updateProgress, this.onSuccessUpload, this.onFailedUpload, this);
       }
     },
     onSuccessUpload: function onSuccessUpload(request) {
       // the id of the new attachment is buried in the Location response header...
-      var url = request.getResponseHeader('Location');
-      var re = /'\w+'/g;
-      var matches = url.match(re);
+      const url = request.getResponseHeader('Location');
+      const re = /'\w+'/g;
+      const matches = url.match(re);
 
       if (matches) {
-        var id = matches[0].replace(/'/g, '');
+        const id = matches[0].replace(/'/g, '');
         // now that we have the id, we can fetch it using the SingleEntrySDataStore
         this.requestData(id, function success(attachment) {
-          var mixin = this._getAttachmentContextMixin(attachment.fileName);
+          const mixin = this._getAttachmentContextMixin(attachment.fileName);
           if (mixin) {
             attachment.attachDate = _Convert2.default.toIsoStringFromDate(new Date());
             attachment.dataType = 'R';
             attachment.description = this._getFileDescription(attachment.fileName);
-            var a = _lang2.default.mixin(attachment, mixin);
-            var req = this.createDataRequest(id);
+            const a = _lang2.default.mixin(attachment, mixin);
+            const req = this.createDataRequest(id);
             if (req) {
               req.update(a, {
                 success: this.onSuccessUpdate,
@@ -304,12 +304,12 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       }
     },
     onFailedUpload: function onFailedUpload(resp) {
-      var err = new Error('Failed to upload.');
+      const err = new Error('Failed to upload.');
       err.resp = resp;
       throw err;
     },
     _onFailedAdd: function _onFailedAdd(resp) {
-      var err = new Error('Failed to save.');
+      const err = new Error('Failed to save.');
       err.resp = resp;
       throw err;
     },
@@ -318,7 +318,7 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
      */
     onSuccessUpdate: function onSuccessUpdate() {},
     onFailedUpdate: function onFailedUpdate(resp) {
-      var err = new Error('Failed to update.');
+      const err = new Error('Failed to update.');
       err.resp = resp;
       throw err;
     },
@@ -327,10 +327,10 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
      */
     onUpdateProgress: function onUpdateProgress() {},
     _updateProgress: function _updateProgress(curFileProgress) {
-      var pct = this._totalProgress;
+      let pct = this._totalProgress;
 
       if (curFileProgress && curFileProgress.lengthComputable) {
-        var filePercent = curFileProgress.loaded / curFileProgress.total * 100;
+        const filePercent = curFileProgress.loaded / curFileProgress.total * 100;
         pct = filePercent;
       } else if (curFileProgress) {
         pct = curFileProgress;
@@ -355,7 +355,7 @@ define('crm/AttachmentManager', ['module', 'exports', './FileManager', 'dojo/_ba
       this._totalProgress = 0;
     },
     getAttachmentFile: function getAttachmentFile(attachmentId, responseType, onSuccsess) {
-      var url = this.getAttachmentUrl(attachmentId);
+      const url = this.getAttachmentUrl(attachmentId);
       this._fileManager.getFile(url, responseType, onSuccsess);
     }
   }); /* Copyright 2017 Infor

--- a/src-out/Bootstrap.js
+++ b/src-out/Bootstrap.js
@@ -32,64 +32,63 @@ define('crm/Bootstrap', ['module', 'exports', './MingleUtility', 'argos/Language
    * limitations under the License.
    */
 
-  function bootstrap(_ref) {
-    var serviceWorkerPath = _ref.serviceWorkerPath,
-        serviceWorkerRegistrationOptions = _ref.serviceWorkerRegistrationOptions,
-        supportedLocales = _ref.supportedLocales,
-        defaultLocale = _ref.defaultLocale,
-        currentLocale = _ref.currentLocale,
-        parentLocale = _ref.parentLocale,
-        defaultRegionLocale = _ref.defaultRegionLocale,
-        currentRegionLocale = _ref.currentRegionLocale,
-        parentRegionLocale = _ref.parentRegionLocale,
-        application = _ref.application,
-        configuration = _ref.configuration,
-        legacyLocalization = _ref.legacyLocalization,
-        legacyLocalizationFallback = _ref.legacyLocalizationFallback,
-        localeFiles = _ref.localeFiles,
-        regionalFiles = _ref.regionalFiles,
-        isRegionMetric = _ref.isRegionMetric,
-        _ref$cacheFiles = _ref.cacheFiles,
-        cacheFiles = _ref$cacheFiles === undefined ? [] : _ref$cacheFiles,
-        rootElement = _ref.rootElement;
-
+  function bootstrap({
+    serviceWorkerPath,
+    serviceWorkerRegistrationOptions,
+    supportedLocales,
+    defaultLocale,
+    currentLocale,
+    parentLocale, // eslint-disable-line
+    defaultRegionLocale,
+    currentRegionLocale,
+    parentRegionLocale,
+    application,
+    configuration,
+    legacyLocalization,
+    legacyLocalizationFallback,
+    localeFiles,
+    regionalFiles,
+    isRegionMetric,
+    cacheFiles = [],
+    rootElement
+  }) {
     function mapFiles(files, ctx, defaultCtx) {
-      return files.map(function (path) {
-        var trimmed = path;
-        supportedLocales.forEach(function (locale) {
-          trimmed = trimmed.replace(new RegExp('/' + locale + '/'), '/');
+      return files.map(path => {
+        let trimmed = path;
+        supportedLocales.forEach(locale => {
+          trimmed = trimmed.replace(new RegExp(`/${locale}/`), '/');
         });
 
-        var index = trimmed.lastIndexOf('/');
-        var basePath = trimmed.substring(0, index);
-        var file = trimmed.substring(index + 1, trimmed.length);
+        const index = trimmed.lastIndexOf('/');
+        const basePath = trimmed.substring(0, index);
+        const file = trimmed.substring(index + 1, trimmed.length);
         return {
           base: basePath,
-          file: file
+          file
         };
-      }).reduce(function (p, c) {
-        if (p.some(function (pathInfo) {
+      }).reduce((p, c) => {
+        if (p.some(pathInfo => {
           return pathInfo.base === c.base && pathInfo.file === c.file;
         })) {
           return p;
         }
 
         return p.concat(c);
-      }, []).forEach(function (pathInfo) {
-        [ctx, defaultCtx].forEach(function (context) {
-          context.linkResource(function (locale) {
+      }, []).forEach(pathInfo => {
+        [ctx, defaultCtx].forEach(context => {
+          context.linkResource(locale => {
             return [pathInfo.base, locale, pathInfo.file].join('/');
           });
         });
       });
     }
-    var languageService = new _LanguageService2.default();
-    var ctx = window.L20n.getContext();
-    var defaultCtx = window.L20n.getContext();
+    const languageService = new _LanguageService2.default();
+    const ctx = window.L20n.getContext();
+    const defaultCtx = window.L20n.getContext();
 
-    var ctxRegional = window.L20n.getContext();
-    var defaultCtxRegional = window.L20n.getContext();
-    var localesLong = {
+    const ctxRegional = window.L20n.getContext();
+    const defaultCtxRegional = window.L20n.getContext();
+    const localesLong = {
       en: 'en-US',
       'en-GB': 'en-GB',
       de: 'de-DE',
@@ -128,34 +127,26 @@ define('crm/Bootstrap', ['module', 'exports', './MingleUtility', 'argos/Language
     window.defaultregionalContext = defaultCtxRegional;
 
     // Set the window locale for the Soho Library
-    var normalizedLocale = languageService.bestAvailableLocale(supportedLocales, currentLocale) || currentLocale;
-    var normalizedRegionLocale = languageService.bestAvailableLocale(supportedLocales, currentRegionLocale) || currentRegionLocale;
+    const normalizedLocale = languageService.bestAvailableLocale(supportedLocales, currentLocale) || currentLocale;
+    const normalizedRegionLocale = languageService.bestAvailableLocale(supportedLocales, currentRegionLocale) || currentRegionLocale;
     if (localesLong[normalizedLocale]) {
       Soho.Locale.set(localesLong[normalizedLocale]);
     }
     languageService.setLanguage(normalizedLocale || currentLocale || parentLocale || defaultLocale);
     languageService.setRegion(normalizedRegionLocale || currentRegionLocale || parentRegionLocale || defaultRegionLocale);
 
-    Promise.all([new Promise(function (resolve) {
-      ctxRegional.ready(function () {
-        return resolve(true);
-      });
-    }), new Promise(function (resolve) {
-      defaultCtxRegional.ready(function () {
-        return resolve(true);
-      });
-    }), new Promise(function (resolve) {
-      ctx.ready(function () {
-        return resolve(true);
-      });
-    }), new Promise(function (resolve) {
-      defaultCtx.ready(function () {
-        return resolve(true);
-      });
-    })]).then(function () {
-      window.require([application].concat(configuration), function (Application, appConfig) {
-        var completed = false;
-        var mingleAuthResults = void 0;
+    Promise.all([new Promise(resolve => {
+      ctxRegional.ready(() => resolve(true));
+    }), new Promise(resolve => {
+      defaultCtxRegional.ready(() => resolve(true));
+    }), new Promise(resolve => {
+      ctx.ready(() => resolve(true));
+    }), new Promise(resolve => {
+      defaultCtx.ready(() => resolve(true));
+    })]).then(() => {
+      window.require([application].concat(configuration), (Application, appConfig) => {
+        let completed = false;
+        let mingleAuthResults;
 
         if (appConfig.mingleEnabled || appConfig.enableMingle) {
           mingleAuthResults = _MingleUtility2.default.populateAccessToken(appConfig);
@@ -163,23 +154,23 @@ define('crm/Bootstrap', ['module', 'exports', './MingleUtility', 'argos/Language
             return;
           }
         }
-        var req = function req(requires) {
-          require(requires.concat('dojo/domReady!'), function () {
+        const req = requires => {
+          require(requires.concat('dojo/domReady!'), () => {
             if (completed) {
               return;
             }
 
-            var results = moment.locale(parentRegionLocale);
+            let results = moment.locale(parentRegionLocale);
 
             // moment will return the set culture if successful, otherwise it returns the currently set culture.
             // Check to see if the culture set failed, and attept to use the specific culture instead
             if (results !== parentRegionLocale.toLocaleLowerCase()) {
               results = moment.locale(currentRegionLocale);
               if (results !== currentRegionLocale.toLocaleLowerCase()) {
-                console.error('Failed to set the culture for moment.js, culture set to ' + results); // eslint-disable-line
+                console.error(`Failed to set the culture for moment.js, culture set to ${results}`); // eslint-disable-line
               }
             }
-            var instance = new Application(appConfig);
+            const instance = new Application(appConfig);
             instance.serviceWorkerPath = serviceWorkerPath;
             instance.serviceWorkerRegistrationOptions = serviceWorkerRegistrationOptions;
             instance.context.localization = {
@@ -187,7 +178,7 @@ define('crm/Bootstrap', ['module', 'exports', './MingleUtility', 'argos/Language
               defaultLocaleContext: defaultCtx,
               locale: normalizedLocale || currentLocale || defaultLocale,
               region: normalizedRegionLocale || currentRegionLocale || defaultRegionLocale,
-              supportedLocales: supportedLocales
+              supportedLocales
             };
             instance.localeContext = ctx;
             instance.isRegionMetric = isRegionMetric;
@@ -200,7 +191,7 @@ define('crm/Bootstrap', ['module', 'exports', './MingleUtility', 'argos/Language
           });
         };
 
-        require.on('error', function () {
+        require.on('error', () => {
           console.log('Error loading localization, falling back to "en"'); // eslint-disable-line
           req(legacyLocalizationFallback);
         });

--- a/src-out/DefaultMetrics.js
+++ b/src-out/DefaultMetrics.js
@@ -15,22 +15,22 @@ define('crm/DefaultMetrics', ['module', 'exports', 'dojo/_base/declare', 'argos/
     };
   }
 
-  var resource = (0, _I18n2.default)('defaultMetrics'); /* Copyright 2017 Infor
-                                                         *
-                                                         * Licensed under the Apache License, Version 2.0 (the "License");
-                                                         * you may not use this file except in compliance with the License.
-                                                         * You may obtain a copy of the License at
-                                                         *
-                                                         *    http://www.apache.org/licenses/LICENSE-2.0
-                                                         *
-                                                         * Unless required by applicable law or agreed to in writing, software
-                                                         * distributed under the License is distributed on an "AS IS" BASIS,
-                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                         * See the License for the specific language governing permissions and
-                                                         * limitations under the License.
-                                                         */
+  const resource = (0, _I18n2.default)('defaultMetrics'); /* Copyright 2017 Infor
+                                                           *
+                                                           * Licensed under the Apache License, Version 2.0 (the "License");
+                                                           * you may not use this file except in compliance with the License.
+                                                           * You may obtain a copy of the License at
+                                                           *
+                                                           *    http://www.apache.org/licenses/LICENSE-2.0
+                                                           *
+                                                           * Unless required by applicable law or agreed to in writing, software
+                                                           * distributed under the License is distributed on an "AS IS" BASIS,
+                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                           * See the License for the specific language governing permissions and
+                                                           * limitations under the License.
+                                                           */
 
-  var __class = (0, _declare2.default)('crm.DefaultMetrics', [_CustomizationMixin3.default], {
+  const __class = (0, _declare2.default)('crm.DefaultMetrics', [_CustomizationMixin3.default], {
     // Localiztion
     accountsText: {
       totalRevenue: resource.totalRevenue,

--- a/src-out/Environment.js
+++ b/src-out/Environment.js
@@ -34,7 +34,7 @@ define('crm/Environment', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/s
   /**
   * @module crm/Environment
   */
-  var __class = _lang2.default.setObject('crm.Environment', /** @lends module:crm/Environment */{
+  const __class = _lang2.default.setObject('crm.Environment', /** @lends module:crm/Environment */{
     /**
      * @param {string} number
      */
@@ -42,19 +42,19 @@ define('crm/Environment', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/s
       // todo: open a new browser window for these when on a mobile device?
       // on a mobile device, launching an external handler can impact a view transition, and cause issues, which the timeout takes care of.
       // not the best way, perhaps a post-transition callback should be used for launching these? check transitioning, then queue if needed?
-      setTimeout(function () {
-        window.location.href = 'tel:' + number;
+      setTimeout(() => {
+        window.location.href = `tel:${number}`;
       }, 500);
     },
     initiateEmail: function initiateEmail(email, subject, body) {
-      setTimeout(function () {
-        var mailtoUri = subject ? 'mailto:' + email + '?subject=' + subject + '&body=' + (body || '') : 'mailto:' + email;
+      setTimeout(() => {
+        const mailtoUri = subject ? `mailto:${email}?subject=${subject}&body=${body || ''}` : `mailto:${email}`;
         window.location.href = mailtoUri;
       }, 1000); // 1 sec delay for iPad iOS5 to actually save nav state to local storage
     },
     showMapForAddress: function showMapForAddress(address) {
-      var href = window.location.protocol + '//maps.google.com/maps?output=embed&q=' + address;
-      var view = App.getView('link_view');
+      const href = `${window.location.protocol}//maps.google.com/maps?output=embed&q=${address}`;
+      const view = App.getView('link_view');
       if (view) {
         view.show({
           link: href,
@@ -68,21 +68,21 @@ define('crm/Environment', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/s
     refreshStaleDetailViews: function refreshStaleDetailViews() {
       // List of detail views that will need refreshed when a note is added or an activity is completed (possibly others??).
       // Otherwise the etag will change and the server will give a 412: Preconditioned failed when we attempt to edit/save.
-      var views = crm.Environment.detailViewsToRefreshOnUpdate || [];
+      const views = crm.Environment.detailViewsToRefreshOnUpdate || [];
       crm.Environment.refreshViews(views);
     },
     refreshActivityLists: function refreshActivityLists() {
-      var views = crm.Environment.activityViewsToRefresh || [];
+      const views = crm.Environment.activityViewsToRefresh || [];
       crm.Environment.refreshViews(views);
     },
     refreshAttachmentViews: function refreshAttachmentViews() {
-      var views = crm.Environment.attachmentViewsToRefresh || [];
+      const views = crm.Environment.attachmentViewsToRefresh || [];
       crm.Environment.refreshViews(views);
     },
     refreshViews: function refreshViews(views) {
       if (views && views.length > 0) {
-        views.forEach(function (viewId) {
-          var view = App.getView(viewId);
+        views.forEach(viewId => {
+          const view = App.getView(viewId);
           if (view) {
             view.refreshRequired = true;
           }

--- a/src-out/Fields/AddressField.js
+++ b/src-out/Fields/AddressField.js
@@ -32,10 +32,20 @@ define('crm/Fields/AddressField', ['module', 'exports', 'dojo/_base/declare', 'a
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('addressField');
+  const resource = (0, _I18n2.default)('addressField');
 
-  var control = (0, _declare2.default)('crm.Fields.AddressField', [_EditorField2.default], {
-    widgetTemplate: new Simplate(['<label for="{%= $.name %}">{%: $.label %}</label>\n    <div class="field field-control-wrapper">\n      <button\n        class="button simpleSubHeaderButton field-control-trigger"\n        aria-label="{%: $.lookupLabelText %}">\n        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.iconClass %}"></use>\n        </svg>\n      </button>\n      <label data-dojo-attach-point="inputNode"></label>\n    </div>']),
+  const control = (0, _declare2.default)('crm.Fields.AddressField', [_EditorField2.default], {
+    widgetTemplate: new Simplate([`<label for="{%= $.name %}">{%: $.label %}</label>
+    <div class="field field-control-wrapper">
+      <button
+        class="button simpleSubHeaderButton field-control-trigger"
+        aria-label="{%: $.lookupLabelText %}">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.iconClass %}"></use>
+        </svg>
+      </button>
+      <label data-dojo-attach-point="inputNode"></label>
+    </div>`]),
     iconClass: 'quick-edit',
 
     attributeMap: {

--- a/src-out/Fields/MultiCurrencyField.js
+++ b/src-out/Fields/MultiCurrencyField.js
@@ -15,7 +15,7 @@ define('crm/Fields/MultiCurrencyField', ['module', 'exports', 'dojo/_base/declar
     };
   }
 
-  var control = (0, _declare2.default)('crm.Fields.MultiCurrencyField', [_DecimalField2.default], {
+  const control = (0, _declare2.default)('crm.Fields.MultiCurrencyField', [_DecimalField2.default], {
     attributeMap: {
       inputValue: {
         node: 'inputNode',

--- a/src-out/Fields/NameField.js
+++ b/src-out/Fields/NameField.js
@@ -32,17 +32,29 @@ define('crm/Fields/NameField', ['module', 'exports', 'dojo/_base/declare', 'argo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('nameField');
+  const resource = (0, _I18n2.default)('nameField');
 
-  var control = (0, _declare2.default)('crm.Fields.NameField', [_EditorField2.default], {
+  const control = (0, _declare2.default)('crm.Fields.NameField', [_EditorField2.default], {
     // Localization
     emptyText: resource.emptyText,
-    widgetTemplate: new Simplate(['<label for="{%= $.name %}"\n      {% if ($.required) { %}\n          class="required"\n      {% } %}>{%: $.label %}</label>\n    <div class="field field-control-wrapper">\n      <button class="button simpleSubHeaderButton field-control-trigger\n        aria-label="{%: $.lookupLabelText %}">\n        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.iconClass %}"></use>\n        </svg>\n      </button>\n      <input data-dojo-attach-point="inputNode" readonly="readonly" type="text" />\n    </div>']),
+    widgetTemplate: new Simplate([`<label for="{%= $.name %}"
+      {% if ($.required) { %}
+          class="required"
+      {% } %}>{%: $.label %}</label>
+    <div class="field field-control-wrapper">
+      <button class="button simpleSubHeaderButton field-control-trigger
+        aria-label="{%: $.lookupLabelText %}">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.iconClass %}"></use>
+        </svg>
+      </button>
+      <input data-dojo-attach-point="inputNode" readonly="readonly" type="text" />
+    </div>`]),
 
     iconClass: 'quick-edit',
 
     createNavigationOptions: function createNavigationOptions() {
-      var options = this.inherited(createNavigationOptions, arguments);
+      const options = this.inherited(createNavigationOptions, arguments);
       // Name does not have an entity.
       delete options.entityName;
 

--- a/src-out/Fields/PicklistField.js
+++ b/src-out/Fields/PicklistField.js
@@ -17,22 +17,31 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
     };
   }
 
-  var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
-    return typeof obj;
-  } : function (obj) {
-    return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-  };
+  /* Copyright 2017 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
 
-  var viewsByName = {};
-  var viewsByNameCount = 0;
+  const viewsByName = {};
+  let viewsByNameCount = 0;
 
-  var getOrCreateViewFor = function getOrCreateViewFor(name) {
+  const getOrCreateViewFor = function getOrCreateViewFor(name) {
     if (viewsByName[name]) {
       return viewsByName[name];
     }
 
-    var view = new _PickList2.default({
-      id: 'pick_list_' + viewsByNameCount++,
+    const view = new _PickList2.default({
+      id: `pick_list_${viewsByNameCount++}`,
       expose: false,
       picklistName: name
     });
@@ -43,7 +52,7 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
     return App.getView(view.id);
   };
 
-  var control = (0, _declare2.default)('crm.Fields.PicklistField', [_LookupField2.default], {
+  const control = (0, _declare2.default)('crm.Fields.PicklistField', [_LookupField2.default], {
     picklist: false,
     picklistName: false,
     picklistOptions: null,
@@ -85,21 +94,21 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
         return false;
       }
       // Current flag for checking whether the picklist is a code picklist server side is the default language
-      var picklist = App.picklistService.getPicklistByName(this.picklistName, this.languageCode);
+      const picklist = App.picklistService.getPicklistByName(this.picklistName, this.languageCode);
       return picklist && picklist.defaultLanguage;
     },
     formatResourcePredicate: function formatResourcePredicate(name) {
-      return 'name eq "' + name + '"';
+      return `name eq "${name}"`;
     },
     _handleSaleslogixMultiSelectPicklist: function _handleSaleslogixMultiSelectPicklist(value, unloadedValues) {
       if (typeof value === 'string') {
         return value;
       }
 
-      var values = [];
-      for (var key in value) {
+      let values = [];
+      for (const key in value) {
         if (value.hasOwnProperty(key)) {
-          var data = value[key].data;
+          const data = value[key].data;
           if (data && data.text) {
             values.push(data.text);
           } else if (typeof data === 'string') {
@@ -115,7 +124,7 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
       return values.join(', ');
     },
     textRenderer: function textRenderer(value, unloadedValues) {
-      var results = void 0;
+      let results;
 
       if (this.singleSelect) {
         if (typeof value === 'string' || typeof value === 'number') {
@@ -130,7 +139,7 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
       return results;
     },
     formatValue: function formatValue(value) {
-      var results = void 0;
+      let results;
       if (this.singleSelect) {
         results = this.inherited(formatValue, arguments);
       } else {
@@ -151,15 +160,15 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
         if (val && !this.picklistName) {
           this.picklistName = this.picklist;
           if (typeof this.picklistName === 'function') {
-            var dependent = this.getDependentValue();
-            if ((typeof dependent === 'undefined' ? 'undefined' : _typeof(dependent)) === 'object') {
+            let dependent = this.getDependentValue();
+            if (typeof dependent === 'object') {
               dependent = dependent.code;
             }
             this.picklistName = this.dependsOn // only pass dependentValue if there is a dependency
             ? this.expandExpression(this.picklist, dependent) : this.expandExpression(this.picklist);
           }
         }
-        var picklistItem = false;
+        let picklistItem = false;
         this.languageCode = this.getLanguageCode();
         if (this.storageMode === 'text') {
           picklistItem = this.app.picklistService.getPicklistItemTextByCode(this.picklistName, val, this.languageCode);
@@ -180,8 +189,8 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
       this.inherited(setValue, arguments);
     },
     createSelections: function createSelections() {
-      var value = this.getText();
-      var selections = [];
+      const value = this.getText();
+      let selections = [];
       if (value) {
         if (value.indexOf(', ') !== -1) {
           selections = value.split(', ');
@@ -192,7 +201,7 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
       return selections;
     },
     createNavigationOptions: function createNavigationOptions() {
-      var options = this.inherited(createNavigationOptions, arguments);
+      const options = this.inherited(createNavigationOptions, arguments);
 
       if (this.picklist) {
         this.picklistName = this.picklist;
@@ -240,11 +249,11 @@ define('crm/Fields/PicklistField', ['module', 'exports', 'dojo/_base/declare', '
         return;
       }
 
-      var options = this.createNavigationOptions();
+      const options = this.createNavigationOptions();
       if (this.isCodePicklist()) {
         this.keyProperty = 'code';
       }
-      var view = App.getView(this.view) || getOrCreateViewFor(this.picklistName, this.languageCode);
+      const view = App.getView(this.view) || getOrCreateViewFor(this.picklistName, this.languageCode);
 
       if (view && options) {
         view.refreshRequired = true;

--- a/src-out/Fields/RecurrencesField.js
+++ b/src-out/Fields/RecurrencesField.js
@@ -32,9 +32,9 @@ define('crm/Fields/RecurrencesField', ['module', 'exports', 'dojo/_base/declare'
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('recurrencesField');
+  const resource = (0, _I18n2.default)('recurrencesField');
 
-  var control = (0, _declare2.default)('crm.Fields.RecurrencesField', [_EditorField2.default], {
+  const control = (0, _declare2.default)('crm.Fields.RecurrencesField', [_EditorField2.default], {
     // Localization
     titleText: resource.titleText,
     emptyText: resource.emptyText,
@@ -45,7 +45,12 @@ define('crm/Fields/RecurrencesField', ['module', 'exports', 'dojo/_base/declare'
       }
     },
 
-    widgetTemplate: new Simplate(['<label for="{%= $.name %}">{%: $.label %}</label>', '<div class="field field-control-wrapper">', '<button class="button simpleSubHeaderButton field-control-trigger {% if ($$.iconClass) { %} {%: $$.iconClass %} {% } %}" aria-label="{%: $.lookupLabelText %}">\n      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.iconClass %}"></use>\n      </svg>\n      <span>{%: $.lookupText %}</span>\n    </button>', '<div data-dojo-attach-point="inputNode" class="note-text"></div>', '</div>']),
+    widgetTemplate: new Simplate(['<label for="{%= $.name %}">{%: $.label %}</label>', '<div class="field field-control-wrapper">', `<button class="button simpleSubHeaderButton field-control-trigger {% if ($$.iconClass) { %} {%: $$.iconClass %} {% } %}" aria-label="{%: $.lookupLabelText %}">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.iconClass %}"></use>
+      </svg>
+      <span>{%: $.lookupText %}</span>
+    </button>`, '<div data-dojo-attach-point="inputNode" class="note-text"></div>', '</div>']),
     iconClass: 'more',
 
     setText: function setText(text) {

--- a/src-out/FileManager.js
+++ b/src-out/FileManager.js
@@ -15,27 +15,27 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
     };
   }
 
-  var resource = (0, _I18n2.default)('fileManager'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('fileManager'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
   /**
   * @module crm/FileManager
   */
 
 
-  var __class = (0, _declare2.default)('crm.FileManager', null, /** @lends module:crm/FileManager.prototype */{
+  const __class = (0, _declare2.default)('crm.FileManager', null, /** @lends module:crm/FileManager.prototype */{
     unableToUploadText: resource.unableToUploadText,
     unknownSizeText: resource.unknownSizeText,
     unknownErrorText: resource.unknownErrorText,
@@ -67,10 +67,10 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
      * @returns {Boolean}
      */
     isFileSizeAllowed: function isFileSizeAllowed(files) {
-      var len = 0;
-      var maxfileSize = this.fileUploadOptions.maxFileSize;
+      let len = 0;
+      const maxfileSize = this.fileUploadOptions.maxFileSize;
 
-      for (var i = 0; i < files.length; i++) {
+      for (let i = 0; i < files.length; i++) {
         if (files[i].size === 0) {// eslint-disable-line
           // do nothing.
         } else {
@@ -113,9 +113,9 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
     },
     _uploadFileHTML5_asBinary: function _uploadFileHTML5_asBinary(file, _url, progress, complete, error, scope, asPut) {
       // eslint-disable-line
-      var url = _url;
-      var request = new XMLHttpRequest();
-      var service = App.getService();
+      let url = _url;
+      const request = new XMLHttpRequest();
+      const service = App.getService();
       window.BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder || window.MSBlobBuilder;
       if (!url) {
         // assume Attachment SData url
@@ -131,19 +131,19 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
         request.setRequestHeader('X-Authorization-Mode', 'no-challenge');
 
         if (App.isMingleEnabled()) {
-          var accessToken = App.mingleAuthResults.access_token;
-          request.setRequestHeader('Authorization', 'Bearer ' + accessToken);
-          request.setRequestHeader('X-Authorization', 'Bearer ' + accessToken);
+          const accessToken = App.mingleAuthResults.access_token;
+          request.setRequestHeader('Authorization', `Bearer ${accessToken}`);
+          request.setRequestHeader('X-Authorization', `Bearer ${accessToken}`);
         }
       }
 
-      var reader = new FileReader();
+      const reader = new FileReader();
       reader.onload = _lang2.default.hitch(this, function readerOnLoad(evt) {
-        var unknownErrorText = this.unknownErrorText;
-        var blobReader = new FileReader(); // read the blob as an ArrayBuffer to work around this android issue: https://code.google.com/p/android/issues/detail?id=39882
-        var bb = void 0;
-        var usingBlobBuilder = void 0;
-        var blobData = void 0;
+        const unknownErrorText = this.unknownErrorText;
+        const blobReader = new FileReader(); // read the blob as an ArrayBuffer to work around this android issue: https://code.google.com/p/android/issues/detail?id=39882
+        let bb;
+        let usingBlobBuilder;
+        let blobData;
 
         try {
           bb = new Blob(); // This will throw an exception if it is not supported (android)
@@ -153,17 +153,17 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
           usingBlobBuilder = true;
         }
 
-        var binary = evt.target.result;
-        var boundary = '---------------------------' + new Date().getTime();
-        var dashdash = '--';
-        var crlf = '\r\n';
+        const binary = evt.target.result;
+        const boundary = `---------------------------${new Date().getTime()}`;
+        const dashdash = '--';
+        const crlf = '\r\n';
 
         this._append(bb, dashdash + boundary + crlf);
         this._append(bb, 'Content-Disposition: attachment; ');
         this._append(bb, 'name="file_"; ');
-        this._append(bb, 'filename*="' + encodeURI(file.name) + '" ');
+        this._append(bb, `filename*="${encodeURI(file.name)}" `);
         this._append(bb, crlf);
-        this._append(bb, 'Content-Type: ' + file.type);
+        this._append(bb, `Content-Type: ${file.type}`);
         this._append(bb, crlf + crlf);
         this._append(bb, binary);
         this._append(bb, crlf);
@@ -190,7 +190,7 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
           });
         }
 
-        request.setRequestHeader('Content-Type', 'multipart/attachment; boundary=' + boundary);
+        request.setRequestHeader('Content-Type', `multipart/attachment; boundary=${boundary}`);
 
         if (usingBlobBuilder) {
           blobData = bb.getBlob(file.type);
@@ -217,7 +217,7 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
       }
     },
     _onUnableToUploadError: function _onUnableToUploadError(_msg, onError) {
-      var msg = _msg;
+      let msg = _msg;
       if (!msg) {
         msg = this.unableToUploadText;
       }
@@ -233,7 +233,7 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
      * @returns {String}
      */
     formatFileSize: function formatFileSize(_size) {
-      var size = _size;
+      let size = _size;
       size = parseInt(size, 10);
       if (size === 0) {
         return '0 KB';
@@ -244,7 +244,7 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
       if (size < 1024) {
         return '1 KB';
       }
-      return Soho.Locale.formatNumber(Math.round(size / 1024)) + ' KB';
+      return `${Soho.Locale.formatNumber(Math.round(size / 1024))} KB`;
     },
     /**
      * Loads a remote file.
@@ -254,8 +254,8 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
      * @param {Object} onSuccess.responseInfo
      */
     getFile: function getFile(fileUrl, responseType, onSuccess) {
-      var request = new XMLHttpRequest();
-      var service = App.getService();
+      const request = new XMLHttpRequest();
+      const service = App.getService();
       request.open('GET', fileUrl, true);
 
       if (responseType) {
@@ -269,22 +269,22 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
         request.setRequestHeader('X-Authorization-Mode', 'no-challenge');
 
         if (App.isMingleEnabled()) {
-          var accessToken = App.mingleAuthResults.access_token;
-          request.setRequestHeader('Authorization', 'Bearer ' + accessToken);
-          request.setRequestHeader('X-Authorization', 'Bearer ' + accessToken);
+          const accessToken = App.mingleAuthResults.access_token;
+          request.setRequestHeader('Authorization', `Bearer ${accessToken}`);
+          request.setRequestHeader('X-Authorization', `Bearer ${accessToken}`);
         }
       }
 
       request.addEventListener('load', function load() {
-        var contentType = this.getResponseHeader('Content-Type');
-        var contentInfo = this.getResponseHeader('Content-Disposition');
-        var fileName = contentInfo.split('=')[1];
-        var responseInfo = {
+        const contentType = this.getResponseHeader('Content-Type');
+        const contentInfo = this.getResponseHeader('Content-Disposition');
+        const fileName = contentInfo.split('=')[1];
+        const responseInfo = {
           request: this,
-          responseType: responseType,
+          responseType,
           response: this.response,
-          contentType: contentType,
-          fileName: fileName
+          contentType,
+          fileName
         };
         if (onSuccess) {
           onSuccess(responseInfo);

--- a/src-out/Format.js
+++ b/src-out/Format.js
@@ -35,8 +35,8 @@ define('crm/Format', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
   /**
    * @module crm/Format
    */
-  var f = ICRMCommonSDK.format;
-  var resource = (0, _I18n2.default)('crmFormat');
+  const f = ICRMCommonSDK.format;
+  const resource = (0, _I18n2.default)('crmFormat');
 
   /**
    * @class
@@ -44,7 +44,7 @@ define('crm/Format', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
    * @extends module:argos/Format
    * @static
    */
-  var __class = _lang2.default.setObject('crm.Format', _lang2.default.mixin({}, _Format2.default, /** @lends module:crm/Format */{
+  const __class = _lang2.default.setObject('crm.Format', _lang2.default.mixin({}, _Format2.default, /** @lends module:crm/Format */{
     /**
      * Address Culture Formats as defined by crm.Format.address
      * http://msdn.microsoft.com/en-us/library/cc195167.aspx
@@ -94,28 +94,25 @@ define('crm/Format', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
     // These were added to the SDK, and should not be here. Keeping the alias to not break anyone with a minor update.
     phoneFormat: f.phoneFormat,
     phone: f.phone,
-    picklist: function picklist(service, // Picklist service reference
+    picklist: (service, // Picklist service reference
     model, // Reference to the entity's model for call getPicklistNameByProperty
     property, // Property to reference for fetching the picklist off the model
-    picklistName) {
-      var languageCode = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : App.getCurrentLocale();
-      var picklistOptions = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : { // Override for picklistOptions on storage and display modes
-        storage: f.PicklistStorageType.CODE,
-        display: f.PicklistDataDisplayType.TEXT
-      };
-
-      var name = picklistName;
+    picklistName, // Picklist name used (can use this instead of model-property)
+    languageCode = App.getCurrentLocale(), // Override for languageCode to fetch
+    picklistOptions = { // Override for picklistOptions on storage and display modes
+      storage: f.PicklistStorageType.CODE,
+      display: f.PicklistDataDisplayType.TEXT
+    }) => {
+      let name = picklistName;
       if (!name) {
         if (!service || !model || !property) {
-          return function (val) {
-            return val;
-          };
+          return val => val;
         }
         name = model.getPicklistNameByProperty(property);
       }
-      var picklist = service.getPicklistByName(name, languageCode);
+      const picklist = service.getPicklistByName(name, languageCode);
 
-      return function (val) {
+      return val => {
         return f.picklist(val, Object.assign({}, picklistOptions, picklist));
       };
     },
@@ -125,14 +122,14 @@ define('crm/Format', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
       return f.currency(_val, Soho.Locale.currentLocale.data.numbers.decimal, Soho.Locale.currentLocale.data.numbers.group);
     },
     bigNumber: function bigNumber(val) {
-      var numParse = typeof val !== 'number' ? parseFloat(val) : val;
-      var absVal = Math.abs(numParse);
+      let numParse = typeof val !== 'number' ? parseFloat(val) : val;
+      const absVal = Math.abs(numParse);
 
       if (isNaN(numParse)) {
         return val;
       }
 
-      var results = numParse.toString();
+      let results = numParse.toString();
       if (absVal >= 1000000000) {
         // Billion
         numParse = numParse / 1000000000;
@@ -156,7 +153,7 @@ define('crm/Format', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
       return results;
     },
     relativeDate: function relativeDate(date, timeless) {
-      var val = f.date(date, timeless);
+      const val = f.date(date, timeless);
       return moment(val).fromNow();
     },
     multiCurrency: function multiCurrency(_val, code) {
@@ -198,16 +195,14 @@ define('crm/Format', ['module', 'exports', 'dojo/_base/lang', 'dojo/string', 'ar
     fixedLocale: function fixedLocale(val, d) {
       return f.fixedLocale(val, d, Soho.Locale.currentLocale.data.numbers.group, Soho.Locale.currentLocale.data.numbers.decimal);
     },
-    time: function time(rawValue) {
-      var type = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'days';
-
-      var val = rawValue;
+    time: function time(rawValue, type = 'days') {
+      let val = rawValue;
 
       if (typeof rawValue !== 'number') {
         val = parseFloat(rawValue);
       }
 
-      var numParse = crm.Format.fixedLocale(val, 2);
+      const numParse = crm.Format.fixedLocale(val, 2);
       switch (type) {// eslint-disable-line
         case 'days':
           return _string2.default.substitute(resource.daysText, {

--- a/src-out/GroupUtility.js
+++ b/src-out/GroupUtility.js
@@ -35,10 +35,10 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
   /**
   * @module crm/GroupUtility
   */
-  var dtFormatResource = (0, _I18n2.default)('groupUtilityDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('groupUtilityDateTimeFormat');
 
   function _createGroupRequest(o) {
-    var defaultOptions = {
+    const defaultOptions = {
       connection: App.getService(false),
       groupId: '',
       resourceKind: 'groups',
@@ -47,15 +47,15 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
       queryArgs: null
     };
 
-    var options = _lang2.default.mixin(defaultOptions, o);
+    const options = _lang2.default.mixin(defaultOptions, o);
 
-    var request = new Sage.SData.Client.SDataNamedQueryRequest(options.connection);
+    const request = new Sage.SData.Client.SDataNamedQueryRequest(options.connection);
     request.setQueryName(options.queryName);
     request.setResourceKind(options.resourceKind);
     request.setContractName(options.contractName);
-    request.getUri().setCollectionPredicate('\'' + options.groupId + '\'');
+    request.getUri().setCollectionPredicate(`'${options.groupId}'`);
 
-    for (var arg in options.queryArgs) {
+    for (const arg in options.queryArgs) {
       if (options.queryArgs.hasOwnProperty(arg)) {
         request.setQueryArg(arg, options.queryArgs[arg]);
       }
@@ -69,7 +69,7 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
    * @alias module:crm/GroupUtility
    * @singleton
    */
-  var __class = _lang2.default.setObject('crm.GroupUtility', /** @lends module:crm/GroupUtility */{
+  const __class = _lang2.default.setObject('crm.GroupUtility', /** @lends module:crm/GroupUtility */{
     groupDateFormatText: dtFormatResource.groupDateFormatText,
     groupDateFormatText24: dtFormatResource.groupDateFormatText24,
     /**
@@ -81,7 +81,7 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
      *
      */
     createGroupRequest: function createGroupRequest(options) {
-      var defaults = {
+      const defaults = {
         queryName: 'execute',
         queryArgs: {
           language: App.getCurrentLocale()
@@ -100,7 +100,7 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
      *
      */
     createGroupMetricRequest: function createGroupMetricRequest(options) {
-      var defaults = {
+      const defaults = {
         queryName: 'executeMetric',
         queryArgs: {
           language: App.getCurrentLocale()
@@ -182,7 +182,7 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
       },
       formatter: function formatDate(value, formatString, formatOptions) {
         if (typeof value === 'string') {
-          var dateValue = moment(value);
+          const dateValue = moment(value);
           if (dateValue.isValid()) {
             if (formatOptions && formatOptions.useRelative) {
               return _Format2.default.relativeDate(dateValue);
@@ -200,13 +200,13 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
         return layoutItem.format === 'Boolean';
       },
       formatter: function formatBoolean(value) {
-        var truthy = ['T', 't', 'Y', '1', '+'];
+        const truthy = ['T', 't', 'Y', '1', '+'];
 
         return truthy.indexOf(value) === -1 ? _Format4.default.noText : _Format4.default.yesText;
       }
     }],
     transformDateFormatString: function transformDateFormatString(gf, defaultFormat) {
-      var groupFormat = gf;
+      let groupFormat = gf;
       if (groupFormat) {
         groupFormat = groupFormat.replace('MM', 'M');
         groupFormat = groupFormat.replace('mm', 'M');
@@ -253,25 +253,25 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
       }
     },
     getFormatterByLayout: function getFormatterByLayout(layoutItem) {
-      var results = void 0;
+      let results;
       if (layoutItem.format && layoutItem.format !== 'None') {
-        results = this.groupFormatters.filter(function (formatter) {
+        results = this.groupFormatters.filter(formatter => {
           return formatter.name === layoutItem.format;
         });
         if (results.length === 0) {
-          results = this.groupFormatters.filter(function (formatter) {
+          results = this.groupFormatters.filter(formatter => {
             return formatter.name === 'None';
           });
         }
       } else {
-        var fieldFormatType = this.formatTypeByField[layoutItem.fieldType];
+        let fieldFormatType = this.formatTypeByField[layoutItem.fieldType];
         if (!fieldFormatType) {
           fieldFormatType = {
             name: 'None',
             formatString: ''
           };
         }
-        results = this.groupFormatters.filter(function (formatter) {
+        results = this.groupFormatters.filter(formatter => {
           return formatter.name === fieldFormatType.name;
         });
       }
@@ -286,7 +286,7 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
         });
       }
 
-      var fieldFormatter = {
+      const fieldFormatter = {
         name: results[0].name,
         options: results[0].options,
         formatter: results[0].formatter.bind(this)
@@ -300,26 +300,24 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
       return fieldFormatter;
     },
     getLayout: function getLayout(group) {
-      var _this = this;
-
-      var i = 0;
-      var layout = group.layout.filter(function (item) {
+      let i = 0;
+      const layout = group.layout.filter(item => {
         item.index = i++;
-        return _this.groupFilters.every(function (filter) {
+        return this.groupFilters.every(filter => {
           return filter(item);
         });
       }, this);
       return layout;
     },
     getColumnNames: function getColumnNames(layout) {
-      var extraSelectColumns = [];
-      var columns = layout.map(function (item) {
+      const extraSelectColumns = [];
+      const columns = layout.map(item => {
         if (item.format === 'PickList Item') {
-          extraSelectColumns.push(item.alias + 'TEXT');
+          extraSelectColumns.push(`${item.alias}TEXT`);
         }
 
         if (item.format === 'User' || item.format === 'Owner') {
-          extraSelectColumns.push(item.alias + 'NAME');
+          extraSelectColumns.push(`${item.alias}NAME`);
         }
 
         return item.alias;
@@ -327,32 +325,32 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
       return columns.concat(extraSelectColumns);
     },
     setDefaultGroupPreference: function setDefaultGroupPreference(entityName, groupName) {
-      App.preferences['default-group-' + entityName + '-userId-' + App.context.user.$key] = groupName;
+      App.preferences[`default-group-${entityName}-userId-${App.context.user.$key}`] = groupName;
       App.persistPreferences();
     },
     getDefaultGroupPreference: function getDefaultGroupPreference(entityName) {
-      var defaultGroupName = App.preferences['default-group-' + entityName + '-userId-' + App.context.user.$key];
+      let defaultGroupName = App.preferences[`default-group-${entityName}-userId-${App.context.user.$key}`];
       if (!defaultGroupName) {
         defaultGroupName = this.getDefaultGroupUserPreference(entityName);
       }
       return defaultGroupName;
     },
     getDefaultGroupUserPreference: function getDefaultGroupUserPreference(entityName) {
-      var defaultGroupName = App.context.userOptions['DefaultGroup:' + entityName.toUpperCase()];
+      let defaultGroupName = App.context.userOptions[`DefaultGroup:${entityName.toUpperCase()}`];
       if (defaultGroupName) {
         defaultGroupName = defaultGroupName.split(':')[1];
       }
       return defaultGroupName;
     },
     getDefaultGroup: function getDefaultGroup(entityName) {
-      var groupList = App.preferences['groups-' + entityName + '-userId-' + App.context.user.$key];
-      var defaultGroup = null;
-      var defaultGroupName = null;
+      const groupList = App.preferences[`groups-${entityName}-userId-${App.context.user.$key}`];
+      let defaultGroup = null;
+      let defaultGroupName = null;
 
       defaultGroupName = this.getDefaultGroupPreference(entityName);
 
       if (groupList && groupList.length > 0) {
-        groupList.forEach(function (group) {
+        groupList.forEach(group => {
           if (group.name === defaultGroupName) {
             defaultGroup = group;
           }
@@ -365,13 +363,13 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
       }
     },
     addToGroupPreferences: function addToGroupPreferences(items, entityName, overwrite) {
-      var found = void 0;
-      var groupList = this.getGroupPreferences(entityName);
+      let found;
+      let groupList = this.getGroupPreferences(entityName);
       if (!overwrite && groupList && groupList.length > 0) {
         if (items && items.length > 0) {
-          items.forEach(function (item) {
+          items.forEach(item => {
             found = -1;
-            groupList.forEach(function (group, i) {
+            groupList.forEach((group, i) => {
               if (group.$key === item.$key) {
                 found = i;
               }
@@ -388,14 +386,14 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
         groupList = items;
       }
 
-      App.preferences['groups-' + entityName + '-userId-' + App.context.user.$key] = groupList;
+      App.preferences[`groups-${entityName}-userId-${App.context.user.$key}`] = groupList;
       App.persistPreferences();
     },
     removeGroupPreferences: function removeGroupPreferences(itemKey, entityName) {
-      var found = -1;
-      var groupList = this.getGroupPreferences(entityName);
+      let found = -1;
+      const groupList = this.getGroupPreferences(entityName);
       if (groupList && groupList.length > 0) {
-        groupList.forEach(function (group, i) {
+        groupList.forEach((group, i) => {
           if (group.$key === itemKey) {
             found = i;
           }
@@ -404,12 +402,12 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
 
       if (found > -1) {
         groupList.splice(found, 1);
-        App.preferences['groups-' + entityName + '-userId-' + App.context.user.$key] = groupList;
+        App.preferences[`groups-${entityName}-userId-${App.context.user.$key}`] = groupList;
         App.persistPreferences();
       }
     },
     getGroupPreferences: function getGroupPreferences(entityName) {
-      var groupList = App.preferences['groups-' + entityName + '-userId-' + App.context.user.$key];
+      const groupList = App.preferences[`groups-${entityName}-userId-${App.context.user.$key}`];
       return groupList;
     },
     groupFieldNames: [{
@@ -418,7 +416,7 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
         return layoutItem.format === 'PickList Item';
       },
       fieldName: function pickListFieldName(layoutItem) {
-        return layoutItem.alias.toUpperCase() + 'TEXT';
+        return `${layoutItem.alias.toUpperCase()}TEXT`;
       }
     }, {
       name: 'OwnerOrUser',
@@ -426,7 +424,7 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
         return layoutItem.format === 'Owner' || layoutItem.format === 'User';
       },
       fieldName: function ownerOrUserFieldName(layoutItem) {
-        return layoutItem.alias.toUpperCase() + 'NAME';
+        return `${layoutItem.alias.toUpperCase()}NAME`;
       }
     }],
     getFieldNameByLayout: function getFieldNameByLayout(layoutItem) {
@@ -434,7 +432,7 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
       // This is usually just the layout item's alias in upper case, however there are some exceptions:
       // Picklist layout items need to select the alias + 'TEXT',
       // Owner and user items need to select the alias + 'NAME'
-      var results = this.groupFieldNames.filter(function (name) {
+      const results = this.groupFieldNames.filter(name => {
         return name.test(layoutItem);
       });
 
@@ -449,10 +447,10 @@ define('crm/GroupUtility', ['module', 'exports', 'dojo/_base/lang', './Format', 
       return results[0].fieldName(layoutItem);
     },
     getSelectedGroupLayoutTemplate: function getSelectedGroupLayoutTemplate(entityName) {
-      return App.preferences['groups-selected-template-name-' + entityName + '-userId-' + App.context.user.$key];
+      return App.preferences[`groups-selected-template-name-${entityName}-userId-${App.context.user.$key}`];
     },
     setSelectedGroupLayoutTemplate: function setSelectedGroupLayoutTemplate(entityName, name) {
-      App.preferences['groups-selected-template-name-' + entityName + '-userId-' + App.context.user.$key] = name;
+      App.preferences[`groups-selected-template-name-${entityName}-userId-${App.context.user.$key}`] = name;
       App.persistPreferences();
     }
   });

--- a/src-out/Integrations/ActivityAssociations/ApplicationModule.js
+++ b/src-out/Integrations/ActivityAssociations/ApplicationModule.js
@@ -19,22 +19,22 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
     };
   }
 
-  var resource = (0, _I18n2.default)('activityAssociationModule'); /* Copyright 2020 Infor
-                                                                    *
-                                                                    * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                    * you may not use this file except in compliance with the License.
-                                                                    * You may obtain a copy of the License at
-                                                                    *
-                                                                    *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                    *
-                                                                    * Unless required by applicable law or agreed to in writing, software
-                                                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                    * See the License for the specific language governing permissions and
-                                                                    * limitations under the License.
-                                                                    */
+  const resource = (0, _I18n2.default)('activityAssociationModule'); /* Copyright 2020 Infor
+                                                                      *
+                                                                      * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                      * you may not use this file except in compliance with the License.
+                                                                      * You may obtain a copy of the License at
+                                                                      *
+                                                                      *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                      *
+                                                                      * Unless required by applicable law or agreed to in writing, software
+                                                                      * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                      * See the License for the specific language governing permissions and
+                                                                      * limitations under the License.
+                                                                      */
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.ApplicationModule', [_ApplicationModule2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.ApplicationModule', [_ApplicationModule2.default], {
     hasNewActivityAssociations: function hasNewActivityAssociations() {
       return this.application.context.enableActivityAssociations === true;
     },
@@ -53,8 +53,6 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
       }));
     },
     loadCustomizationsDynamic: function loadCustomizations() {
-      var _this = this;
-
       if (!this.hasNewActivityAssociations()) {
         return;
       }
@@ -67,8 +65,8 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
         value: {
           name: 'AssociationRelated',
           label: resource.relatedAssociationText,
-          where: function where(entry) {
-            return 'ActivityId eq "' + entry.$key + '"';
+          where: entry => {
+            return `ActivityId eq "${entry.$key}"`;
           },
           view: 'activity_association_related',
           title: resource.relatedAssociationTitleText
@@ -83,8 +81,8 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
         value: {
           name: 'AssociationRelated',
           label: resource.relatedAssociationText,
-          where: function where(entry) {
-            return 'HistoryId eq "' + entry.$key + '"';
+          where: entry => {
+            return `HistoryId eq "${entry.$key}"`;
           },
           view: 'history_association_related',
           title: resource.relatedHistoryAssociationTitleText
@@ -94,10 +92,8 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
       // Remove "for lead" toggle on activity edit, along with company, always show lead lookup
       crm.Views.Activity.Edit.prototype.fieldsForLeads = [];
       crm.Views.Activity.Edit.prototype.fieldsForStandard = [];
-      crm.Views.Activity.Edit.prototype.onLeadChange = function () {};
-      var companyEditAt = function companyEditAt(row) {
-        return row.name === 'AccountName' && row.type === 'text';
-      };
+      crm.Views.Activity.Edit.prototype.onLeadChange = () => {};
+      const companyEditAt = row => row.name === 'AccountName' && row.type === 'text';
       this.registerCustomization('edit', 'activity_edit', {
         at: function at(row) {
           return row.name === 'IsLead';
@@ -118,7 +114,7 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
       // Remove "for lead" toggle on activity complete, along with company, always show lead lookup
       crm.Views.Activity.Complete.prototype.fieldsForLeads = [];
       crm.Views.Activity.Complete.prototype.fieldsForStandard = [];
-      crm.Views.Activity.Complete.prototype.onLeadChange = function () {};
+      crm.Views.Activity.Complete.prototype.onLeadChange = () => {};
       this.registerCustomization('edit', 'activity_complete', {
         at: function at(row) {
           return row.name === 'IsLead';
@@ -139,7 +135,7 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
       // Remove "for lead" toggle on history edit, along with company, always show lead lookup
       crm.Views.History.Edit.prototype.fieldsForLeads = [];
       crm.Views.History.Edit.prototype.fieldsForStandard = [];
-      crm.Views.History.Edit.prototype.onLeadChange = function () {};
+      crm.Views.History.Edit.prototype.onLeadChange = () => {};
       this.registerCustomization('edit', 'history_edit', {
         at: function at(row) {
           return row.name === 'IsLead';
@@ -158,9 +154,7 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
       });
 
       // Remove the "company" field, which is the second AccountName binding
-      var companyAt = function companyAt(row) {
-        return row.name === 'AccountName' && typeof row.view === 'undefined';
-      };
+      const companyAt = row => row.name === 'AccountName' && typeof row.view === 'undefined';
       this.registerCustomization('detail', 'activity_detail', {
         at: companyAt,
         type: 'remove'
@@ -171,20 +165,18 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
         type: 'remove'
       });
 
-      var removeExcludedProperty = ['AccountName', 'ContactName', 'OpportunityName', 'TicketNumber'];
-      removeExcludedProperty.forEach(function (prop) {
-        var at = function at(row) {
-          return row.name === prop;
-        };
-        _this.registerCustomization('detail', 'activity_detail', {
-          at: at,
+      const removeExcludedProperty = ['AccountName', 'ContactName', 'OpportunityName', 'TicketNumber'];
+      removeExcludedProperty.forEach(prop => {
+        const at = row => row.name === prop;
+        this.registerCustomization('detail', 'activity_detail', {
+          at,
           type: 'modify',
           value: {
             exclude: null
           }
         });
-        _this.registerCustomization('detail', 'history_detail', {
-          at: at,
+        this.registerCustomization('detail', 'history_detail', {
+          at,
           type: 'modify',
           value: {
             exclude: null
@@ -193,19 +185,19 @@ define('crm/Integrations/ActivityAssociations/ApplicationModule', ['module', 'ex
       });
     },
     loadAppStatePromises: function loadAppStatePromises() {
-      var app = this.application;
-      this.registerAppStatePromise(function () {
-        return new Promise(function (resolve) {
+      const app = this.application;
+      this.registerAppStatePromise(() => {
+        return new Promise(resolve => {
           // We are going to query the new activityAssociation endpoint to see if it 404 errors.
           // This will tell us what the server supports for activity associations, which started in 8.4.0.4
-          var request = new Sage.SData.Client.SDataResourceCollectionRequest(app.getService()).setContractName('dynamic').setResourceKind('activityAssociations').setQueryArg('select', '$key').setQueryArg('count', 1);
+          const request = new Sage.SData.Client.SDataResourceCollectionRequest(app.getService()).setContractName('dynamic').setResourceKind('activityAssociations').setQueryArg('select', '$key').setQueryArg('count', 1);
 
           request.read({
-            success: function success() {
+            success: () => {
               resolve(true);
               app.context.enableActivityAssociations = true;
             },
-            failure: function failure() {
+            failure: () => {
               resolve(false);
               app.context.enableActivityAssociations = false;
             }

--- a/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/Base.js
+++ b/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/Base.js
@@ -32,9 +32,9 @@ define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/Base', 
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityAssociationModel'); // eslint-disable-line
+  const resource = (0, _I18n2.default)('activityAssociationModel'); // eslint-disable-line
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.Base', [_ModelBase3.default], {
     resourceKind: 'activityAssociations',
     entityName: 'ActivityAssociation',
     entityDisplayName: resource.entityDisplayName,
@@ -42,7 +42,7 @@ define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/Base', 
     modelName: _Names2.default.ACTIVITYASSOCIATION,
     listViewId: 'activity_association_list',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/Offline.js
+++ b/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/Offline
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'activity_association_offline_model'
   });
 

--- a/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/SData.js
+++ b/src-out/Integrations/ActivityAssociations/Models/ActivityAssociation/SData.js
@@ -36,7 +36,7 @@ define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/SData',
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.ActivityAssociation.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'activity_association_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -54,11 +54,9 @@ define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/SData',
       }];
     },
     deleteEntry: function getEntry(entityId) {
-      var _this = this;
+      const request = new Sage.SData.Client.SDataSingleResourceRequest(App.getService()).setContractName('dynamic').setResourceKind(this.resourceKind).setResourceSelector(`"${entityId}"`);
 
-      var request = new Sage.SData.Client.SDataSingleResourceRequest(App.getService()).setContractName('dynamic').setResourceKind(this.resourceKind).setResourceSelector('"' + entityId + '"');
-
-      return new Promise(function (resolve, reject) {
+      return new Promise((resolve, reject) => {
         request.delete({}, {
           success: function success(entry) {
             resolve(entry);
@@ -66,7 +64,7 @@ define('crm/Integrations/ActivityAssociations/Models/ActivityAssociation/SData',
           failure: function failure(e) {
             reject(e);
           },
-          scope: _this
+          scope: this
         });
       });
     }

--- a/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/Base.js
+++ b/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/Base.js
@@ -32,9 +32,9 @@ define('crm/Integrations/ActivityAssociations/Models/HistoryAssociation/Base', [
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('historyAssociationModel'); // eslint-disable-line
+  const resource = (0, _I18n2.default)('historyAssociationModel'); // eslint-disable-line
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.Base', [_ModelBase3.default], {
     resourceKind: 'historyAssociations',
     entityName: 'HistoryAssociation',
     entityDisplayName: resource.entityDisplayName,
@@ -42,7 +42,7 @@ define('crm/Integrations/ActivityAssociations/Models/HistoryAssociation/Base', [
     modelName: _Names2.default.ACTIVITYASSOCIATION,
     listViewId: 'history_association_list',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/Offline.js
+++ b/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/ActivityAssociations/Models/HistoryAssociation/Offline'
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'history_association_offline_model'
   });
 

--- a/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/SData.js
+++ b/src-out/Integrations/ActivityAssociations/Models/HistoryAssociation/SData.js
@@ -36,7 +36,7 @@ define('crm/Integrations/ActivityAssociations/Models/HistoryAssociation/SData', 
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Models.HistoryAssociation.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'history_association_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/ActivityAssociations/Views/ActivityAssociation/List.js
+++ b/src-out/Integrations/ActivityAssociations/Views/ActivityAssociation/List.js
@@ -19,22 +19,22 @@ define('crm/Integrations/ActivityAssociations/Views/ActivityAssociation/List', [
     };
   }
 
-  var resource = (0, _I18n2.default)('activityAssociationList'); /* Copyright 2020 Infor
-                                                                  *
-                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                  * you may not use this file except in compliance with the License.
-                                                                  * You may obtain a copy of the License at
-                                                                  *
-                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                  *
-                                                                  * Unless required by applicable law or agreed to in writing, software
-                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                  * See the License for the specific language governing permissions and
-                                                                  * limitations under the License.
-                                                                  */
+  const resource = (0, _I18n2.default)('activityAssociationList'); /* Copyright 2020 Infor
+                                                                    *
+                                                                    * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                    * you may not use this file except in compliance with the License.
+                                                                    * You may obtain a copy of the License at
+                                                                    *
+                                                                    *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                    *
+                                                                    * Unless required by applicable law or agreed to in writing, software
+                                                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                    * See the License for the specific language governing permissions and
+                                                                    * limitations under the License.
+                                                                    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Views.ActivityAssociation.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Views.ActivityAssociation.List', [_List2.default], {
     // Localization
     titleText: resource.titleText,
     primaryText: resource.primaryText,
@@ -54,7 +54,7 @@ define('crm/Integrations/ActivityAssociations/Views/ActivityAssociation/List', [
     modelName: _Names2.default.ACTIVITYASSOCIATION,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(EntityName) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(EntityName) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     },
     getTitle: function getTitle(entry) {
       if (!entry) {
@@ -69,20 +69,18 @@ define('crm/Integrations/ActivityAssociations/Views/ActivityAssociation/List', [
       });
     },
     deleteAssociation: function deleteAssociation(_, selection) {
-      var _this = this;
-
       App.modal.createSimpleDialog({
         title: 'alert',
         content: this.confirmDeleteText,
-        getContent: function getContent() {}
-      }).then(function () {
-        var entry = selection && selection.data;
-        var model = _this.getModel();
-        model.deleteEntry(entry.$key).then(function () {
+        getContent: () => {}
+      }).then(() => {
+        const entry = selection && selection.data;
+        const model = this.getModel();
+        model.deleteEntry(entry.$key).then(() => {
           _connect2.default.publish('/app/refresh', [{
-            resourceKind: _this.resourceKind
+            resourceKind: this.resourceKind
           }]);
-          _this.forceRefresh();
+          this.forceRefresh();
         });
       });
     },

--- a/src-out/Integrations/ActivityAssociations/Views/HistoryAssociation/List.js
+++ b/src-out/Integrations/ActivityAssociations/Views/HistoryAssociation/List.js
@@ -32,9 +32,9 @@ define('crm/Integrations/ActivityAssociations/Views/HistoryAssociation/List', ['
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('historyAssociationList');
+  const resource = (0, _I18n2.default)('historyAssociationList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Views.HistoryAssociation.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.ActivityAssociations.Views.HistoryAssociation.List', [_List2.default], {
     // Localization
     titleText: resource.titleText,
     primaryText: resource.primaryText,
@@ -51,7 +51,7 @@ define('crm/Integrations/ActivityAssociations/Views/HistoryAssociation/List', ['
     modelName: _Names2.default.HISTORYASSOCIATION,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(EntityName) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(EntityName) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     },
     getTitle: function getTitle(entry) {
       if (!entry) {

--- a/src-out/Integrations/BOE/Aggregate.js
+++ b/src-out/Integrations/BOE/Aggregate.js
@@ -37,19 +37,16 @@ define('crm/Integrations/BOE/Aggregate', ['module', 'exports', 'dojo/_base/lang'
   /**
   * @module crm/Integrations/BOE/Aggregate
   */
-  var __class = _lang2.default.setObject('crm.Integrations.BOE.Aggregate', /** @lends module:crm/Integrations/BOE/Aggregate */{
+  const __class = _lang2.default.setObject('crm.Integrations.BOE.Aggregate', /** @lends module:crm/Integrations/BOE/Aggregate */{
     /**
      * Calculate Profit
      * @param {Array} data arrays of revenue and cost
      * @return {Number}
      */
-    calcProfit: function calcProfit() {
-      var revenue = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
-      var cost = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
-
-      var totalRevenue = _Aggregate2.default.sum(revenue);
-      var totalCost = _Aggregate2.default.sum(cost);
-      var profit = totalRevenue - totalCost;
+    calcProfit: function calcProfit(revenue = 0, cost = 0) {
+      const totalRevenue = _Aggregate2.default.sum(revenue);
+      const totalCost = _Aggregate2.default.sum(cost);
+      const profit = totalRevenue - totalCost;
 
       return profit;
     },
@@ -58,13 +55,10 @@ define('crm/Integrations/BOE/Aggregate', ['module', 'exports', 'dojo/_base/lang'
      * @param {Array} data arrays of revenue and cost
      * @return {Number}
      */
-    calcMargin: function calcMargin() {
-      var revenue = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
-      var cost = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
-
-      var profitTotal = icboe.Aggregate.calcProfit(revenue, cost);
-      var revenueTotal = _Aggregate2.default.sum(revenue);
-      var margin = void 0;
+    calcMargin: function calcMargin(revenue = 0, cost = 0) {
+      const profitTotal = icboe.Aggregate.calcProfit(revenue, cost);
+      const revenueTotal = _Aggregate2.default.sum(revenue);
+      let margin;
       if (revenueTotal !== 0) {
         margin = profitTotal / revenueTotal;
       } else {
@@ -79,9 +73,9 @@ define('crm/Integrations/BOE/Aggregate', ['module', 'exports', 'dojo/_base/lang'
      * @return {Number}
      */
     calcYoYRevenue: function calcYoYRevenue(pastYear, between) {
-      var revenuePastYear = _Aggregate2.default.sum(pastYear);
-      var revenueBetween = _Aggregate2.default.sum(between);
-      var revenueYoY = void 0;
+      const revenuePastYear = _Aggregate2.default.sum(pastYear);
+      const revenueBetween = _Aggregate2.default.sum(between);
+      let revenueYoY;
 
       if (revenueBetween !== 0) {
         revenueYoY = (revenuePastYear - revenueBetween) / revenueBetween;
@@ -97,9 +91,9 @@ define('crm/Integrations/BOE/Aggregate', ['module', 'exports', 'dojo/_base/lang'
      * @return {Number}
      */
     calcYoYProfit: function calcYoYProfit(revenuePastYear, costPastYear, revenueBetween, costBetween) {
-      var profitPastYear = icboe.Aggregate.calcProfit(revenuePastYear, costPastYear);
-      var profitBetween = icboe.Aggregate.calcProfit(revenueBetween, costBetween);
-      var profitYoY = void 0;
+      const profitPastYear = icboe.Aggregate.calcProfit(revenuePastYear, costPastYear);
+      const profitBetween = icboe.Aggregate.calcProfit(revenueBetween, costBetween);
+      let profitYoY;
 
       if (profitBetween !== 0) {
         profitYoY = (profitPastYear - profitBetween) / profitBetween;
@@ -115,9 +109,9 @@ define('crm/Integrations/BOE/Aggregate', ['module', 'exports', 'dojo/_base/lang'
      * @return {Number}
      */
     calcYoYMargin: function calcYoYMargin(revenuePastYear, costPastYear, revenueBetween, costBetween) {
-      var marginPastYear = icboe.Aggregate.calcMargin(revenuePastYear, costPastYear);
-      var marginBetween = icboe.Aggregate.calcMargin(revenueBetween, costBetween);
-      var marginYoY = void 0;
+      const marginPastYear = icboe.Aggregate.calcMargin(revenuePastYear, costPastYear);
+      const marginBetween = icboe.Aggregate.calcMargin(revenueBetween, costBetween);
+      let marginYoY;
 
       if (marginBetween !== 0) {
         marginYoY = (marginPastYear - marginBetween) / marginBetween;
@@ -131,7 +125,7 @@ define('crm/Integrations/BOE/Aggregate', ['module', 'exports', 'dojo/_base/lang'
       * @deprecated
       */
     changeColor: function changeColor(widget, value) {
-      var temp = value;
+      let temp = value;
       temp = temp * 100;
 
       if (temp > 0.01) {

--- a/src-out/Integrations/BOE/ApplicationModule.js
+++ b/src-out/Integrations/BOE/ApplicationModule.js
@@ -89,7 +89,7 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.ApplicationModule', [_ApplicationModule2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.ApplicationModule', [_ApplicationModule2.default], {
     modules: null,
     init: function init() {
       this.inherited(init, arguments);
@@ -98,7 +98,7 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
       App.enableDashboards = this.enableDashboards;
       this.modules = [new _AccountAssociationModule2.default(this), new _AccountModule2.default(this), new _BillToAccountModule2.default(this), new _BillToModule2.default(this), new _ContactModule2.default(this), new _ContactAssociationModule2.default(this), new _HelpModule2.default(this), new _InvoiceLineModule2.default(this), new _InvoiceModule2.default(this), new _OpportunityModule2.default(this), new _PayFromModule2.default(this), new _ProductModule2.default(this), new _QuoteModule2.default(this), new _QuotePersonModule2.default(this), new _QuoteLineModule2.default(this), new _ReceivableLineModule2.default(this), new _ReceivableModule2.default(this), new _ReturnLineModule2.default(this), new _ReturnModule2.default(this), new _SalesOrderItemModule2.default(this), new _SalesOrderModule2.default(this), new _ShipmentLineModule2.default(this), new _ShipmentModule2.default(this), new _ShipToAccountModule2.default(this), new _ShipToModule2.default(this)];
 
-      this.modules.forEach(function (mod) {
+      this.modules.forEach(mod => {
         mod.init();
       });
     },
@@ -107,16 +107,14 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
         return;
       }
 
-      this.modules.forEach(function (mod) {
+      this.modules.forEach(mod => {
         mod.initDynamic();
       });
 
       this.inherited(initDynamic, arguments);
     },
     isIntegrationEnabled: function isIntegrationEnabled() {
-      var results = this.application.context.integrations.filter(function (integration) {
-        return integration.Name === 'Back Office Extension';
-      })[0];
+      const results = this.application.context.integrations.filter(integration => integration.Name === 'Back Office Extension')[0];
       return results && results.Enabled;
     },
     loadViewsDynamic: function loadViewsDynamic() {
@@ -124,7 +122,7 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
         return;
       }
 
-      this.modules.forEach(function (module) {
+      this.modules.forEach(module => {
         module.loadViews();
       });
     },
@@ -133,15 +131,15 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
         return;
       }
 
-      this.modules.forEach(function (module) {
+      this.modules.forEach(module => {
         module.loadCustomizations();
       });
       this.registerDefaultViews();
 
       _lang2.default.extend(argos._ListBase, { // TODO: Avoid global
         navigateToInsertView: function navigateToInsertView(additionalOptions) {
-          var view = this.app.getView(this.insertView || this.editView);
-          var options = {
+          const view = this.app.getView(this.insertView || this.editView);
+          let options = {
             detailView: this.detailView,
             returnTo: this.id,
             insert: true
@@ -165,7 +163,7 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
       _lang2.default.extend(argos._EditBase, { // TODO: Avoid global
         onInsertCompleted: function onInsertCompleted(entry) {
           if (this.options && this.options.detailView) {
-            var view = App.getView(this.options.detailView);
+            const view = App.getView(this.options.detailView);
             if (view) {
               view.show({
                 key: entry.$key,
@@ -176,10 +174,10 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
               });
             }
           } else if (this.options && this.options.returnTo) {
-            var returnTo = this.options.returnTo;
-            var _view = App.getView(returnTo);
-            if (_view) {
-              _view.show();
+            const returnTo = this.options.returnTo;
+            const view = App.getView(returnTo);
+            if (view) {
+              view.show();
             } else {
               window.location.hash = returnTo;
             }
@@ -196,7 +194,7 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
         },
         getValueStyle: function getValueStyle() {
           if (this.valueColor) {
-            return 'style=color:' + this.valueColor;
+            return `style=color:${this.valueColor}`;
           }
           return '';
         }
@@ -207,8 +205,8 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
       });
 
       // Recently viewed support
-      var originalMappings = _List2.default.prototype.entityMappings;
-      var originalText = _List2.default.prototype.entityText;
+      const originalMappings = _List2.default.prototype.entityMappings;
+      const originalText = _List2.default.prototype.entityText;
 
       _List2.default.prototype.entityText = Object.assign({}, originalText, {
         ERPShipment: (0, _I18n2.default)('erpShipmentModel').entityDisplayNamePlural,
@@ -241,7 +239,7 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
         return;
       }
 
-      this.modules.forEach(function (module) {
+      this.modules.forEach(module => {
         module.loadToolbars();
       });
     },
@@ -260,12 +258,12 @@ define('crm/Integrations/BOE/ApplicationModule', ['module', 'exports', 'dojo/_ba
       // });
     },
     registerDefaultViews: function registerDefaultViews() {
-      var self = this;
-      var originalGetDefaultViews = _Application2.default.prototype.getDefaultViews;
+      const self = this;
+      const originalGetDefaultViews = _Application2.default.prototype.getDefaultViews;
       _lang2.default.extend(_Application2.default, {
         getDefaultViews: function getDefaultViews() {
-          var views = originalGetDefaultViews.apply(this, arguments) || [];
-          self.modules.forEach(function (module) {
+          const views = originalGetDefaultViews.apply(this, arguments) || [];
+          self.modules.forEach(module => {
             module.registerDefaultViews(views);
           });
           return views;

--- a/src-out/Integrations/BOE/DashboardWidget.js
+++ b/src-out/Integrations/BOE/DashboardWidget.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/DashboardWidget', ['module', 'exports', 'dojo/_base
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.DashboardWidget', [_DashboardWidgetBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.DashboardWidget', [_DashboardWidgetBase3.default], {
     buildView: function buildView(entry) {
       this.destroyWidgets();
       this.metricWidgets = [];
@@ -46,28 +46,26 @@ define('crm/Integrations/BOE/DashboardWidget', ['module', 'exports', 'dojo/_base
       this.getQueryData();
     },
     createMetricWidgets: function createMetricWidgets(entry) {
-      var _this = this;
-
       // Create metrics widgets and place them in the metricsNode
-      var frag = document.createDocumentFragment();
-      var widgetOptions = this.createMetricLayout(entry) || [];
-      widgetOptions.forEach(function (options) {
-        if (_this.hasValidOptions(options)) {
+      const frag = document.createDocumentFragment();
+      const widgetOptions = this.createMetricLayout(entry) || [];
+      widgetOptions.forEach(options => {
+        if (this.hasValidOptions(options)) {
           // Check if widget has a navigate to view option
           if (options.navTo) {
-            var obj = _this.values.filter(_this.checkForValue, options)[0];
-            options.navToReportView = _this.navToReportView;
+            const obj = this.values.filter(this.checkForValue, options)[0];
+            options.navToReportView = this.navToReportView;
             options.chartType = 'noChart';
             if (!(obj.queryIndex instanceof Array)) {
               // Get the active filter from the query args array and pass it as an option to the widget to be consumed by the navToReportView function
-              options.activeFilter = _this.queryArgs[obj.queryIndex][1]._activeFilter;
+              options.activeFilter = this.queryArgs[obj.queryIndex][1]._activeFilter;
             }
           }
-          var widget = new _MetricWidget2.default(options);
-          var itemNode = $(_this.metricItemTemplate.apply(options, _this));
+          const widget = new _MetricWidget2.default(options);
+          const itemNode = $(this.metricItemTemplate.apply(options, this));
           frag.appendChild(itemNode.get(0));
           $(itemNode).append($(widget)[0].domNode);
-          _this.registerWidget(widget);
+          this.registerWidget(widget);
         }
       });
       if (frag.childNodes.length) {
@@ -75,19 +73,17 @@ define('crm/Integrations/BOE/DashboardWidget', ['module', 'exports', 'dojo/_base
       }
     },
     createRangeWidgets: function createRangeWidgets() {
-      var _this2 = this;
-
-      var rangeFrag = document.createDocumentFragment();
+      const rangeFrag = document.createDocumentFragment();
       // Check if range widgets are desired, if so create and place in rangeNode
       if (this.createRangeLayout) {
-        var rangeOptions = this.createRangeLayout() || [];
-        rangeOptions.forEach(function (options) {
-          options.changeRange = _this2.changeRange;
-          options.parent = _this2;
-          var widget = new _DateRangeWidget2.default(options);
-          var itemNode = $(_this2.rangeItemTemplate.apply(options, _this2)).get(0);
-          if (options.value === _this2.dayValue) {
-            _this2.selectedRange = itemNode;
+        const rangeOptions = this.createRangeLayout() || [];
+        rangeOptions.forEach(options => {
+          options.changeRange = this.changeRange;
+          options.parent = this;
+          const widget = new _DateRangeWidget2.default(options);
+          const itemNode = $(this.rangeItemTemplate.apply(options, this)).get(0);
+          if (options.value === this.dayValue) {
+            this.selectedRange = itemNode;
           }
           rangeFrag.appendChild(itemNode);
           $(itemNode).append($(widget)[0].domNode);
@@ -111,7 +107,7 @@ define('crm/Integrations/BOE/DashboardWidget', ['module', 'exports', 'dojo/_base
     }
   });
 
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('dashboard_widget', __class);
   _lang2.default.setObject('crm.Views.DashboardWidget', __class);
   exports.default = __class;

--- a/src-out/Integrations/BOE/DateRangeWidget.js
+++ b/src-out/Integrations/BOE/DateRangeWidget.js
@@ -31,7 +31,7 @@ define('crm/Integrations/BOE/DateRangeWidget', ['module', 'exports', 'dojo/_base
    * See the License for the specific language governing permissions and
    * limitations under the License.
    */
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.DateRangeWidget', [_Widget3.default, _Templated3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.DateRangeWidget', [_Widget3.default, _Templated3.default], {
     widgetTemplate: new Simplate(['<div class="range-widget">', '<button data-dojo-attach-event="onclick:changeRange">', '<div data-dojo-attach-point="rangeDetailNode" class="range-detail">', '{%! $.itemTemplate %}', '</div>', '</button>', '</div>']),
 
     /*

--- a/src-out/Integrations/BOE/Models/BackOffice/Base.js
+++ b/src-out/Integrations/BOE/Models/BackOffice/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/BackOffice/Base', ['module', 'exports', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('backOfficeModel'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('backOfficeModel'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOffice.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOffice.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'backOffices',
     entityName: 'BackOffice',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/BackOffice/Base', ['module', 'exports', 'doj
     listViewId: 'backoffices_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/BackOffice/Offline.js
+++ b/src-out/Integrations/BOE/Models/BackOffice/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/BackOffice/Offline', ['module', 'exports', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOffice.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOffice.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'backoffice_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/BackOffice/SData.js
+++ b/src-out/Integrations/BOE/Models/BackOffice/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/BackOffice/SData', ['module', 'exports', 'do
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integration.BOE.Models.BackOffice.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integration.BOE.Models.BackOffice.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'backoffice_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/BackOfficeAccountingEntity/Base.js
+++ b/src-out/Integrations/BOE/Models/BackOfficeAccountingEntity/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/BackOfficeAccountingEntity/Base', ['module',
     };
   }
 
-  var resource = (0, _I18n2.default)('backOfficeAccountingEntityModel'); /* Copyright 2017 Infor
-                                                                          *
-                                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                          * you may not use this file except in compliance with the License.
-                                                                          * You may obtain a copy of the License at
-                                                                          *
-                                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                          *
-                                                                          * Unless required by applicable law or agreed to in writing, software
-                                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                          * See the License for the specific language governing permissions and
-                                                                          * limitations under the License.
-                                                                          */
+  const resource = (0, _I18n2.default)('backOfficeAccountingEntityModel'); /* Copyright 2017 Infor
+                                                                            *
+                                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                            * you may not use this file except in compliance with the License.
+                                                                            * You may obtain a copy of the License at
+                                                                            *
+                                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                            *
+                                                                            * Unless required by applicable law or agreed to in writing, software
+                                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                            * See the License for the specific language governing permissions and
+                                                                            * limitations under the License.
+                                                                            */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOfficeAccountingEntities.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOfficeAccountingEntities.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'backOfficeAccountingEntities',
     entityName: 'BackOfficeAcctEntity',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/BackOfficeAccountingEntity/Base', ['module',
     listViewId: 'backofficeaccountingentities_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/BackOfficeAccountingEntity/Offline.js
+++ b/src-out/Integrations/BOE/Models/BackOfficeAccountingEntity/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/BackOfficeAccountingEntity/Offline', ['modul
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOfficeAccountingEntity.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOfficeAccountingEntity.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'backofficeaccountingentity_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/BackOfficeAccountingEntity/SData.js
+++ b/src-out/Integrations/BOE/Models/BackOfficeAccountingEntity/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/BackOfficeAccountingEntity/SData', ['module'
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOfficeAccountingEntity.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.BackOfficeAccountingEntity.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'backofficeaccountingentity_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/Carrier/Base.js
+++ b/src-out/Integrations/BOE/Models/Carrier/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/Carrier/Base', ['module', 'exports', 'dojo/_
     };
   }
 
-  var resource = (0, _I18n2.default)('carrierModel'); /* Copyright 2017 Infor
-                                                       *
-                                                       * Licensed under the Apache License, Version 2.0 (the "License");
-                                                       * you may not use this file except in compliance with the License.
-                                                       * You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing, software
-                                                       * distributed under the License is distributed on an "AS IS" BASIS,
-                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                       * See the License for the specific language governing permissions and
-                                                       * limitations under the License.
-                                                       */
+  const resource = (0, _I18n2.default)('carrierModel'); /* Copyright 2017 Infor
+                                                         *
+                                                         * Licensed under the Apache License, Version 2.0 (the "License");
+                                                         * you may not use this file except in compliance with the License.
+                                                         * You may obtain a copy of the License at
+                                                         *
+                                                         *    http://www.apache.org/licenses/LICENSE-2.0
+                                                         *
+                                                         * Unless required by applicable law or agreed to in writing, software
+                                                         * distributed under the License is distributed on an "AS IS" BASIS,
+                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                         * See the License for the specific language governing permissions and
+                                                         * limitations under the License.
+                                                         */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Carrier.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Carrier.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'carriers',
     entityName: 'Carrier',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/Carrier/Base', ['module', 'exports', 'dojo/_
     listViewId: 'carriers_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/Carrier/Offline.js
+++ b/src-out/Integrations/BOE/Models/Carrier/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/Carrier/Offline', ['module', 'exports', 'doj
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Carrier.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Carrier.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'carrier_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/Carrier/SData.js
+++ b/src-out/Integrations/BOE/Models/Carrier/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/Carrier/SData', ['module', 'exports', 'dojo/
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Carrier.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Carrier.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'carrier_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpAccountPerson/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpAccountPerson/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/ErpAccountPerson/Base', ['module', 'exports'
     };
   }
 
-  var resource = (0, _I18n2.default)('erpAccountPersonModel'); /* Copyright 2017 Infor
-                                                                *
-                                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                * you may not use this file except in compliance with the License.
-                                                                * You may obtain a copy of the License at
-                                                                *
-                                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                *
-                                                                * Unless required by applicable law or agreed to in writing, software
-                                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                * See the License for the specific language governing permissions and
-                                                                * limitations under the License.
-                                                                */
+  const resource = (0, _I18n2.default)('erpAccountPersonModel'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpAccountPerson.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpAccountPerson.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpAccountPersons',
     entityName: 'ERPAccountPerson',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/ErpAccountPerson/Base', ['module', 'exports'
     listViewId: 'erpaccountperson_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/ErpAccountPerson/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpAccountPerson/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpAccountPerson/Offline', ['module', 'expor
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpAccountPerson.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpAccountPerson.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpaccountperson_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpAccountPerson/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpAccountPerson/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpAccountPerson/SData', ['module', 'exports
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpAccountPerson.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpAccountPerson.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpaccountperson_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpBillTo/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpBillTo/Base.js
@@ -19,7 +19,7 @@ define('crm/Integrations/BOE/Models/ErpBillTo/Base', ['module', 'exports', 'dojo
     };
   }
 
-  var resource = (0, _I18n2.default)('erpBillToModel');
+  const resource = (0, _I18n2.default)('erpBillToModel');
   // const accountResource = getResource('accountModel');
   // const shiptoResource = getResource('erpShipToModel');
   /* Copyright 2017 Infor
@@ -37,13 +37,13 @@ define('crm/Integrations/BOE/Models/ErpBillTo/Base', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var quoteResource = (0, _I18n2.default)('quoteModel');
-  var salesorderResource = (0, _I18n2.default)('salesOrderModel');
-  var invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
-  var returnResource = (0, _I18n2.default)('returnModel');
-  var syncresultResource = (0, _I18n2.default)('syncResultModel');
+  const quoteResource = (0, _I18n2.default)('quoteModel');
+  const salesorderResource = (0, _I18n2.default)('salesOrderModel');
+  const invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
+  const returnResource = (0, _I18n2.default)('returnModel');
+  const syncresultResource = (0, _I18n2.default)('syncResultModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillTo.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillTo.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpBillTos',
     entityName: 'ERPBillTo',
@@ -61,7 +61,7 @@ define('crm/Integrations/BOE/Models/ErpBillTo/Base', ['module', 'exports', 'dojo
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [
+      const rel = this.relationships || (this.relationships = [
       // TODO: Update with ManyToMany relationship when available in core.
       // {
       //   name: 'Account',

--- a/src-out/Integrations/BOE/Models/ErpBillTo/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpBillTo/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpBillTo/Offline', ['module', 'exports', 'd
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillTo.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillTo.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpbillto_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpBillTo/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpBillTo/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpBillTo/SData', ['module', 'exports', 'doj
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillTo.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillTo.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpbillto_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpBillToAccount/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpBillToAccount/Base.js
@@ -19,24 +19,24 @@ define('crm/Integrations/BOE/Models/ErpBillToAccount/Base', ['module', 'exports'
     };
   }
 
-  var resource = (0, _I18n2.default)('erpBillToAccountModel'); /* Copyright 2017 Infor
-                                                                *
-                                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                * you may not use this file except in compliance with the License.
-                                                                * You may obtain a copy of the License at
-                                                                *
-                                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                *
-                                                                * Unless required by applicable law or agreed to in writing, software
-                                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                * See the License for the specific language governing permissions and
-                                                                * limitations under the License.
-                                                                */
+  const resource = (0, _I18n2.default)('erpBillToAccountModel'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-  var accountResource = (0, _I18n2.default)('accountModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillToAccount.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillToAccount.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpBillToAccounts',
     entityName: 'ERPBillToAccount',
@@ -48,7 +48,7 @@ define('crm/Integrations/BOE/Models/ErpBillToAccount/Base', ['module', 'exports'
     listViewId: 'erpbilltoaccounts_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/ErpBillToAccount/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpBillToAccount/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpBillToAccount/Offline', ['module', 'expor
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillToAccount.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillToAccount.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpbilltoaccount_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpBillToAccount/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpBillToAccount/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpBillToAccount/SData', ['module', 'exports
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillToAccount.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpBillToAccount.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpbilltoaccount_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpContactAssociation/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpContactAssociation/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/ErpContactAssociation/Base', ['module', 'exp
     };
   }
 
-  var resource = (0, _I18n2.default)('erpContactAssociationModel'); /* Copyright 2017 Infor
-                                                                     *
-                                                                     * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                     * you may not use this file except in compliance with the License.
-                                                                     * You may obtain a copy of the License at
-                                                                     *
-                                                                     *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                     *
-                                                                     * Unless required by applicable law or agreed to in writing, software
-                                                                     * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                     * See the License for the specific language governing permissions and
-                                                                     * limitations under the License.
-                                                                     */
+  const resource = (0, _I18n2.default)('erpContactAssociationModel'); /* Copyright 2017 Infor
+                                                                       *
+                                                                       * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                       * you may not use this file except in compliance with the License.
+                                                                       * You may obtain a copy of the License at
+                                                                       *
+                                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                       *
+                                                                       * Unless required by applicable law or agreed to in writing, software
+                                                                       * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                       * See the License for the specific language governing permissions and
+                                                                       * limitations under the License.
+                                                                       */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpContactAssociation.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpContactAssociation.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpContactAccounts',
     entityName: 'ERPContactAccount',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/ErpContactAssociation/Base', ['module', 'exp
     listViewId: 'erpcontactassociations_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/ErpContactAssociation/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpContactAssociation/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpContactAssociation/Offline', ['module', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpContactAssociation.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpContactAssociation.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpcontactassociation_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpContactAssociation/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpContactAssociation/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpContactAssociation/SData', ['module', 'ex
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpContactAssociation.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpContactAssociation.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpcontactassociation_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpInvoice/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoice/Base.js
@@ -19,28 +19,28 @@ define('crm/Integrations/BOE/Models/ErpInvoice/Base', ['module', 'exports', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('erpInvoiceModel'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('erpInvoiceModel'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var billToResource = (0, _I18n2.default)('erpBillToModel');
-  var shipToResource = (0, _I18n2.default)('erpShipToModel');
-  var invoiceItemResource = (0, _I18n2.default)('erpInvoiceItemModel');
-  var receivableResource = (0, _I18n2.default)('erpReceivableModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const billToResource = (0, _I18n2.default)('erpBillToModel');
+  const shipToResource = (0, _I18n2.default)('erpShipToModel');
+  const invoiceItemResource = (0, _I18n2.default)('erpInvoiceItemModel');
+  const receivableResource = (0, _I18n2.default)('erpReceivableModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoice.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoice.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpInvoices',
     entityName: 'ERPInvoice',
@@ -58,7 +58,7 @@ define('crm/Integrations/BOE/Models/ErpInvoice/Base', ['module', 'exports', 'doj
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/ErpInvoice/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoice/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpInvoice/Offline', ['module', 'exports', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoice.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoice.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpinvoice_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpInvoice/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoice/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpInvoice/SData', ['module', 'exports', 'do
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoice.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoice.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpinvoice_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpInvoiceItem/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoiceItem/Base.js
@@ -19,25 +19,25 @@ define('crm/Integrations/BOE/Models/ErpInvoiceItem/Base', ['module', 'exports', 
     };
   }
 
-  var resource = (0, _I18n2.default)('erpInvoiceItemModel'); /* Copyright 2017 Infor
-                                                              *
-                                                              * Licensed under the Apache License, Version 2.0 (the "License");
-                                                              * you may not use this file except in compliance with the License.
-                                                              * You may obtain a copy of the License at
-                                                              *
-                                                              *    http://www.apache.org/licenses/LICENSE-2.0
-                                                              *
-                                                              * Unless required by applicable law or agreed to in writing, software
-                                                              * distributed under the License is distributed on an "AS IS" BASIS,
-                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                              * See the License for the specific language governing permissions and
-                                                              * limitations under the License.
-                                                              */
+  const resource = (0, _I18n2.default)('erpInvoiceItemModel'); /* Copyright 2017 Infor
+                                                                *
+                                                                * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                * you may not use this file except in compliance with the License.
+                                                                * You may obtain a copy of the License at
+                                                                *
+                                                                *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                *
+                                                                * Unless required by applicable law or agreed to in writing, software
+                                                                * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                * See the License for the specific language governing permissions and
+                                                                * limitations under the License.
+                                                                */
 
-  var invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
-  var salesOrderResource = (0, _I18n2.default)('saleOrderModel');
+  const invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
+  const salesOrderResource = (0, _I18n2.default)('saleOrderModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoiceItem.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoiceItem.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpInvoiceItems',
     entityName: 'ERPInvoiceItem',
@@ -49,7 +49,7 @@ define('crm/Integrations/BOE/Models/ErpInvoiceItem/Base', ['module', 'exports', 
     listViewId: 'invoice_item_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Invoice',
         displayName: invoiceResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/ErpInvoiceItem/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoiceItem/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpInvoiceItem/Offline', ['module', 'exports
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoiceItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoiceItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpinvoiceitem_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpInvoiceItem/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoiceItem/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpInvoiceItem/SData', ['module', 'exports',
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoiceItem.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoiceItem.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpinvoiceitem_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpInvoicePerson/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoicePerson/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/ErpInvoicePerson/Base', ['module', 'exports'
     };
   }
 
-  var resource = (0, _I18n2.default)('erpInvoicePersonModel'); /* Copyright 2017 Infor
-                                                                *
-                                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                * you may not use this file except in compliance with the License.
-                                                                * You may obtain a copy of the License at
-                                                                *
-                                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                *
-                                                                * Unless required by applicable law or agreed to in writing, software
-                                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                * See the License for the specific language governing permissions and
-                                                                * limitations under the License.
-                                                                */
+  const resource = (0, _I18n2.default)('erpInvoicePersonModel'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoicePerson.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoicePerson.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpInvoicePersons',
     entityName: 'ERPInvoicePerson',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/ErpInvoicePerson/Base', ['module', 'exports'
     listViewId: 'invoiceperson_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/ErpInvoicePerson/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoicePerson/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpInvoicePerson/Offline', ['module', 'expor
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoicePerson.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoicePerson.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpinvoiceperson_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpInvoicePerson/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpInvoicePerson/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpInvoicePerson/SData', ['module', 'exports
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoicePerson.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpInvoicePerson.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpinvoiceperson_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpReceivable/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpReceivable/Base.js
@@ -19,28 +19,28 @@ define('crm/Integrations/BOE/Models/ErpReceivable/Base', ['module', 'exports', '
     };
   }
 
-  var resource = (0, _I18n2.default)('erpReceivableModel'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('erpReceivableModel'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var billToResource = (0, _I18n2.default)('erpBillToModel');
-  var shipToResource = (0, _I18n2.default)('erpShipToModel');
-  var receivableItemResource = (0, _I18n2.default)('erpReceivableItemModel');
-  var invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const billToResource = (0, _I18n2.default)('erpBillToModel');
+  const shipToResource = (0, _I18n2.default)('erpShipToModel');
+  const receivableItemResource = (0, _I18n2.default)('erpReceivableItemModel');
+  const invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivable.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivable.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpReceivables',
     entityName: 'ERPReceivable',
@@ -52,7 +52,7 @@ define('crm/Integrations/BOE/Models/ErpReceivable/Base', ['module', 'exports', '
     listViewId: 'erpreceivables_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/ErpReceivable/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpReceivable/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpReceivable/Offline', ['module', 'exports'
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivable.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivable.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpreceivable_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpReceivable/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpReceivable/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpReceivable/SData', ['module', 'exports', 
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivable.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivable.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpreceivable_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpReceivableItem/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpReceivableItem/Base.js
@@ -19,25 +19,25 @@ define('crm/Integrations/BOE/Models/ErpReceivableItem/Base', ['module', 'exports
     };
   }
 
-  var resource = (0, _I18n2.default)('erpReceivableItemModel'); /* Copyright 2017 Infor
-                                                                 *
-                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                 * you may not use this file except in compliance with the License.
-                                                                 * You may obtain a copy of the License at
-                                                                 *
-                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                 *
-                                                                 * Unless required by applicable law or agreed to in writing, software
-                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                 * See the License for the specific language governing permissions and
-                                                                 * limitations under the License.
-                                                                 */
+  const resource = (0, _I18n2.default)('erpReceivableItemModel'); /* Copyright 2017 Infor
+                                                                   *
+                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                   * you may not use this file except in compliance with the License.
+                                                                   * You may obtain a copy of the License at
+                                                                   *
+                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                   *
+                                                                   * Unless required by applicable law or agreed to in writing, software
+                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                   * See the License for the specific language governing permissions and
+                                                                   * limitations under the License.
+                                                                   */
 
-  var receivableResource = (0, _I18n2.default)('erpReceivableModel');
-  var invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
+  const receivableResource = (0, _I18n2.default)('erpReceivableModel');
+  const invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivableItem.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivableItem.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpReceivableItems',
     entityName: 'ERPReceivableItem',
@@ -49,7 +49,7 @@ define('crm/Integrations/BOE/Models/ErpReceivableItem/Base', ['module', 'exports
     listViewId: 'erpreceivable_items_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Invoice',
         displayName: invoiceResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/ErpReceivableItem/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpReceivableItem/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpReceivableItem/Offline', ['module', 'expo
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivableItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivableItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpreceivableitem_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpReceivableItem/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpReceivableItem/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpReceivableItem/SData', ['module', 'export
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivableItem.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpReceivableItem.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpreceivableitem_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpSalesOrderPerson/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpSalesOrderPerson/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/ErpSalesOrderPerson/Base', ['module', 'expor
     };
   }
 
-  var resource = (0, _I18n2.default)('erpSalesOrderPersonModel'); /* Copyright 2017 Infor
-                                                                   *
-                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                   * you may not use this file except in compliance with the License.
-                                                                   * You may obtain a copy of the License at
-                                                                   *
-                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                   *
-                                                                   * Unless required by applicable law or agreed to in writing, software
-                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                   * See the License for the specific language governing permissions and
-                                                                   * limitations under the License.
-                                                                   */
+  const resource = (0, _I18n2.default)('erpSalesOrderPersonModel'); /* Copyright 2017 Infor
+                                                                     *
+                                                                     * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                     * you may not use this file except in compliance with the License.
+                                                                     * You may obtain a copy of the License at
+                                                                     *
+                                                                     *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                     *
+                                                                     * Unless required by applicable law or agreed to in writing, software
+                                                                     * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                     * See the License for the specific language governing permissions and
+                                                                     * limitations under the License.
+                                                                     */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpSalesOrderPerson.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpSalesOrderPerson.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpSalesOrderPersons',
     entityName: 'ERPSalesOrderPerson',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/ErpSalesOrderPerson/Base', ['module', 'expor
     listViewId: 'erpsalesorderperson_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/ErpSalesOrderPerson/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpSalesOrderPerson/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpSalesOrderPerson/Offline', ['module', 'ex
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpSalesOrderPerson.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpSalesOrderPerson.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpsalesorderperson_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpSalesOrderPerson/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpSalesOrderPerson/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpSalesOrderPerson/SData', ['module', 'expo
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpSalesOrderPerson.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpSalesOrderPerson.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpsalesorderperson_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpShipTo/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpShipTo/Base.js
@@ -19,7 +19,7 @@ define('crm/Integrations/BOE/Models/ErpShipTo/Base', ['module', 'exports', 'dojo
     };
   }
 
-  var resource = (0, _I18n2.default)('erpShipToModel');
+  const resource = (0, _I18n2.default)('erpShipToModel');
   // const accountResource = getResource('accountModel');
   // const billtoResource = getResource('erpBillToModel');
   /* Copyright 2017 Infor
@@ -37,14 +37,14 @@ define('crm/Integrations/BOE/Models/ErpShipTo/Base', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var quoteResource = (0, _I18n2.default)('quoteModel');
-  var salesorderResource = (0, _I18n2.default)('salesOrderModel');
-  var receivableResource = (0, _I18n2.default)('erpReceivableModel');
-  var invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
-  var returnResource = (0, _I18n2.default)('returnModel');
-  var syncresultResource = (0, _I18n2.default)('syncResultModel');
+  const quoteResource = (0, _I18n2.default)('quoteModel');
+  const salesorderResource = (0, _I18n2.default)('salesOrderModel');
+  const receivableResource = (0, _I18n2.default)('erpReceivableModel');
+  const invoiceResource = (0, _I18n2.default)('erpInvoiceModel');
+  const returnResource = (0, _I18n2.default)('returnModel');
+  const syncresultResource = (0, _I18n2.default)('syncResultModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipTo.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipTo.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpShipTos',
     entityName: 'ERPShipTo',
@@ -62,7 +62,7 @@ define('crm/Integrations/BOE/Models/ErpShipTo/Base', ['module', 'exports', 'dojo
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [
+      const rel = this.relationships || (this.relationships = [
       // TODO: Update when ManyToMany relationship is supported
       // {
       //   name: 'Account',

--- a/src-out/Integrations/BOE/Models/ErpShipTo/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpShipTo/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpShipTo/Offline', ['module', 'exports', 'd
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipTo.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipTo.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpshipto_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpShipTo/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpShipTo/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpShipTo/SData', ['module', 'exports', 'doj
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipTo.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipTo.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpshipto_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpShipToAccount/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpShipToAccount/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/ErpShipToAccount/Base', ['module', 'exports'
     };
   }
 
-  var resource = (0, _I18n2.default)('erpShipToAccountModel'); /* Copyright 2017 Infor
-                                                                *
-                                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                * you may not use this file except in compliance with the License.
-                                                                * You may obtain a copy of the License at
-                                                                *
-                                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                *
-                                                                * Unless required by applicable law or agreed to in writing, software
-                                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                * See the License for the specific language governing permissions and
-                                                                * limitations under the License.
-                                                                */
+  const resource = (0, _I18n2.default)('erpShipToAccountModel'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipToAccount.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipToAccount.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpShipToAccounts',
     entityName: 'ERPShipToAccount',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/ErpShipToAccount/Base', ['module', 'exports'
     listViewId: 'erpshipto_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/ErpShipToAccount/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpShipToAccount/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpShipToAccount/Offline', ['module', 'expor
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipToAccount.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipToAccount.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpshiptoaccount_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpShipToAccount/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpShipToAccount/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpShipToAccount/SData', ['module', 'exports
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipToAccount.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipToAccount.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpshiptoaccount_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpShipment/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpShipment/Base.js
@@ -19,26 +19,26 @@ define('crm/Integrations/BOE/Models/ErpShipment/Base', ['module', 'exports', 'do
     };
   }
 
-  var resource = (0, _I18n2.default)('erpShipmentModel'); /* Copyright 2017 Infor
-                                                           *
-                                                           * Licensed under the Apache License, Version 2.0 (the "License");
-                                                           * you may not use this file except in compliance with the License.
-                                                           * You may obtain a copy of the License at
-                                                           *
-                                                           *    http://www.apache.org/licenses/LICENSE-2.0
-                                                           *
-                                                           * Unless required by applicable law or agreed to in writing, software
-                                                           * distributed under the License is distributed on an "AS IS" BASIS,
-                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                           * See the License for the specific language governing permissions and
-                                                           * limitations under the License.
-                                                           */
+  const resource = (0, _I18n2.default)('erpShipmentModel'); /* Copyright 2017 Infor
+                                                             *
+                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                             * you may not use this file except in compliance with the License.
+                                                             * You may obtain a copy of the License at
+                                                             *
+                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                             *
+                                                             * Unless required by applicable law or agreed to in writing, software
+                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                             * See the License for the specific language governing permissions and
+                                                             * limitations under the License.
+                                                             */
 
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var shipToResource = (0, _I18n2.default)('erpShipToModel');
-  var shipmentItemResource = (0, _I18n2.default)('erpShipmentItemModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const shipToResource = (0, _I18n2.default)('erpShipToModel');
+  const shipmentItemResource = (0, _I18n2.default)('erpShipmentItemModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipment.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipment.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpShipments',
     entityName: 'ERPShipment',
@@ -50,7 +50,7 @@ define('crm/Integrations/BOE/Models/ErpShipment/Base', ['module', 'exports', 'do
     listViewId: 'erpshipments_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/ErpShipment/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpShipment/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpShipment/Offline', ['module', 'exports', 
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipment.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipment.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpshipment_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpShipment/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpShipment/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpShipment/SData', ['module', 'exports', 'd
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipment.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipment.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpshipment_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/ErpShipmentItem/Base.js
+++ b/src-out/Integrations/BOE/Models/ErpShipmentItem/Base.js
@@ -19,25 +19,25 @@ define('crm/Integrations/BOE/Models/ErpShipmentItem/Base', ['module', 'exports',
     };
   }
 
-  var resource = (0, _I18n2.default)('erpShipmentItemModel'); /* Copyright 2017 Infor
-                                                               *
-                                                               * Licensed under the Apache License, Version 2.0 (the "License");
-                                                               * you may not use this file except in compliance with the License.
-                                                               * You may obtain a copy of the License at
-                                                               *
-                                                               *    http://www.apache.org/licenses/LICENSE-2.0
-                                                               *
-                                                               * Unless required by applicable law or agreed to in writing, software
-                                                               * distributed under the License is distributed on an "AS IS" BASIS,
-                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                               * See the License for the specific language governing permissions and
-                                                               * limitations under the License.
-                                                               */
+  const resource = (0, _I18n2.default)('erpShipmentItemModel'); /* Copyright 2017 Infor
+                                                                 *
+                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                 * you may not use this file except in compliance with the License.
+                                                                 * You may obtain a copy of the License at
+                                                                 *
+                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                 *
+                                                                 * Unless required by applicable law or agreed to in writing, software
+                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                 * See the License for the specific language governing permissions and
+                                                                 * limitations under the License.
+                                                                 */
 
-  var shipmentResource = (0, _I18n2.default)('erpShipmentModel');
-  var salesOrderResource = (0, _I18n2.default)('salesOrderModel');
+  const shipmentResource = (0, _I18n2.default)('erpShipmentModel');
+  const salesOrderResource = (0, _I18n2.default)('salesOrderModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipmentItem.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipmentItem.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'erpShipmentItems',
     entityName: 'ERPShipmentItem',
@@ -49,7 +49,7 @@ define('crm/Integrations/BOE/Models/ErpShipmentItem/Base', ['module', 'exports',
     listViewId: 'erpshipment_items_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Shipment',
         displayName: shipmentResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/ErpShipmentItem/Offline.js
+++ b/src-out/Integrations/BOE/Models/ErpShipmentItem/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/ErpShipmentItem/Offline', ['module', 'export
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipmentItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipmentItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'erpshipmentitem_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/ErpShipmentItem/SData.js
+++ b/src-out/Integrations/BOE/Models/ErpShipmentItem/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/ErpShipmentItem/SData', ['module', 'exports'
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipmentItem.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.ErpShipmentItem.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'erpshipmentitem_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/Location/Base.js
+++ b/src-out/Integrations/BOE/Models/Location/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/Location/Base', ['module', 'exports', 'dojo/
     };
   }
 
-  var resource = (0, _I18n2.default)('locationModel'); /* Copyright 2017 Infor
-                                                        *
-                                                        * Licensed under the Apache License, Version 2.0 (the "License");
-                                                        * you may not use this file except in compliance with the License.
-                                                        * You may obtain a copy of the License at
-                                                        *
-                                                        *    http://www.apache.org/licenses/LICENSE-2.0
-                                                        *
-                                                        * Unless required by applicable law or agreed to in writing, software
-                                                        * distributed under the License is distributed on an "AS IS" BASIS,
-                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                        * See the License for the specific language governing permissions and
-                                                        * limitations under the License.
-                                                        */
+  const resource = (0, _I18n2.default)('locationModel'); /* Copyright 2017 Infor
+                                                          *
+                                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                                          * you may not use this file except in compliance with the License.
+                                                          * You may obtain a copy of the License at
+                                                          *
+                                                          *    http://www.apache.org/licenses/LICENSE-2.0
+                                                          *
+                                                          * Unless required by applicable law or agreed to in writing, software
+                                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                          * See the License for the specific language governing permissions and
+                                                          * limitations under the License.
+                                                          */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Location.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Location.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'slxLocations',
     entityName: 'SlxLocation',

--- a/src-out/Integrations/BOE/Models/Location/Offline.js
+++ b/src-out/Integrations/BOE/Models/Location/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/Location/Offline', ['module', 'exports', 'do
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Location.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Location.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'slxlocation_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/Location/SData.js
+++ b/src-out/Integrations/BOE/Models/Location/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/Location/SData', ['module', 'exports', 'dojo
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Location.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Location.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'slxlocation_sdata_model',
     createQueryModels: function createQueryModels() {
       // Unable to order by Description

--- a/src-out/Integrations/BOE/Models/OperatingCompany/Base.js
+++ b/src-out/Integrations/BOE/Models/OperatingCompany/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/OperatingCompany/Base', ['module', 'exports'
     };
   }
 
-  var resource = (0, _I18n2.default)('operatingCompanyModel'); /* Copyright 2017 Infor
-                                                                *
-                                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                * you may not use this file except in compliance with the License.
-                                                                * You may obtain a copy of the License at
-                                                                *
-                                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                *
-                                                                * Unless required by applicable law or agreed to in writing, software
-                                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                * See the License for the specific language governing permissions and
-                                                                * limitations under the License.
-                                                                */
+  const resource = (0, _I18n2.default)('operatingCompanyModel'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.OperatingCompany.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.OperatingCompany.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'operatingCompanies',
     entityName: 'AppIdMapping',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/OperatingCompany/Base', ['module', 'exports'
     listViewId: '',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/OperatingCompany/Offline.js
+++ b/src-out/Integrations/BOE/Models/OperatingCompany/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/OperatingCompany/Offline', ['module', 'expor
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.OperatingCompany.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.OperatingCompany.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'operatingcompany_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/OperatingCompany/SData.js
+++ b/src-out/Integrations/BOE/Models/OperatingCompany/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/OperatingCompany/SData', ['module', 'exports
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.OperatingCompany.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.OperatingCompany.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'operatingcompany_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/Product/Base.js
+++ b/src-out/Integrations/BOE/Models/Product/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/Product/Base', ['module', 'exports', 'dojo/_
     };
   }
 
-  var resource = (0, _I18n2.default)('productModel'); /* Copyright 2017 Infor
-                                                       *
-                                                       * Licensed under the Apache License, Version 2.0 (the "License");
-                                                       * you may not use this file except in compliance with the License.
-                                                       * You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing, software
-                                                       * distributed under the License is distributed on an "AS IS" BASIS,
-                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                       * See the License for the specific language governing permissions and
-                                                       * limitations under the License.
-                                                       */
+  const resource = (0, _I18n2.default)('productModel'); /* Copyright 2017 Infor
+                                                         *
+                                                         * Licensed under the Apache License, Version 2.0 (the "License");
+                                                         * you may not use this file except in compliance with the License.
+                                                         * You may obtain a copy of the License at
+                                                         *
+                                                         *    http://www.apache.org/licenses/LICENSE-2.0
+                                                         *
+                                                         * Unless required by applicable law or agreed to in writing, software
+                                                         * distributed under the License is distributed on an "AS IS" BASIS,
+                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                         * See the License for the specific language governing permissions and
+                                                         * limitations under the License.
+                                                         */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Product.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Product.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'products',
     entityName: 'Product',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/Product/Base', ['module', 'exports', 'dojo/_
     listViewId: '',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/Product/Offline.js
+++ b/src-out/Integrations/BOE/Models/Product/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/Product/Offline', ['module', 'exports', 'doj
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Product.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Product.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'product_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/Product/SData.js
+++ b/src-out/Integrations/BOE/Models/Product/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/Product/SData', ['module', 'exports', 'dojo/
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Product.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Product.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'product_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/Quote/Base.js
+++ b/src-out/Integrations/BOE/Models/Quote/Base.js
@@ -19,31 +19,31 @@ define('crm/Integrations/BOE/Models/Quote/Base', ['module', 'exports', 'dojo/_ba
     };
   }
 
-  var resource = (0, _I18n2.default)('quoteModel'); /* Copyright 2017 Infor
-                                                     *
-                                                     * Licensed under the Apache License, Version 2.0 (the "License");
-                                                     * you may not use this file except in compliance with the License.
-                                                     * You may obtain a copy of the License at
-                                                     *
-                                                     *    http://www.apache.org/licenses/LICENSE-2.0
-                                                     *
-                                                     * Unless required by applicable law or agreed to in writing, software
-                                                     * distributed under the License is distributed on an "AS IS" BASIS,
-                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                     * See the License for the specific language governing permissions and
-                                                     * limitations under the License.
-                                                     */
+  const resource = (0, _I18n2.default)('quoteModel'); /* Copyright 2017 Infor
+                                                       *
+                                                       * Licensed under the Apache License, Version 2.0 (the "License");
+                                                       * you may not use this file except in compliance with the License.
+                                                       * You may obtain a copy of the License at
+                                                       *
+                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                       *
+                                                       * Unless required by applicable law or agreed to in writing, software
+                                                       * distributed under the License is distributed on an "AS IS" BASIS,
+                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                       * See the License for the specific language governing permissions and
+                                                       * limitations under the License.
+                                                       */
 
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var quoteItemsResource = (0, _I18n2.default)('quoteItemModel');
-  var opportunityResource = (0, _I18n2.default)('opportunityModel');
-  var salesorderResource = (0, _I18n2.default)('salesOrderModel');
-  var billtoResource = (0, _I18n2.default)('erpBillToModel');
-  var shiptoResource = (0, _I18n2.default)('erpShipToModel');
-  var syncresultResource = (0, _I18n2.default)('syncResultModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const quoteItemsResource = (0, _I18n2.default)('quoteItemModel');
+  const opportunityResource = (0, _I18n2.default)('opportunityModel');
+  const salesorderResource = (0, _I18n2.default)('salesOrderModel');
+  const billtoResource = (0, _I18n2.default)('erpBillToModel');
+  const shiptoResource = (0, _I18n2.default)('erpShipToModel');
+  const syncresultResource = (0, _I18n2.default)('syncResultModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Quote.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Quote.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'quotes',
     entityName: 'Quote',
@@ -64,7 +64,7 @@ define('crm/Integrations/BOE/Models/Quote/Base', ['module', 'exports', 'dojo/_ba
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayNamePlural,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/Quote/Offline.js
+++ b/src-out/Integrations/BOE/Models/Quote/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/Quote/Offline', ['module', 'exports', 'dojo/
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Quote.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Quote.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'quote_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/Quote/SData.js
+++ b/src-out/Integrations/BOE/Models/Quote/SData.js
@@ -25,45 +25,22 @@ define('crm/Integrations/BOE/Models/Quote/SData', ['module', 'exports', 'dojo/_b
     };
   }
 
-  var _slicedToArray = function () {
-    function sliceIterator(arr, i) {
-      var _arr = [];
-      var _n = true;
-      var _d = false;
-      var _e = undefined;
+  /* Copyright 2017 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
 
-      try {
-        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-          _arr.push(_s.value);
-
-          if (i && _arr.length === i) break;
-        }
-      } catch (err) {
-        _d = true;
-        _e = err;
-      } finally {
-        try {
-          if (!_n && _i["return"]) _i["return"]();
-        } finally {
-          if (_d) throw _e;
-        }
-      }
-
-      return _arr;
-    }
-
-    return function (arr, i) {
-      if (Array.isArray(arr)) {
-        return arr;
-      } else if (Symbol.iterator in Object(arr)) {
-        return sliceIterator(arr, i);
-      } else {
-        throw new TypeError("Invalid attempt to destructure non-iterable instance");
-      }
-    };
-  }();
-
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Quotes.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Quotes.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'quote_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -81,23 +58,22 @@ define('crm/Integrations/BOE/Models/Quote/SData', ['module', 'exports', 'dojo/_b
       }];
     },
     isClosed: function isClosed($key, options) {
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('isClosed');
-      var entry = {
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('isClosed');
+      const entry = {
         $name: 'isClosed',
         request: {
           entity: {
-            $key: $key
+            $key
           }
         }
       };
-      return new Promise(function (resolve, reject) {
+      return new Promise((resolve, reject) => {
         request.execute(entry, {
-          success: function success(data) {
-            var Result = data.response.Result;
-
+          success: data => {
+            const { response: { Result } } = data;
             resolve(Result);
           },
-          failure: function failure(response, o) {
+          failure: (response, o) => {
             _ErrorManager2.default.addError(response, o, options, 'failure');
             reject(response);
           }
@@ -105,13 +81,9 @@ define('crm/Integrations/BOE/Models/Quote/SData', ['module', 'exports', 'dojo/_b
       });
     },
     getEntry: function getEntry(key, options) {
-      var results$ = this.inherited(getEntry, arguments);
-      var closed$ = this.isClosed(key, options);
-      return Promise.all([results$, closed$]).then(function (_ref) {
-        var _ref2 = _slicedToArray(_ref, 2),
-            entry = _ref2[0],
-            closed = _ref2[1];
-
+      const results$ = this.inherited(getEntry, arguments);
+      const closed$ = this.isClosed(key, options);
+      return Promise.all([results$, closed$]).then(([entry, closed]) => {
         entry.IsClosed = closed;
         return entry;
       });

--- a/src-out/Integrations/BOE/Models/QuoteItem/Base.js
+++ b/src-out/Integrations/BOE/Models/QuoteItem/Base.js
@@ -19,24 +19,24 @@ define('crm/Integrations/BOE/Models/QuoteItem/Base', ['module', 'exports', 'dojo
     };
   }
 
-  var resource = (0, _I18n2.default)('quoteItemModel'); /* Copyright 2017 Infor
-                                                         *
-                                                         * Licensed under the Apache License, Version 2.0 (the "License");
-                                                         * you may not use this file except in compliance with the License.
-                                                         * You may obtain a copy of the License at
-                                                         *
-                                                         *    http://www.apache.org/licenses/LICENSE-2.0
-                                                         *
-                                                         * Unless required by applicable law or agreed to in writing, software
-                                                         * distributed under the License is distributed on an "AS IS" BASIS,
-                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                         * See the License for the specific language governing permissions and
-                                                         * limitations under the License.
-                                                         */
+  const resource = (0, _I18n2.default)('quoteItemModel'); /* Copyright 2017 Infor
+                                                           *
+                                                           * Licensed under the Apache License, Version 2.0 (the "License");
+                                                           * you may not use this file except in compliance with the License.
+                                                           * You may obtain a copy of the License at
+                                                           *
+                                                           *    http://www.apache.org/licenses/LICENSE-2.0
+                                                           *
+                                                           * Unless required by applicable law or agreed to in writing, software
+                                                           * distributed under the License is distributed on an "AS IS" BASIS,
+                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                           * See the License for the specific language governing permissions and
+                                                           * limitations under the License.
+                                                           */
 
-  var quoteResource = (0, _I18n2.default)('quoteModel');
+  const quoteResource = (0, _I18n2.default)('quoteModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuoteItem.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuoteItem.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'quoteItems',
     entityName: 'QuoteItem',
@@ -48,7 +48,7 @@ define('crm/Integrations/BOE/Models/QuoteItem/Base', ['module', 'exports', 'dojo
     listViewId: 'quote_lines_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Quote',
         displayName: quoteResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/QuoteItem/Offline.js
+++ b/src-out/Integrations/BOE/Models/QuoteItem/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/QuoteItem/Offline', ['module', 'exports', 'd
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuoteItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuoteItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'quoteitem_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/QuoteItem/SData.js
+++ b/src-out/Integrations/BOE/Models/QuoteItem/SData.js
@@ -40,7 +40,7 @@ define('crm/Integrations/BOE/Models/QuoteItem/SData', ['module', 'exports', 'doj
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuoteItem.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuoteItem.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'quoteitem_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -58,17 +58,15 @@ define('crm/Integrations/BOE/Models/QuoteItem/SData', ['module', 'exports', 'doj
       }];
     },
     updateItemWithWarehouse: function updateItemWithWarehouse(quoteItem, warehouse) {
-      var _this = this;
-
-      var promise = new Promise(function (resolve) {
-        _PricingAvailabilityService2.default.updateQuoteItemWarehouse(quoteItem, warehouse.SlxLocation, warehouse.SlxLocationID, warehouse.ATPDate).then(function () {
+      const promise = new Promise(resolve => {
+        _PricingAvailabilityService2.default.updateQuoteItemWarehouse(quoteItem, warehouse.SlxLocation, warehouse.SlxLocationID, warehouse.ATPDate).then(() => {
           quoteItem.SlxLocation = {
             $key: warehouse.SlxLocationID,
             description: warehouse.SlxLocation
           };
-          _PricingAvailabilityService2.default.getQuoteItemPricing(quoteItem).then(function (pricingData) {
-            var entry = _this.createPricingEntryForUpdate(quoteItem, pricingData);
-            _this.updateEntry(entry, { overwrite: true }).then(function (result) {
+          _PricingAvailabilityService2.default.getQuoteItemPricing(quoteItem).then(pricingData => {
+            const entry = this.createPricingEntryForUpdate(quoteItem, pricingData);
+            this.updateEntry(entry, { overwrite: true }).then(result => {
               resolve(result);
             });
           });
@@ -77,7 +75,7 @@ define('crm/Integrations/BOE/Models/QuoteItem/SData', ['module', 'exports', 'doj
       return promise;
     },
     createPricingEntryForUpdate: function createPricingEntryForUpdate(quoteItem, pricingData) {
-      var entry = {};
+      const entry = {};
       entry.$key = quoteItem.$key;
       if (pricingData) {
         if (pricingData.DocCalculatedPrice) {

--- a/src-out/Integrations/BOE/Models/QuotePerson/Base.js
+++ b/src-out/Integrations/BOE/Models/QuotePerson/Base.js
@@ -19,24 +19,24 @@ define('crm/Integrations/BOE/Models/QuotePerson/Base', ['module', 'exports', 'do
     };
   }
 
-  var resource = (0, _I18n2.default)('quotePersonModel'); /* Copyright 2017 Infor
-                                                           *
-                                                           * Licensed under the Apache License, Version 2.0 (the "License");
-                                                           * you may not use this file except in compliance with the License.
-                                                           * You may obtain a copy of the License at
-                                                           *
-                                                           *    http://www.apache.org/licenses/LICENSE-2.0
-                                                           *
-                                                           * Unless required by applicable law or agreed to in writing, software
-                                                           * distributed under the License is distributed on an "AS IS" BASIS,
-                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                           * See the License for the specific language governing permissions and
-                                                           * limitations under the License.
-                                                           */
+  const resource = (0, _I18n2.default)('quotePersonModel'); /* Copyright 2017 Infor
+                                                             *
+                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                             * you may not use this file except in compliance with the License.
+                                                             * You may obtain a copy of the License at
+                                                             *
+                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                             *
+                                                             * Unless required by applicable law or agreed to in writing, software
+                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                             * See the License for the specific language governing permissions and
+                                                             * limitations under the License.
+                                                             */
 
-  var quoteResource = (0, _I18n2.default)('quoteModel');
+  const quoteResource = (0, _I18n2.default)('quoteModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuotePerson.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuotePerson.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'quotePersons',
     entityName: 'QuotePerson',
@@ -48,7 +48,7 @@ define('crm/Integrations/BOE/Models/QuotePerson/Base', ['module', 'exports', 'do
     listViewId: 'quotePerson_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Quote',
         displayName: quoteResource.entityDisplayNamePlural,
         type: 'OneToMany',

--- a/src-out/Integrations/BOE/Models/QuotePerson/Offline.js
+++ b/src-out/Integrations/BOE/Models/QuotePerson/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/QuotePerson/Offline', ['module', 'exports', 
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuotePerson.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuotePerson.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'quoteperson_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/QuotePerson/SData.js
+++ b/src-out/Integrations/BOE/Models/QuotePerson/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/QuotePerson/SData', ['module', 'exports', 'd
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuotePerson.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.QuotePerson.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'quoteperson_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/Return/Base.js
+++ b/src-out/Integrations/BOE/Models/Return/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/Return/Base', ['module', 'exports', 'dojo/_b
     };
   }
 
-  var resource = (0, _I18n2.default)('returnModel'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('returnModel'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Return.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Return.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'returns',
     entityName: 'Return',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/Return/Base', ['module', 'exports', 'dojo/_b
     listViewId: 'returns_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/Return/Offline.js
+++ b/src-out/Integrations/BOE/Models/Return/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/Return/Offline', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Return.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Return.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'return_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/Return/SData.js
+++ b/src-out/Integrations/BOE/Models/Return/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/Return/SData', ['module', 'exports', 'dojo/_
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Return.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.Return.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'return_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/SalesOrder/Base.js
+++ b/src-out/Integrations/BOE/Models/SalesOrder/Base.js
@@ -19,33 +19,33 @@ define('crm/Integrations/BOE/Models/SalesOrder/Base', ['module', 'exports', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('salesOrderModel'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('salesOrderModel'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var orderItemsResource = (0, _I18n2.default)('salesOrderItemModel');
-  var opportunityResource = (0, _I18n2.default)('opportunityModel');
-  var quoteResource = (0, _I18n2.default)('quoteModel');
-  var billtoResource = (0, _I18n2.default)('erpBillToModel');
-  var shiptoResource = (0, _I18n2.default)('erpShipToModel');
-  var syncresultResource = (0, _I18n2.default)('syncResultModel');
-  var invoiceitemResource = (0, _I18n2.default)('erpInvoiceItemModel');
-  var shipmentitemResource = (0, _I18n2.default)('erpShipmentItemModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const orderItemsResource = (0, _I18n2.default)('salesOrderItemModel');
+  const opportunityResource = (0, _I18n2.default)('opportunityModel');
+  const quoteResource = (0, _I18n2.default)('quoteModel');
+  const billtoResource = (0, _I18n2.default)('erpBillToModel');
+  const shiptoResource = (0, _I18n2.default)('erpShipToModel');
+  const syncresultResource = (0, _I18n2.default)('syncResultModel');
+  const invoiceitemResource = (0, _I18n2.default)('erpInvoiceItemModel');
+  const shipmentitemResource = (0, _I18n2.default)('erpShipmentItemModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrder.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrder.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'salesOrders',
     entityName: 'SalesOrder',
@@ -66,7 +66,7 @@ define('crm/Integrations/BOE/Models/SalesOrder/Base', ['module', 'exports', 'doj
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayNamePlural,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/SalesOrder/Offline.js
+++ b/src-out/Integrations/BOE/Models/SalesOrder/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/SalesOrder/Offline', ['module', 'exports', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrder.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrder.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'salesorder_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/SalesOrder/SData.js
+++ b/src-out/Integrations/BOE/Models/SalesOrder/SData.js
@@ -25,45 +25,22 @@ define('crm/Integrations/BOE/Models/SalesOrder/SData', ['module', 'exports', 'do
     };
   }
 
-  var _slicedToArray = function () {
-    function sliceIterator(arr, i) {
-      var _arr = [];
-      var _n = true;
-      var _d = false;
-      var _e = undefined;
+  /* Copyright 2017 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
 
-      try {
-        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-          _arr.push(_s.value);
-
-          if (i && _arr.length === i) break;
-        }
-      } catch (err) {
-        _d = true;
-        _e = err;
-      } finally {
-        try {
-          if (!_n && _i["return"]) _i["return"]();
-        } finally {
-          if (_d) throw _e;
-        }
-      }
-
-      return _arr;
-    }
-
-    return function (arr, i) {
-      if (Array.isArray(arr)) {
-        return arr;
-      } else if (Symbol.iterator in Object(arr)) {
-        return sliceIterator(arr, i);
-      } else {
-        throw new TypeError("Invalid attempt to destructure non-iterable instance");
-      }
-    };
-  }();
-
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrder.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrder.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'salesorder_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -86,23 +63,22 @@ define('crm/Integrations/BOE/Models/SalesOrder/SData', ['module', 'exports', 'do
       }];
     },
     isClosed: function isClosed($key, options) {
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('isClosed');
-      var entry = {
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('isClosed');
+      const entry = {
         $name: 'isClosed',
         request: {
           entity: {
-            $key: $key
+            $key
           }
         }
       };
-      return new Promise(function (resolve, reject) {
+      return new Promise((resolve, reject) => {
         request.execute(entry, {
-          success: function success(data) {
-            var Result = data.response.Result;
-
+          success: data => {
+            const { response: { Result } } = data;
             resolve(Result);
           },
-          failure: function failure(response, o) {
+          failure: (response, o) => {
             _ErrorManager2.default.addError(response, o, options, 'failure');
             reject(response);
           }
@@ -110,13 +86,9 @@ define('crm/Integrations/BOE/Models/SalesOrder/SData', ['module', 'exports', 'do
       });
     },
     getEntry: function getEntry(key, options) {
-      var results$ = this.inherited(getEntry, arguments);
-      var closed$ = this.isClosed(key, options);
-      return Promise.all([results$, closed$]).then(function (_ref) {
-        var _ref2 = _slicedToArray(_ref, 2),
-            entry = _ref2[0],
-            closed = _ref2[1];
-
+      const results$ = this.inherited(getEntry, arguments);
+      const closed$ = this.isClosed(key, options);
+      return Promise.all([results$, closed$]).then(([entry, closed]) => {
         entry.IsClosed = closed;
         return entry;
       });

--- a/src-out/Integrations/BOE/Models/SalesOrderItem/Base.js
+++ b/src-out/Integrations/BOE/Models/SalesOrderItem/Base.js
@@ -19,24 +19,24 @@ define('crm/Integrations/BOE/Models/SalesOrderItem/Base', ['module', 'exports', 
     };
   }
 
-  var resource = (0, _I18n2.default)('salesOrderItemModel'); /* Copyright 2017 Infor
-                                                              *
-                                                              * Licensed under the Apache License, Version 2.0 (the "License");
-                                                              * you may not use this file except in compliance with the License.
-                                                              * You may obtain a copy of the License at
-                                                              *
-                                                              *    http://www.apache.org/licenses/LICENSE-2.0
-                                                              *
-                                                              * Unless required by applicable law or agreed to in writing, software
-                                                              * distributed under the License is distributed on an "AS IS" BASIS,
-                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                              * See the License for the specific language governing permissions and
-                                                              * limitations under the License.
-                                                              */
+  const resource = (0, _I18n2.default)('salesOrderItemModel'); /* Copyright 2017 Infor
+                                                                *
+                                                                * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                * you may not use this file except in compliance with the License.
+                                                                * You may obtain a copy of the License at
+                                                                *
+                                                                *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                *
+                                                                * Unless required by applicable law or agreed to in writing, software
+                                                                * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                * See the License for the specific language governing permissions and
+                                                                * limitations under the License.
+                                                                */
 
-  var salesorderResource = (0, _I18n2.default)('salesOrderModel');
+  const salesorderResource = (0, _I18n2.default)('salesOrderModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrderItem.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrderItem.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'salesOrderItems',
     entityName: 'SalesOrderItem',
@@ -48,7 +48,7 @@ define('crm/Integrations/BOE/Models/SalesOrderItem/Base', ['module', 'exports', 
     listViewId: 'salessorder_items_list',
     editViewId: 'salesorder_item_edit',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'SalesOrder',
         displayName: salesorderResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Integrations/BOE/Models/SalesOrderItem/Offline.js
+++ b/src-out/Integrations/BOE/Models/SalesOrderItem/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/SalesOrderItem/Offline', ['module', 'exports
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrderItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrderItem.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'salesorderitem_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/SalesOrderItem/SData.js
+++ b/src-out/Integrations/BOE/Models/SalesOrderItem/SData.js
@@ -40,7 +40,7 @@ define('crm/Integrations/BOE/Models/SalesOrderItem/SData', ['module', 'exports',
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrderItem.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SalesOrderItem.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'salesorderitem_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -58,17 +58,15 @@ define('crm/Integrations/BOE/Models/SalesOrderItem/SData', ['module', 'exports',
       }];
     },
     updateItemWithWarehouse: function updateItemWithWarehouse(orderItem, warehouse) {
-      var _this = this;
-
-      var promise = new Promise(function (resolve) {
-        _PricingAvailabilityService2.default.updateOrderItemWarehouse(orderItem, warehouse.SlxLocation, warehouse.SlxLocationID, warehouse.ATPDate).then(function () {
+      const promise = new Promise(resolve => {
+        _PricingAvailabilityService2.default.updateOrderItemWarehouse(orderItem, warehouse.SlxLocation, warehouse.SlxLocationID, warehouse.ATPDate).then(() => {
           orderItem.SlxLocation = {
             $key: warehouse.SlxLocationID,
             description: warehouse.SlxLocation
           };
-          _PricingAvailabilityService2.default.getOrderItemPricing(orderItem).then(function (pricingData) {
-            var entry = _this.createPricingEntryForUpdate(orderItem, pricingData);
-            _this.updateEntry(entry, { overwrite: true }).then(function (result) {
+          _PricingAvailabilityService2.default.getOrderItemPricing(orderItem).then(pricingData => {
+            const entry = this.createPricingEntryForUpdate(orderItem, pricingData);
+            this.updateEntry(entry, { overwrite: true }).then(result => {
               resolve(result);
             });
           });
@@ -77,7 +75,7 @@ define('crm/Integrations/BOE/Models/SalesOrderItem/SData', ['module', 'exports',
       return promise;
     },
     createPricingEntryForUpdate: function createPricingEntryForUpdate(orderItem, pricingData) {
-      var entry = {};
+      const entry = {};
       entry.$key = orderItem.$key;
       if (pricingData) {
         if (pricingData.DocCalculatedPrice) {

--- a/src-out/Integrations/BOE/Models/SyncResult/Base.js
+++ b/src-out/Integrations/BOE/Models/SyncResult/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/SyncResult/Base', ['module', 'exports', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('syncResultModel'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('syncResultModel'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SyncResult.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SyncResult.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'syncResults',
     entityName: 'SyncResult',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/SyncResult/Base', ['module', 'exports', 'doj
     listViewId: 'syncresult_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/SyncResult/Offline.js
+++ b/src-out/Integrations/BOE/Models/SyncResult/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/SyncResult/Offline', ['module', 'exports', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SyncResult.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SyncResult.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'syncresult_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/SyncResult/SData.js
+++ b/src-out/Integrations/BOE/Models/SyncResult/SData.js
@@ -23,7 +23,7 @@ define('crm/Integrations/BOE/Models/SyncResult/SData', ['module', 'exports', 'do
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SyncResult.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.SyncResult.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'syncresult_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Integrations/BOE/Models/UnitOfMeasure/Base.js
+++ b/src-out/Integrations/BOE/Models/UnitOfMeasure/Base.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Models/UnitOfMeasure/Base', ['module', 'exports', '
     };
   }
 
-  var resource = (0, _I18n2.default)('unitOfMeasureModel'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('unitOfMeasureModel'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.UnitOfMeasure.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.UnitOfMeasure.Base', [_ModelBase3.default], {
     contractName: 'dynamic',
     resourceKind: 'unitsOfMeasure',
     entityName: 'UnitOfMeasure',
@@ -46,7 +46,7 @@ define('crm/Integrations/BOE/Models/UnitOfMeasure/Base', ['module', 'exports', '
     listViewId: 'unitofmeasure_list',
     editViewId: '',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Integrations/BOE/Models/UnitOfMeasure/Offline.js
+++ b/src-out/Integrations/BOE/Models/UnitOfMeasure/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/BOE/Models/UnitOfMeasure/Offline', ['module', 'exports'
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.UnitOfMeasure.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.UnitOfMeasure.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'unitofmeasure_offline_model'
   });
 

--- a/src-out/Integrations/BOE/Models/UnitOfMeasure/SData.js
+++ b/src-out/Integrations/BOE/Models/UnitOfMeasure/SData.js
@@ -27,7 +27,7 @@ define('crm/Integrations/BOE/Models/UnitOfMeasure/SData', ['module', 'exports', 
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Models.UnitOfMeasure.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Models.UnitOfMeasure.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'unitofmeasure_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -41,24 +41,24 @@ define('crm/Integrations/BOE/Models/UnitOfMeasure/SData', ['module', 'exports', 
       }];
     },
     getUnitOfMeasureFromCode: function getUnitOfMeasureFromCode(uomCode, productId) {
-      var queryResults = void 0;
-      var def = new _Deferred2.default();
-      var queryOptions = {
-        where: 'Product.Id eq "' + productId + '"'
+      let queryResults;
+      const def = new _Deferred2.default();
+      const queryOptions = {
+        where: `Product.Id eq "${productId}"`
       };
       if (uomCode && productId) {
         queryResults = this.getEntries(null, queryOptions);
-        (0, _when2.default)(queryResults, function (entries) {
-          var uof = null;
+        (0, _when2.default)(queryResults, entries => {
+          let uof = null;
           if (entries) {
-            entries.forEach(function (item) {
+            entries.forEach(item => {
               if (item.Name === uomCode) {
                 uof = item;
               }
             });
           }
           def.resolve(uof);
-        }, function (err) {
+        }, err => {
           def.reject(err);
         });
       } else {

--- a/src-out/Integrations/BOE/Modules/AccountAssociationModule.js
+++ b/src-out/Integrations/BOE/Modules/AccountAssociationModule.js
@@ -15,7 +15,7 @@ define('crm/Integrations/BOE/Modules/AccountAssociationModule', ['module', 'expo
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.AccountAssociationModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.AccountAssociationModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/AccountModule.js
+++ b/src-out/Integrations/BOE/Modules/AccountModule.js
@@ -64,9 +64,9 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('accountModule');
+  const resource = (0, _I18n2.default)('accountModule');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.AccountModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.AccountModule', [_Module3.default], {
     // Localization
     erpStatusText: resource.erpStatusText,
     erpCustomerText: resource.erpCustomerText,
@@ -118,7 +118,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
       App.picklistService.registerPicklistToView('ErpAccountStatus', 'account_detail');
     },
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _List6.default({
         id: 'account_erpinvoice_related',
@@ -340,16 +340,16 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
-      var Busy = _BusyIndicator2.default;
+      const am = this.applicationModule;
+      const Busy = _BusyIndicator2.default;
 
       // Row names to match in the detail and more detail sections.
       // These are the last item in the section.
-      var detailRowMatch = 'AccountManager.UserInfo';
-      var moreDetailRowMatch = 'Owner.OwnerDescription';
+      const detailRowMatch = 'AccountManager.UserInfo';
+      const moreDetailRowMatch = 'Owner.OwnerDescription';
 
       am.registerCustomization('models/list/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -357,7 +357,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpExtId'
       });
       am.registerCustomization('models/list/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -365,7 +365,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpAccountingEntityId'
       });
       am.registerCustomization('models/list/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -375,13 +375,13 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
 
       _lang2.default.extend(crm.Views.Account.List, {
         formatSearchQuery: function formatSearchQuery(searchQuery) {
-          var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-          return 'AccountNameUpper like "' + q + '%" or upper(ErpExtId) like "' + q + '%"';
+          const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+          return `AccountNameUpper like "${q}%" or upper(ErpExtId) like "${q}%"`;
         }
       });
 
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -389,7 +389,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpExtId'
       });
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -397,7 +397,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpStatus'
       });
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -405,7 +405,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpStatusDate'
       });
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -413,7 +413,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpPaymentTerm'
       });
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -421,7 +421,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'SyncStatus'
       });
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -429,7 +429,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpAccountingEntityId'
       });
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -437,7 +437,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpLogicalId'
       });
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -445,7 +445,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'PromotedToAccounting'
       });
       am.registerCustomization('models/detail/querySelect', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -453,7 +453,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         value: 'ErpBillToAccounts/*'
       });
       am.registerCustomization('models/picklists', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -464,7 +464,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         }
       });
       am.registerCustomization('models/picklists', 'account_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -476,7 +476,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
       });
 
       am.registerCustomization('models/relationships', 'account_offline_model', {
-        at: function at(relationship) {
+        at: relationship => {
           return relationship.name === 'Tickets';
         },
         type: 'insert',
@@ -512,7 +512,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         }]
       });
       am.registerCustomization('models/relationships', 'account_sdata_model', {
-        at: function at(relationship) {
+        at: relationship => {
           return relationship.name === 'Tickets';
         },
         type: 'insert',
@@ -560,19 +560,19 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
           this.orginalProcessEntry(entry);
         },
         selectedTab: function selectedTab(params) {
-          var key = params.key;
+          const key = params.key;
           if (!this.dashboardLoaded && key === 'DashboardSection') {
             this._loadDashboards();
             this.dashboardLoaded = true;
           }
         },
         _loadDashboards: function _loadDashboards() {
-          var layout = this._createCustomizedLayout(this.createLayout());
-          for (var key in layout) {
+          const layout = this._createCustomizedLayout(this.createLayout());
+          for (const key in layout) {
             if (layout.hasOwnProperty(key)) {
-              var item = layout[key];
+              const item = layout[key];
               if (item.name === 'DashboardSection') {
-                for (var i in item.children) {
+                for (const i in item.children) {
                   if (item.children[i]) {
                     this._loadDashboard(item.children[i]);
                   }
@@ -582,11 +582,11 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
           }
         },
         _loadDashboard: function _loadDashboard(dashboardLayout) {
-          var rvm = this.getRelatedViewManager(dashboardLayout.relatedView);
+          const rvm = this.getRelatedViewManager(dashboardLayout.relatedView);
           if (rvm) {
-            for (var key in rvm.relatedViews) {
+            for (const key in rvm.relatedViews) {
               if (rvm.relatedViews.hasOwnProperty(key)) {
-                var dashboard = rvm.relatedViews[key];
+                const dashboard = rvm.relatedViews[key];
                 if (dashboard) {
                   dashboard.onToggleView(true);
                 }
@@ -595,61 +595,57 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
           }
         },
         _canPromote: function _canPromote() {
-          var _this = this;
-
-          var promise = new Promise(function (resolve) {
-            _this.showBusy();
-            var entry = {
+          const promise = new Promise(resolve => {
+            this.showBusy();
+            const entry = {
               $name: 'CanPromoteAccount',
               request: {
-                accountId: _this.entry.$key
+                accountId: this.entry.$key
               }
             };
-            var request = new Sage.SData.Client.SDataServiceOperationRequest(_this.getService()).setResourceKind('accounts').setContractName('dynamic').setOperationName('CanPromoteAccount');
+            const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind('accounts').setContractName('dynamic').setOperationName('CanPromoteAccount');
 
-            var canPromote = {
+            const canPromote = {
               value: false,
               result: ''
             };
 
             request.execute(entry, {
               async: false,
-              success: function success(result) {
+              success: result => {
                 canPromote.value = result.response.Result;
                 resolve(canPromote);
               },
-              failure: function failure(err) {
-                var response = JSON.parse(err.response)[0];
+              failure: err => {
+                const response = JSON.parse(err.response)[0];
                 canPromote.result = response.message;
                 resolve(canPromote);
               },
-              scope: _this
+              scope: this
             });
           });
           return promise;
         },
         _onPromoteAccountClick: function _onPromoteAccountClick() {
-          var _this2 = this;
-
-          var canPromotePromise = this._canPromote();
-          canPromotePromise.then(function (val) {
-            _this2.hideBusy();
+          const canPromotePromise = this._canPromote();
+          canPromotePromise.then(val => {
+            this.hideBusy();
             if (!val.value) {
               App.modal.createSimpleDialog({
                 title: 'alert',
                 content: val.result,
-                getContent: function getContent() {
+                getContent: () => {
                   return;
                 }
               });
               return;
             }
-            var promote = new _Promote2.default();
-            promote.promoteToBackOffice(_this2.entry, 'Account', _this2);
+            const promote = new _Promote2.default();
+            promote.promoteToBackOffice(this.entry, 'Account', this);
           });
         },
         _onAddQuoteClick: function _onAddQuoteClick() {
-          var view = App.getView('quote_edit');
+          const view = App.getView('quote_edit');
           view.show({
             fromContext: this,
             detailView: 'quote_detail',
@@ -657,7 +653,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
           });
         },
         _onAddOrderClick: function _onAddOrderClick() {
-          var view = App.getView('salesorder_edit');
+          const view = App.getView('salesorder_edit');
           view.show({
             fromContext: this,
             detailView: 'salesorder_detail',
@@ -673,7 +669,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         },
         showBusy: function showBusy() {
           if (!this._busyIndicator || this._busyIndicator._destroyed) {
-            this._busyIndicator = new Busy({ id: this.id + '-busyIndicator' });
+            this._busyIndicator = new Busy({ id: `${this.id}-busyIndicator` });
           }
           this._busyIndicator.start();
           App.modal.disableClose = true;
@@ -682,11 +678,11 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         }
       });
 
-      var originalProcessData = crm.Views.Account.Edit.prototype.processData;
-      var originalInit = crm.Views.Account.Edit.prototype.init;
-      var originalProcessEntry = crm.Views.Account.Edit.prototype.processEntry;
-      var originalOnRefreshInsert = crm.Views.Account.Edit.prototype.onRefreshInsert;
-      var icboeUtility = _Utility2.default;
+      const originalProcessData = crm.Views.Account.Edit.prototype.processData;
+      const originalInit = crm.Views.Account.Edit.prototype.init;
+      const originalProcessEntry = crm.Views.Account.Edit.prototype.processEntry;
+      const originalOnRefreshInsert = crm.Views.Account.Edit.prototype.onRefreshInsert;
+      const icboeUtility = _Utility2.default;
       _lang2.default.extend(crm.Views.Account.Edit, {
         _busyIndicator: null,
         init: function init() {
@@ -717,23 +713,21 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
           this.getEntriesFromIds();
         },
         getEntriesFromIds: function getEntriesFromIds() {
-          var _this3 = this;
-
-          var mappedLookups = ['BackOffice', 'BackOfficeAccountingEntity'];
-          var mappedProperties = ['LogicalId', 'AcctEntityExtId'];
-          var fields = ['ErpLogicalId', 'ErpAccountingEntityId'];
-          icboeUtility.setFieldsFromIds(mappedLookups, mappedProperties, fields, this).then(function () {
-            _this3.hideBusy();
+          const mappedLookups = ['BackOffice', 'BackOfficeAccountingEntity'];
+          const mappedProperties = ['LogicalId', 'AcctEntityExtId'];
+          const fields = ['ErpLogicalId', 'ErpAccountingEntityId'];
+          icboeUtility.setFieldsFromIds(mappedLookups, mappedProperties, fields, this).then(() => {
+            this.hideBusy();
           });
         },
         onBackOfficeChange: function onBackOfficeChange(value, field) {
           this.fields.BackOffice.setValue(field.currentSelection);
           this.fields.ErpLogicalId.setValue(field.currentSelection.LogicalId);
-          var accountingField = this.fields.BackOfficeAccountingEntity;
-          accountingField.where = 'BackOffice.Id eq "' + field.currentSelection.$key + '"';
-          var accountingIsToBackOffice = accountingField.currentSelection && accountingField.currentSelection.BackOffice.$key === field.currentSelection.$key;
+          const accountingField = this.fields.BackOfficeAccountingEntity;
+          accountingField.where = `BackOffice.Id eq "${field.currentSelection.$key}"`;
+          const accountingIsToBackOffice = accountingField.currentSelection && accountingField.currentSelection.BackOffice.$key === field.currentSelection.$key;
           if (field.currentSelection.BackOfficeAccountingEntities.$resources && !accountingIsToBackOffice) {
-            var entry = field.currentSelection.BackOfficeAccountingEntities.$resources[0];
+            const entry = field.currentSelection.BackOfficeAccountingEntities.$resources[0];
             if (entry) {
               accountingField.setSelection(entry);
               this.onBackOfficeAccountingEntityChange(accountingField.getValue(), accountingField);
@@ -757,7 +751,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
         },
         showBusy: function showBusy() {
           if (!this._busyIndicator || this._busyIndicator._destroyed) {
-            this._busyIndicator = new Busy({ id: this.id + '-busyIndicator' });
+            this._busyIndicator = new Busy({ id: `${this.id}-busyIndicator` });
           }
           this._busyIndicator.start();
           App.modal.disableClose = true;
@@ -770,7 +764,7 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
        * Edit View
        */
       am.registerCustomization('edit', 'account_edit', {
-        at: function at(row) {
+        at: row => {
           return row.name === 'BusinessDescription';
         },
         type: 'insert',
@@ -912,77 +906,77 @@ define('crm/Integrations/BOE/Modules/AccountModule', ['module', 'exports', 'dojo
             name: 'Quotes',
             label: this.quotesText,
             where: function where(entry) {
-              return 'Account.Id eq "' + entry.$key + '"';
+              return `Account.Id eq "${entry.$key}"`;
             },
             view: 'account_quotes_related'
           }, {
             name: 'SalesOrders',
             label: this.ordersText,
             where: function where(entry) {
-              return 'Account.Id eq "' + entry.$key + '"';
+              return `Account.Id eq "${entry.$key}"`;
             },
             view: 'account_salesorders_related'
           }, {
             name: 'Shipments',
             label: this.erpShipmentsText,
             where: function where(entry) {
-              return 'Account.Id eq "' + entry.$key + '"';
+              return `Account.Id eq "${entry.$key}"`;
             },
             view: 'account_erpshipments_related'
           }, {
             name: 'ERPInvoicesRelated',
             label: this.erpInvoicesText,
             where: function where(entry) {
-              return 'Account.Id eq "' + entry.$key + '"';
+              return `Account.Id eq "${entry.$key}"`;
             },
             view: 'account_erpinvoice_related'
           }, {
             name: 'ERPReceivablesRelated',
             label: this.erpReceivablesText,
             where: function where(entry) {
-              return 'Account.Id eq "' + entry.$key + '"';
+              return `Account.Id eq "${entry.$key}"`;
             },
             view: 'account_erpreceivables_related'
           }, {
             name: 'ERPReturnsRelated',
             label: this.erpReturnsText,
             where: function where(entry) {
-              return 'Account.Id eq "' + entry.$key + '"';
+              return `Account.Id eq "${entry.$key}"`;
             },
             view: 'account_returns_related'
           }, {
             name: 'BillTo',
             label: this.erpBillToText,
             where: function where(entry) {
-              return 'ErpBillToAccounts.Account.Id eq "' + entry.$key + '"';
+              return `ErpBillToAccounts.Account.Id eq "${entry.$key}"`;
             },
             view: 'account_billto_related'
           }, {
             name: 'ShipTo',
             label: this.erpShipToText,
             where: function where(entry) {
-              return 'ErpShipToAccounts.Account.Id eq "' + entry.$key + '"';
+              return `ErpShipToAccounts.Account.Id eq "${entry.$key}"`;
             },
             view: 'account_shipto_related'
           }, {
             name: 'ContactAssociations',
             label: this.erpContactAssociationText,
             where: function where(entry) {
-              return 'Account.Id eq "' + entry.$key + '"';
+              return `Account.Id eq "${entry.$key}"`;
             },
             view: 'account_contactassociations_related'
           }, {
             name: 'SalesPersons',
             label: this.erpSalesPersonText,
             where: function where(entry) {
-              return 'Account.Id eq "' + entry.$key + '"';
+              return `Account.Id eq "${entry.$key}"`;
             },
             view: 'account_salesperson_related'
           }, {
             name: 'SyncHistory',
             label: this.syncHistoryText,
-            where: function where(entry) {
-              return 'EntityType eq "Account" and EntityId eq "' + entry.$key + '"';
+            where: entry => {
+              return `EntityType eq "Account" and EntityId eq "${entry.$key}"`;
             },
             view: 'account_syncresults_related'
           }]

--- a/src-out/Integrations/BOE/Modules/BillToAccountModule.js
+++ b/src-out/Integrations/BOE/Modules/BillToAccountModule.js
@@ -35,10 +35,10 @@ define('crm/Integrations/BOE/Modules/BillToAccountModule', ['module', 'exports',
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.BillToAccountModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.BillToAccountModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _Detail2.default());
       am.registerView(new _Edit2.default());

--- a/src-out/Integrations/BOE/Modules/BillToModule.js
+++ b/src-out/Integrations/BOE/Modules/BillToModule.js
@@ -52,12 +52,12 @@ define('crm/Integrations/BOE/Modules/BillToModule', ['module', 'exports', 'dojo/
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.BillToModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.BillToModule', [_Module3.default], {
     init: function init() {
       App.picklistService.registerPicklistToView('SyncStatus', 'erpbillto_detail');
     },
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerView(new _List4.default());
       am.registerView(new _Detail2.default());
       am.registerView(new _Edit2.default());
@@ -123,7 +123,7 @@ define('crm/Integrations/BOE/Modules/BillToModule', ['module', 'exports', 'dojo/
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerCustomization('detail/tools', 'erpbillto_detail', {
         at: function at(tool) {
           return tool.id === 'edit';
@@ -131,25 +131,25 @@ define('crm/Integrations/BOE/Modules/BillToModule', ['module', 'exports', 'dojo/
         type: 'remove'
       });
       am.registerCustomization('list/tools', 'billto_accounts_related', {
-        at: function at(tool) {
+        at: tool => {
           return tool.id === 'new';
         },
         type: 'remove'
       });
       am.registerCustomization('list/tools', 'billto_receivables_related', {
-        at: function at(tool) {
+        at: tool => {
           return tool.id === 'new';
         },
         type: 'remove'
       });
       am.registerCustomization('list/tools', 'billto_invoices_related', {
-        at: function at(tool) {
+        at: tool => {
           return tool.id === 'new';
         },
         type: 'remove'
       });
       am.registerCustomization('list/tools', 'billto_returns_related', {
-        at: function at(tool) {
+        at: tool => {
           return tool.id === 'new';
         },
         type: 'remove'

--- a/src-out/Integrations/BOE/Modules/ContactAssociationModule.js
+++ b/src-out/Integrations/BOE/Modules/ContactAssociationModule.js
@@ -15,7 +15,7 @@ define('crm/Integrations/BOE/Modules/ContactAssociationModule', ['module', 'expo
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ContactAssociationModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ContactAssociationModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/ContactModule.js
+++ b/src-out/Integrations/BOE/Modules/ContactModule.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('contactModule');
+  const resource = (0, _I18n2.default)('contactModule');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ContactModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ContactModule', [_Module3.default], {
     // Localization
     erpStatusText: resource.erpStatusText,
     erpContactIdText: resource.erpContactIdText,
@@ -56,7 +56,7 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
 
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _List2.default({
         id: 'contact_account_related',
@@ -93,14 +93,14 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       // Row names to match in the detail and more detail sections.
       // These are the last item in the section.
-      var detailRowMatch = 'AccountManager.UserInfo';
+      const detailRowMatch = 'AccountManager.UserInfo';
 
       am.registerCustomization('models/detail/querySelect', 'contact_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -108,7 +108,7 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
         value: 'ErpStatus'
       });
       am.registerCustomization('models/detail/querySelect', 'contact_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -117,7 +117,7 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
       });
 
       am.registerCustomization('models/relationships', 'contact_offline_model', {
-        at: function at(relationship) {
+        at: relationship => {
           return relationship.name === 'Tickets';
         },
         type: 'insert',
@@ -154,7 +154,7 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
       });
 
       am.registerCustomization('models/relationships', 'contact_sdata_model', {
-        at: function at(relationship) {
+        at: relationship => {
           return relationship.name === 'Tickets';
         },
         type: 'insert',
@@ -191,7 +191,7 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
       });
       _lang2.default.extend(crm.Views.Contact.Detail, {
         _onAddQuoteClick: function _onAddQuoteClick() {
-          var view = App.getView('quote_edit');
+          const view = App.getView('quote_edit');
           view.show({
             detailView: 'quote_detail',
             fromContext: this,
@@ -199,7 +199,7 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
           });
         },
         _onAddOrderClick: function _onAddOrderClick() {
-          var view = App.getView('salesorder_edit');
+          const view = App.getView('salesorder_edit');
           view.show({
             detailView: 'salesorder_detail',
             fromContext: this,
@@ -270,28 +270,28 @@ define('crm/Integrations/BOE/Modules/ContactModule', ['module', 'exports', 'dojo
             name: 'AccountAssociations',
             label: this.erpAccountAssociationsText,
             where: function where(entry) {
-              return 'Contact.Id eq "' + entry.$key + '"';
+              return `Contact.Id eq "${entry.$key}"`;
             },
             view: 'contact_account_related'
           }, {
             name: 'Quotes',
             label: this.quotesText,
             where: function where(entry) {
-              return 'RequestedBy.Id eq "' + entry.$key + '"';
+              return `RequestedBy.Id eq "${entry.$key}"`;
             },
             view: 'contact_quotes_related'
           }, {
             name: 'SalesOrders',
             label: this.ordersText,
             where: function where(entry) {
-              return 'RequestedBy.Id eq "' + entry.$key + '"';
+              return `RequestedBy.Id eq "${entry.$key}"`;
             },
             view: 'contact_salesorders_related'
           }, {
             name: 'SyncHistory',
             label: this.syncHistoryText,
-            where: function where(entry) {
-              return 'EntityType eq "Contact" and EntityId eq "' + entry.$key + '"';
+            where: entry => {
+              return `EntityType eq "Contact" and EntityId eq "${entry.$key}"`;
             },
             view: 'contact_syncresults_related'
           }]

--- a/src-out/Integrations/BOE/Modules/HelpModule.js
+++ b/src-out/Integrations/BOE/Modules/HelpModule.js
@@ -32,17 +32,17 @@ define('crm/Integrations/BOE/Modules/HelpModule', ['module', 'exports', 'dojo/_b
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('helpModule');
+  const resource = (0, _I18n2.default)('helpModule');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.HelpModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.HelpModule', [_Module3.default], {
     sectionTitleText: resource.sectionTitleText,
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
-      var onHelpRowCreated = crm.Views.Help.prototype.onHelpRowCreated;
+      const am = this.applicationModule;
+      const onHelpRowCreated = crm.Views.Help.prototype.onHelpRowCreated;
       am.registerCustomization('detail', 'help', {
-        at: function at(row) {
+        at: row => {
           return row.name === 'HelpSection';
         },
         type: 'insert',

--- a/src-out/Integrations/BOE/Modules/InvoiceLineModule.js
+++ b/src-out/Integrations/BOE/Modules/InvoiceLineModule.js
@@ -15,7 +15,7 @@ define('crm/Integrations/BOE/Modules/InvoiceLineModule', ['module', 'exports', '
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.InvoiceLineModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.InvoiceLineModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/InvoiceModule.js
+++ b/src-out/Integrations/BOE/Modules/InvoiceModule.js
@@ -40,13 +40,13 @@ define('crm/Integrations/BOE/Modules/InvoiceModule', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.InvoiceModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.InvoiceModule', [_Module3.default], {
     defaultViews: ['invoice_list'],
     init: function init() {
       App.picklistService.registerPicklistToView('ErpInvoiceStatus');
     },
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerView(new _List2.default());
       am.registerView(new _Detail2.default());
       am.registerView(new _Detail4.default());
@@ -63,7 +63,7 @@ define('crm/Integrations/BOE/Modules/InvoiceModule', ['module', 'exports', 'dojo
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerCustomization('detail/tools', 'invoice_detail', {
         at: function at(tool) {
           return tool.id === 'edit';

--- a/src-out/Integrations/BOE/Modules/OpportunityModule.js
+++ b/src-out/Integrations/BOE/Modules/OpportunityModule.js
@@ -23,22 +23,22 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
     };
   }
 
-  var resource = (0, _I18n2.default)('opportunityModule'); /* Copyright 2017 Infor
-                                                            *
-                                                            * Licensed under the Apache License, Version 2.0 (the "License");
-                                                            * you may not use this file except in compliance with the License.
-                                                            * You may obtain a copy of the License at
-                                                            *
-                                                            *    http://www.apache.org/licenses/LICENSE-2.0
-                                                            *
-                                                            * Unless required by applicable law or agreed to in writing, software
-                                                            * distributed under the License is distributed on an "AS IS" BASIS,
-                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                            * See the License for the specific language governing permissions and
-                                                            * limitations under the License.
-                                                            */
+  const resource = (0, _I18n2.default)('opportunityModule'); /* Copyright 2017 Infor
+                                                              *
+                                                              * Licensed under the Apache License, Version 2.0 (the "License");
+                                                              * you may not use this file except in compliance with the License.
+                                                              * You may obtain a copy of the License at
+                                                              *
+                                                              *    http://www.apache.org/licenses/LICENSE-2.0
+                                                              *
+                                                              * Unless required by applicable law or agreed to in writing, software
+                                                              * distributed under the License is distributed on an "AS IS" BASIS,
+                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                              * See the License for the specific language governing permissions and
+                                                              * limitations under the License.
+                                                              */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.OpportunityModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.OpportunityModule', [_Module3.default], {
     addQuoteText: resource.addQuoteText,
     addOrderText: resource.addOrderText,
     relatedERPItemsText: resource.relatedERPItemsText,
@@ -49,7 +49,7 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
 
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _List2.default({
         id: 'opportunity_quotes_related',
@@ -68,10 +68,10 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerCustomization('models/detail/querySelect', 'opportunity_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -80,7 +80,7 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
       });
 
       am.registerCustomization('models/edit/querySelect', 'opportunity_sdata_model', {
-        at: function at() {
+        at: () => {
           return true;
         },
         type: 'insert',
@@ -90,10 +90,10 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
 
       _lang2.default.extend(crm.Views.Opportunity.Detail, {
         _onAddQuoteClick: function _onAddQuoteClick() {
-          var request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService());
+          const request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService());
           request.setResourceKind('Opportunities');
           request.setOperationName('CreateQuoteFromOpportunity');
-          var entry = {
+          const entry = {
             $name: 'CreateQuoteFromOpportunity',
             request: {
               entity: {
@@ -102,14 +102,14 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
             }
           };
           request.execute(entry, {
-            success: function success(data) {
-              var view = App.getView('quote_detail');
+            success: data => {
+              const view = App.getView('quote_detail');
               view.show({
                 key: data.response.Result
               });
             },
-            failure: function failure(xhr) {
-              var response = JSON.parse(xhr.responseText);
+            failure: xhr => {
+              const response = JSON.parse(xhr.responseText);
               if (response && response.length && response[0].message) {
                 alert(response[0].message); // eslint-disable-line
               }
@@ -117,11 +117,11 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
           });
         },
         _onAddOrderClick: function _onAddOrderClick() {
-          var request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService());
+          const request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService());
           request.setResourceKind('Opportunities');
           request.setOperationName('CreateSalesOrderFromOpportunity');
 
-          var entry = {
+          const entry = {
             $name: 'CreateSalesOrderFromOpportunity',
             request: {
               entity: {
@@ -130,14 +130,14 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
             }
           };
           request.execute(entry, {
-            success: function success(data) {
-              var view = App.getView('salesorder_detail');
+            success: data => {
+              const view = App.getView('salesorder_detail');
               view.show({
                 key: data.response.Result
               });
             },
-            failure: function failure(xhr) {
-              var response = JSON.parse(xhr.responseText);
+            failure: xhr => {
+              const response = JSON.parse(xhr.responseText);
               if (response && response.length && response[0].message) {
                 alert(response[0].message); // eslint-disable-line
               }
@@ -149,14 +149,12 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
           return result;
         },
         opportunityRePrice: function opportunityRePrice() {
-          var _this = this;
-
           if (!this.entry) {
             return;
           }
 
-          _PricingAvailabilityService2.default.opportunityRePrice(this.entry).then(function (result) {
-            _this.handlePricingSuccess(result);
+          _PricingAvailabilityService2.default.opportunityRePrice(this.entry).then(result => {
+            this.handlePricingSuccess(result);
           });
         }
       });
@@ -200,8 +198,8 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
           iconClass: 'finance',
           action: 'opportunityRePrice',
           security: 'Entities/Opportunity/Add',
-          disabled: function disabled() {
-            var boeSettings = App.context.integrationSettings['Back Office Extension'];
+          disabled: () => {
+            const boeSettings = App.context.integrationSettings['Back Office Extension'];
 
             if (boeSettings === null || typeof boeSettings === 'undefined') {
               return true;
@@ -230,14 +228,14 @@ define('crm/Integrations/BOE/Modules/OpportunityModule', ['module', 'exports', '
             name: 'Quotes',
             label: this.quotesText,
             where: function where(entry) {
-              return 'Opportunity.Id eq "' + entry.$key + '"';
+              return `Opportunity.Id eq "${entry.$key}"`;
             },
             view: 'opportunity_quotes_related'
           }, {
             name: 'SalesOrders',
             label: this.ordersText,
             where: function where(entry) {
-              return 'Opportunity.Id eq "' + entry.$key + '"';
+              return `Opportunity.Id eq "${entry.$key}"`;
             },
             view: 'opportunity_salesorders_related'
           }]

--- a/src-out/Integrations/BOE/Modules/PayFromModule.js
+++ b/src-out/Integrations/BOE/Modules/PayFromModule.js
@@ -15,7 +15,7 @@ define('crm/Integrations/BOE/Modules/PayFromModule', ['module', 'exports', 'dojo
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.PayFromModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.PayFromModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/ProductModule.js
+++ b/src-out/Integrations/BOE/Modules/ProductModule.js
@@ -15,7 +15,7 @@ define('crm/Integrations/BOE/Modules/ProductModule', ['module', 'exports', 'dojo
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ProductModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ProductModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/QuoteLineModule.js
+++ b/src-out/Integrations/BOE/Modules/QuoteLineModule.js
@@ -40,10 +40,10 @@ define('crm/Integrations/BOE/Modules/QuoteLineModule', ['module', 'exports', 'do
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.QuoteLineModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.QuoteLineModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _List4.default({
         expose: false,

--- a/src-out/Integrations/BOE/Modules/QuoteModule.js
+++ b/src-out/Integrations/BOE/Modules/QuoteModule.js
@@ -43,14 +43,14 @@ define('crm/Integrations/BOE/Modules/QuoteModule', ['module', 'exports', 'dojo/_
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.QuoteModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.QuoteModule', [_Module3.default], {
     defaultViews: ['quote_list'],
     init: function init() {
       App.picklistService.registerPicklistToView('SyncStatus', 'quote_detail');
       App.picklistService.registerPicklistToView('ErpQuoteStatus', 'quote_detail');
     },
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _Detail4.default());
       am.registerView(new _Edit2.default());
@@ -78,37 +78,35 @@ define('crm/Integrations/BOE/Modules/QuoteModule', ['module', 'exports', 'dojo/_
         hasSettings: false,
         expose: false,
         addLineItems: function addLineItems() {
-          var _this = this;
-
           if (!this.options.selectedEntry.ErpLogicalId) {
             App.modal.createSimpleDialog({
               title: 'alert',
               content: this.accountingEntityRequiredText,
-              getContent: function getContent() {
+              getContent: () => {
                 return;
               }
-            }).then(function () {
-              var quoteEdit = App.getView('quote_edit');
+            }).then(() => {
+              const quoteEdit = App.getView('quote_edit');
               if (quoteEdit) {
-                var options = {
-                  entry: _this.options.selectedEntry,
-                  fromContext: _this.options.fromContext
+                const options = {
+                  entry: this.options.selectedEntry,
+                  fromContext: this.options.fromContext
                 };
                 quoteEdit.show(options);
               }
             });
             return;
           }
-          var view = App.getView('quote_line_edit');
+          const view = App.getView('quote_line_edit');
           if (view) {
-            var quoteItemView = App.getView('quote_lines_related');
-            var count = 0;
+            const quoteItemView = App.getView('quote_lines_related');
+            let count = 0;
             if (quoteItemView) {
-              quoteItemView.getListCount({ where: 'Quote.$key eq "' + this.options.selectedEntry.$key + '"' }).then(function (result) {
+              quoteItemView.getListCount({ where: `Quote.$key eq "${this.options.selectedEntry.$key}"` }).then(result => {
                 count = result;
               });
             }
-            var options = {
+            const options = {
               insert: true,
               context: {
                 Quote: this.options.selectedEntry,
@@ -177,7 +175,7 @@ define('crm/Integrations/BOE/Modules/QuoteModule', ['module', 'exports', 'dojo/_
       am.registerView(new _List18.default());
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerCustomization('list/tools', 'quotepersons_related', {
         at: function at(tool) {
           return tool.id === 'new';

--- a/src-out/Integrations/BOE/Modules/QuotePersonModule.js
+++ b/src-out/Integrations/BOE/Modules/QuotePersonModule.js
@@ -30,7 +30,7 @@ define('crm/Integrations/BOE/Modules/QuotePersonModule', ['module', 'exports', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.QuotePersonModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.QuotePersonModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/ReceivableLineModule.js
+++ b/src-out/Integrations/BOE/Modules/ReceivableLineModule.js
@@ -32,10 +32,10 @@ define('crm/Integrations/BOE/Modules/ReceivableLineModule', ['module', 'exports'
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ReceivableLineModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ReceivableLineModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerView(new _Detail2.default());
     },
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/ReceivableModule.js
+++ b/src-out/Integrations/BOE/Modules/ReceivableModule.js
@@ -36,11 +36,11 @@ define('crm/Integrations/BOE/Modules/ReceivableModule', ['module', 'exports', 'd
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ReceivableModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ReceivableModule', [_Module3.default], {
     defaultViews: ['erpreceivables_list'],
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _Detail2.default());
       am.registerView(new _List2.default({
@@ -53,7 +53,7 @@ define('crm/Integrations/BOE/Modules/ReceivableModule', ['module', 'exports', 'd
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerCustomization('detail/tools', 'erpreceivables_detail', {
         at: function at(tool) {

--- a/src-out/Integrations/BOE/Modules/ReturnLineModule.js
+++ b/src-out/Integrations/BOE/Modules/ReturnLineModule.js
@@ -15,7 +15,7 @@ define('crm/Integrations/BOE/Modules/ReturnLineModule', ['module', 'exports', 'd
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ReturnLineModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ReturnLineModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/ReturnModule.js
+++ b/src-out/Integrations/BOE/Modules/ReturnModule.js
@@ -15,7 +15,7 @@ define('crm/Integrations/BOE/Modules/ReturnModule', ['module', 'exports', 'dojo/
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ReturnModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ReturnModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {},
     loadCustomizations: function loadCustomizations() {},

--- a/src-out/Integrations/BOE/Modules/SalesOrderItemModule.js
+++ b/src-out/Integrations/BOE/Modules/SalesOrderItemModule.js
@@ -27,10 +27,10 @@ define('crm/Integrations/BOE/Modules/SalesOrderItemModule', ['module', 'exports'
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.SalesOrderItemModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.SalesOrderItemModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerView(new _Detail2.default());
       am.registerView(new _List2.default({
         expose: false,

--- a/src-out/Integrations/BOE/Modules/SalesOrderModule.js
+++ b/src-out/Integrations/BOE/Modules/SalesOrderModule.js
@@ -47,14 +47,14 @@ define('crm/Integrations/BOE/Modules/SalesOrderModule', ['module', 'exports', 'd
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.SalesOrderModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.SalesOrderModule', [_Module3.default], {
     defaultViews: ['salesorder_list'],
     init: function init() {
       App.picklistService.registerPicklistToView('SyncStatus', 'salesorder_detail');
       App.picklistService.registerPicklistToView('ErpSalesOrderStatus', 'salesorder_detail');
     },
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerView(new _List18.default({
         expose: true
       }));
@@ -66,30 +66,28 @@ define('crm/Integrations/BOE/Modules/SalesOrderModule', ['module', 'exports', 'd
         hasSettings: false,
         expose: false,
         addLineItems: function addLineItems() {
-          var _this = this;
-
           if (!this.options.selectedEntry.ErpLogicalId) {
             App.modal.createSimpleDialog({
               title: 'alert',
               content: this.accountingEntityRequiredText,
-              getContent: function getContent() {
+              getContent: () => {
                 return;
               }
-            }).then(function () {
-              var orderEdit = App.getView('salesorder_edit');
+            }).then(() => {
+              const orderEdit = App.getView('salesorder_edit');
               if (orderEdit) {
-                var options = {
-                  entry: _this.options.selectedEntry,
-                  fromContext: _this.options.fromContext
+                const options = {
+                  entry: this.options.selectedEntry,
+                  fromContext: this.options.fromContext
                 };
                 orderEdit.show(options);
               }
             });
             return;
           }
-          var view = App.getView('salesorder_item_edit');
+          const view = App.getView('salesorder_item_edit');
           if (view) {
-            var options = {
+            const options = {
               insert: true,
               context: {
                 SalesOrder: this.options.selectedEntry
@@ -192,7 +190,7 @@ define('crm/Integrations/BOE/Modules/SalesOrderModule', ['module', 'exports', 'd
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerCustomization('list/tools', 'salesorder_invoice_items_related', {
         at: function at(tool) {
           return tool.id === 'new';

--- a/src-out/Integrations/BOE/Modules/ShipToAccountModule.js
+++ b/src-out/Integrations/BOE/Modules/ShipToAccountModule.js
@@ -43,10 +43,10 @@ define('crm/Integrations/BOE/Modules/ShipToAccountModule', ['module', 'exports',
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ShipToAccountModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ShipToAccountModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _Detail2.default());
       am.registerView(new _Edit2.default());
@@ -178,7 +178,7 @@ define('crm/Integrations/BOE/Modules/ShipToAccountModule', ['module', 'exports',
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerCustomization('detail/tools', 'erpshiptoaccount_detail', {
         at: function at(tool) {
           return tool.id === 'edit';

--- a/src-out/Integrations/BOE/Modules/ShipToModule.js
+++ b/src-out/Integrations/BOE/Modules/ShipToModule.js
@@ -52,12 +52,12 @@ define('crm/Integrations/BOE/Modules/ShipToModule', ['module', 'exports', 'dojo/
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ShipToModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ShipToModule', [_Module3.default], {
     init: function init() {
       App.picklistService.registerPicklistToView('SyncStatus', 'erpshipto_detail');
     },
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerView(new _List16.default());
       am.registerView(new _Detail2.default());
       am.registerView(new _Edit2.default());
@@ -123,7 +123,7 @@ define('crm/Integrations/BOE/Modules/ShipToModule', ['module', 'exports', 'dojo/
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerCustomization('detail/tools', 'erpshipto_detail', {
         at: function at(tool) {
           return tool.id === 'edit';
@@ -131,25 +131,25 @@ define('crm/Integrations/BOE/Modules/ShipToModule', ['module', 'exports', 'dojo/
         type: 'remove'
       });
       am.registerCustomization('list/tools', 'shipto_accounts_related', {
-        at: function at(tool) {
+        at: tool => {
           return tool.id === 'new';
         },
         type: 'remove'
       });
       am.registerCustomization('list/tools', 'shipto_receivables_related', {
-        at: function at(tool) {
+        at: tool => {
           return tool.id === 'new';
         },
         type: 'remove'
       });
       am.registerCustomization('list/tools', 'shipto_invoices_related', {
-        at: function at(tool) {
+        at: tool => {
           return tool.id === 'new';
         },
         type: 'remove'
       });
       am.registerCustomization('list/tools', 'shipto_returns_related', {
-        at: function at(tool) {
+        at: tool => {
           return tool.id === 'new';
         },
         type: 'remove'

--- a/src-out/Integrations/BOE/Modules/ShipmentLineModule.js
+++ b/src-out/Integrations/BOE/Modules/ShipmentLineModule.js
@@ -32,14 +32,14 @@ define('crm/Integrations/BOE/Modules/ShipmentLineModule', ['module', 'exports', 
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ShipmentLineModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ShipmentLineModule', [_Module3.default], {
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerView(new _Detail2.default());
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerCustomization('detail/tools', 'erpshipment_items_detail', {
         at: function at(tool) {
           return tool.id === 'edit';

--- a/src-out/Integrations/BOE/Modules/ShipmentModule.js
+++ b/src-out/Integrations/BOE/Modules/ShipmentModule.js
@@ -36,11 +36,11 @@ define('crm/Integrations/BOE/Modules/ShipmentModule', ['module', 'exports', 'doj
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ShipmentModule', [_Module3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules.ShipmentModule', [_Module3.default], {
     defaultViews: ['erpshipments_list'],
     init: function init() {},
     loadViews: function loadViews() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
 
       am.registerView(new _Detail2.default());
       am.registerView(new _List2.default());
@@ -52,7 +52,7 @@ define('crm/Integrations/BOE/Modules/ShipmentModule', ['module', 'exports', 'doj
       }));
     },
     loadCustomizations: function loadCustomizations() {
-      var am = this.applicationModule;
+      const am = this.applicationModule;
       am.registerCustomization('list/tools', 'erpshipments_list', {
         at: function at(tool) {
           return tool.id === 'new';

--- a/src-out/Integrations/BOE/Modules/_Module.js
+++ b/src-out/Integrations/BOE/Modules/_Module.js
@@ -28,7 +28,7 @@ define('crm/Integrations/BOE/Modules/_Module', ['module', 'exports', 'dojo/_base
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Modules._Module', null, {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Modules._Module', null, {
     applicationModule: null,
     defaultViews: null,
     constructor: function constructor(applicationModule) {
@@ -41,8 +41,8 @@ define('crm/Integrations/BOE/Modules/_Module', ['module', 'exports', 'dojo/_base
     loadToolbars: function loadToolbars() {},
     registerDefaultViews: function registerDefaultViews(views) {
       if (this.defaultViews && views) {
-        this.defaultViews.forEach(function (defaultView) {
-          var idx = views.indexOf(defaultView);
+        this.defaultViews.forEach(defaultView => {
+          const idx = views.indexOf(defaultView);
           if (idx === -1) {
             views.push(defaultView);
           }

--- a/src-out/Integrations/BOE/PicklistService.js
+++ b/src-out/Integrations/BOE/PicklistService.js
@@ -15,7 +15,7 @@ define('crm/Integrations/BOE/PicklistService', ['module', 'exports', 'dojo/_base
     };
   }
 
-  var __class = _lang2.default.setObject('crm.Integrations.BOE.PicklistService', {
+  const __class = _lang2.default.setObject('crm.Integrations.BOE.PicklistService', {
     _picklists: {},
     _viewMapping: {},
     _store: null,
@@ -29,8 +29,8 @@ define('crm/Integrations/BOE/PicklistService', ['module', 'exports', 'dojo/_base
       return this._picklists[key];
     },
     getPicklistByName: function getPicklistByName(name) {
-      var iterableKeys = Object.keys(this._picklists);
-      for (var i = 0; i < iterableKeys.length; i++) {
+      const iterableKeys = Object.keys(this._picklists);
+      for (let i = 0; i < iterableKeys.length; i++) {
         if (this._picklists[iterableKeys[i]].name === name) {
           return this._picklists[iterableKeys[i]];
         }
@@ -38,10 +38,10 @@ define('crm/Integrations/BOE/PicklistService', ['module', 'exports', 'dojo/_base
       return false;
     },
     getPicklistItemByCode: function getPicklistItemByCode(picklistName, itemCode) {
-      var picklist = this.getPicklistByName(picklistName);
+      const picklist = this.getPicklistByName(picklistName);
 
       if (picklist) {
-        for (var i = 0; i < picklist.items.length; i++) {
+        for (let i = 0; i < picklist.items.length; i++) {
           if (picklist.items[i].code === itemCode) {
             return picklist.items[i];
           }
@@ -50,17 +50,17 @@ define('crm/Integrations/BOE/PicklistService', ['module', 'exports', 'dojo/_base
       return false;
     },
     getPicklistItemTextByCode: function getPicklistItemByCode(picklistName, itemCode) {
-      var picklistItem = this.getPicklistItemByCode(picklistName, itemCode);
+      const picklistItem = this.getPicklistItemByCode(picklistName, itemCode);
       if (itemCode && picklistItem) {
         return picklistItem.text;
       }
       return null;
     },
     getViewPicklists: function getViewPicklists(viewId) {
-      var picklistIds = this._viewMapping[viewId];
-      var picklists = [];
+      const picklistIds = this._viewMapping[viewId];
+      const picklists = [];
       if (picklistIds && picklistIds.length) {
-        for (var i = 0; i < picklistIds.length; i++) {
+        for (let i = 0; i < picklistIds.length; i++) {
           if (this._picklists[picklistIds[i]]) {
             picklists.push(this._picklists[picklistIds[i]]);
           } else {
@@ -89,39 +89,35 @@ define('crm/Integrations/BOE/PicklistService', ['module', 'exports', 'dojo/_base
     },
     // Will request the registered picklists in this._picklists
     requestPicklists: function requestPicklists() {
-      var _this = this;
-
-      var promise = new Promise(function (resolve, reject) {
-        var iterableKeys = Object.keys(_this._picklists);
-        var promises = [];
-        for (var i = 0; i < iterableKeys.length; i++) {
-          promises.push(_this.requestPicklist(iterableKeys[i]));
+      const promise = new Promise((resolve, reject) => {
+        const iterableKeys = Object.keys(this._picklists);
+        const promises = [];
+        for (let i = 0; i < iterableKeys.length; i++) {
+          promises.push(this.requestPicklist(iterableKeys[i]));
         }
-        Promise.all(promises).then(function () {
+        Promise.all(promises).then(() => {
           resolve(true);
-        }, function (response) {
+        }, response => {
           reject(response);
         });
       });
       return promise;
     },
     requestPicklist: function requestPicklist(name, options) {
-      var _this2 = this;
-
-      var promise = new Promise(function (resolve, reject) {
-        var store = _this2.getStore();
-        var queryOptions = {
-          where: 'name eq \'' + name + '\''
+      const promise = new Promise((resolve, reject) => {
+        const store = this.getStore();
+        const queryOptions = {
+          where: `name eq '${name}'`
         };
-        store.query(null, queryOptions).then(function (data) {
-          var picklist = null;
+        store.query(null, queryOptions).then(data => {
+          let picklist = null;
           if (data && data[0] && data[0].items) {
             picklist = data[0];
             picklist.items = picklist.items.$resources;
-            _this2._picklists[picklist.name] = picklist;
+            this._picklists[picklist.name] = picklist;
           }
           resolve(picklist);
-        }, function (response, o) {
+        }, (response, o) => {
           _ErrorManager2.default.addError(response, o, options, 'failure');
           reject(response);
         });
@@ -130,13 +126,13 @@ define('crm/Integrations/BOE/PicklistService', ['module', 'exports', 'dojo/_base
     },
     getStore: function getStore() {
       if (!this._store) {
-        var options = this.getStoreOptions();
+        const options = this.getStoreOptions();
         this._store = new _SData2.default(options);
       }
       return this._store;
     },
     getStoreOptions: function getStoreOptions() {
-      var options = {
+      const options = {
         service: App.getService(false),
         contractName: this.contractName,
         resourceKind: this.resourceKind,

--- a/src-out/Integrations/BOE/PricingAvailabilityService.js
+++ b/src-out/Integrations/BOE/PricingAvailabilityService.js
@@ -15,22 +15,22 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
     };
   }
 
-  var resource = (0, _I18n2.default)('pricingAvailabilityService'); /* Copyright 2017 Infor
-                                                                     *
-                                                                     * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                     * you may not use this file except in compliance with the License.
-                                                                     * You may obtain a copy of the License at
-                                                                     *
-                                                                     *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                     *
-                                                                     * Unless required by applicable law or agreed to in writing, software
-                                                                     * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                     * See the License for the specific language governing permissions and
-                                                                     * limitations under the License.
-                                                                     */
+  const resource = (0, _I18n2.default)('pricingAvailabilityService'); /* Copyright 2017 Infor
+                                                                       *
+                                                                       * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                       * you may not use this file except in compliance with the License.
+                                                                       * You may obtain a copy of the License at
+                                                                       *
+                                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                       *
+                                                                       * Unless required by applicable law or agreed to in writing, software
+                                                                       * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                       * See the License for the specific language governing permissions and
+                                                                       * limitations under the License.
+                                                                       */
 
-  var __class = _lang2.default.setObject('crm.Integrations.BOE.PricingAvailabilityService', {
+  const __class = _lang2.default.setObject('crm.Integrations.BOE.PricingAvailabilityService', {
 
     busyText: resource.busyText,
     checkOrderItemAvailText: resource.checkOrderItemAvailText,
@@ -40,7 +40,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
 
     _busyIndicator: null,
     createAlertDialog: function createAlertDialog(response) {
-      return App.modal.createSimpleDialog({ title: 'alert', content: response, getContent: function getContent() {
+      return App.modal.createSimpleDialog({ title: 'alert', content: response, getContent: () => {
           return;
         }, leftButton: 'cancel', rightButton: 'confirm' });
     },
@@ -63,22 +63,20 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       App.modal.add(this._busyIndicator);
     },
     validateQuoteTotal: function validateQuoteTotal(quote) {
-      var _this = this;
+      const promise = new Promise((resolve, reject) => {
+        const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind('quotes').setOperationName('validateOrderTotal');
 
-      var promise = new Promise(function (resolve, reject) {
-        var request = new Sage.SData.Client.SDataServiceOperationRequest(_this.getService()).setResourceKind('quotes').setOperationName('validateOrderTotal');
-
-        var entry = {
+        const entry = {
           $name: 'ValidateOrderTotal',
           request: {
             QuoteId: quote.$key
           }
         };
         request.execute(entry, {
-          success: function success() {
+          success: () => {
             resolve(true);
           },
-          failure: function failure(result) {
+          failure: result => {
             reject(result); // eslint-disable-line
           }
         });
@@ -86,22 +84,20 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return promise;
     },
     validateOrderTotal: function validateOrderTotal(order) {
-      var _this2 = this;
+      const promise = new Promise((resolve, reject) => {
+        const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind('salesOrders').setOperationName('validateOrderTotal');
 
-      var promise = new Promise(function (resolve, reject) {
-        var request = new Sage.SData.Client.SDataServiceOperationRequest(_this2.getService()).setResourceKind('salesOrders').setOperationName('validateOrderTotal');
-
-        var entry = {
+        const entry = {
           $name: 'ValidateOrderTotal',
           request: {
             SalesOrderId: order.$key
           }
         };
         request.execute(entry, {
-          success: function success() {
+          success: () => {
             resolve(true);
           },
-          failure: function failure(result) {
+          failure: result => {
             reject(result); // eslint-disable-line
           }
         });
@@ -110,9 +106,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
     },
 
     getOrderPricing: function getOrderPricing(order) {
-      var _this3 = this;
-
-      var options = {
+      const options = {
         resourceKind: 'salesOrders',
         operationName: 'requestPricingAvailability',
         requestOptions: {
@@ -123,21 +117,21 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
         },
         transform: this.transformPricing
       };
-      var promise = new Promise(function (resolve, reject) {
-        return _this3.validateOrderTotal(order).then(function () {
-          _this3.executeRequest(options).then(function (pricingData) {
+      const promise = new Promise((resolve, reject) => {
+        return this.validateOrderTotal(order).then(() => {
+          this.executeRequest(options).then(pricingData => {
             resolve(pricingData);
-          }, function (error) {
+          }, error => {
             reject(error);
           });
-        }, function (error) {
+        }, error => {
           reject(error);
         });
       });
       return promise;
     },
     getOrderItemAvailability: function getOrderItemAvailability(orderItem, order, product, quantity) {
-      var options = {
+      const options = {
         resourceKind: 'salesOrders',
         operationName: 'requestPricingAvailability',
         description: this.checkOrderItemAvailText,
@@ -154,7 +148,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return this.executeRequest(options);
     },
     getOrderItemPricing: function getOrderItemPricing(orderItem, order, product, quantity, slxLocation, unitOfMeasure) {
-      var options = {
+      const options = {
         resourceKind: 'salesOrders',
         operationName: 'requestPricingAvailability',
         description: this.checkOrderItemPriceText,
@@ -174,7 +168,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return this.executeRequest(options);
     },
     updateOrderItemWarehouse: function updateOrderItemWarehouse(orderItem, SlxLocation, SlxLoacationId, ATPDate, quantity) {
-      var options = {
+      const options = {
         operationName: 'UpdateLineItemWithWarehouse',
         resourceKind: 'salesOrders',
         requestOptions: {
@@ -182,16 +176,14 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
           entityId: orderItem.$key,
           SlxLocationExtID: SlxLocation,
           SlxLocationID: SlxLoacationId,
-          ATPDate: ATPDate,
+          ATPDate,
           AvailableQuantity: quantity || 1
         }
       };
       return this.executeRequest(options);
     },
     getQuotePricing: function getQuotePricing(quote) {
-      var _this4 = this;
-
-      var options = {
+      const options = {
         resourceKind: 'quotes',
         operationName: 'requestPricingAvailability',
         requestOptions: {
@@ -202,21 +194,21 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
         },
         transform: this.transformPricing
       };
-      var promise = new Promise(function (resolve, reject) {
-        return _this4.validateQuoteTotal(quote).then(function () {
-          _this4.executeRequest(options).then(function (pricingData) {
+      const promise = new Promise((resolve, reject) => {
+        return this.validateQuoteTotal(quote).then(() => {
+          this.executeRequest(options).then(pricingData => {
             resolve(pricingData);
-          }, function (error) {
+          }, error => {
             reject(error);
           });
-        }, function (error) {
+        }, error => {
           reject(error);
         });
       });
       return promise;
     },
     getQuoteItemPricing: function getQuoteItemPricing(quoteItem, quote, product, quantity, slxLocation, unitOfMeasure) {
-      var options = {
+      const options = {
         resourceKind: 'quotes',
         operationName: 'requestPricingAvailability',
         description: this.checkQuoteItemPriceText,
@@ -236,7 +228,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return this.executeRequest(options);
     },
     getQuoteItemAvailability: function getQuoteItemAvailability(quoteItem, quote, product, quantity, unitOfMeasure) {
-      var options = {
+      const options = {
         resourceKind: 'quotes',
         operationName: 'requestPricingAvailability',
         description: this.checkQuoteItemAvailText,
@@ -254,7 +246,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return this.executeRequest(options);
     },
     updateQuoteItemWarehouse: function updateQuoteItemWarehouse(quoteItem, SlxLocation, SlxLoacationId, ATPDate, quantity) {
-      var options = {
+      const options = {
         operationName: 'UpdateLineItemWithWarehouse',
         resourceKind: 'quotes',
         requestOptions: {
@@ -262,14 +254,14 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
           entityId: quoteItem.$key,
           SlxLocationExtID: SlxLocation,
           SlxLocationID: SlxLoacationId,
-          ATPDate: ATPDate,
+          ATPDate,
           AvailableQuantity: quantity || quoteItem.Quantity || 1
         }
       };
       return this.executeRequest(options);
     },
     opportunityRePrice: function opportunityRePrice(opportunity) {
-      var options = {
+      const options = {
         operationName: 'RePriceOpportunity',
         resourceKind: 'opportunities',
         requestOptions: {
@@ -283,7 +275,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return this.executeRequest(options);
     },
     quoteRePrice: function quoteRePrice(quote) {
-      var options = {
+      const options = {
         operationName: 'RePriceQuote',
         resourceKind: 'quotes',
         requestOptions: {
@@ -298,7 +290,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return this.executeRequest(options);
     },
     salesOrderRePrice: function salesOrderRePrice(saleOrder) {
-      var options = {
+      const options = {
         operationName: 'RePriceOrder',
         resourceKind: 'salesorders',
         requestOptions: {
@@ -313,23 +305,23 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return this.executeRequest(options);
     },
     transformPricing: function transformPricing(results) {
-      var promise = new Promise(function (resolve, reject) {
-        var data = {};
+      const promise = new Promise((resolve, reject) => {
+        const data = {};
         if (results && results.Children && results.Children.length) {
           try {
-            var item = results.Children[0];
-            for (var prop in item.Properties) {
+            const item = results.Children[0];
+            for (const prop in item.Properties) {
               if (!prop) {
                 continue;
               }
-              var propName = prop;
+              let propName = prop;
               if (propName && propName.search('.') !== -1) {
                 propName = propName.split('.')[0];
               }
-              var dataItem = {};
+              const dataItem = {};
               dataItem.propertyName = propName;
-              var toDouble = Number.parseFloat(item.Properties[prop]);
-              var toDecimal = Number.parseInt(item.Properties[prop], 10);
+              const toDouble = Number.parseFloat(item.Properties[prop]);
+              const toDecimal = Number.parseInt(item.Properties[prop], 10);
               if (toDouble) {
                 dataItem.type = 'numeric';
                 dataItem.value = toDouble;
@@ -337,16 +329,16 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
                 dataItem.type = 'numeric';
                 dataItem.value = toDecimal;
               } else {
-                var value = item.Properties[prop];
+                let value = item.Properties[prop];
                 if (value.search('#') !== -1) {
-                  var values = value.split('#');
+                  const values = value.split('#');
                   value = values[1];
-                  data[dataItem.propertyName + 'Code'] = {
-                    propertyName: dataItem.propertyName + 'Code',
+                  data[`${dataItem.propertyName}Code`] = {
+                    propertyName: `${dataItem.propertyName}Code`,
                     type: 'text',
                     value: values[0]
                   };
-                  dataItem.propertyName = dataItem.propertyName + 'Id';
+                  dataItem.propertyName = `${dataItem.propertyName}Id`;
                 }
                 dataItem.type = 'text';
                 dataItem.value = value;
@@ -363,20 +355,20 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return promise;
     },
     transformAvailability: function transformAvailability(result) {
-      var promise = new Promise(function (resolve, reject) {
+      const promise = new Promise((resolve, reject) => {
         try {
-          var warehouses = [];
+          const warehouses = [];
           if (result) {
-            for (var i = 0; i < result.Children.length; i++) {
-              var product = result.Children[i];
-              var entity = {};
-              for (var key in product.Properties) {
+            for (let i = 0; i < result.Children.length; i++) {
+              const product = result.Children[i];
+              const entity = {};
+              for (const key in product.Properties) {
                 if (key !== 'ProductCode') {
                   if (key.indexOf('.') > 0 && key.indexOf('ErpExtId') > 0) {
-                    var propName = key.split('.');
-                    var extId = product.Properties[key].split('#');
+                    const propName = key.split('.');
+                    const extId = product.Properties[key].split('#');
                     entity[propName[0]] = extId[0];
-                    entity[propName[0] + 'ID'] = extId[1];
+                    entity[`${propName[0]}ID`] = extId[1];
                   } else {
                     entity[key] = product.Properties[key];
                   }
@@ -394,11 +386,9 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return promise;
     },
     executeRequest: function executeRequest(options, executeOptions) {
-      var _this5 = this;
-
-      var promise = new Promise(function (resolve, reject) {
-        _this5.showBusy(options.description);
-        var entry = {
+      const promise = new Promise((resolve, reject) => {
+        this.showBusy(options.description);
+        let entry = {
           $name: options.operationName,
           request: {
             options: JSON.stringify(options.requestOptions)
@@ -407,16 +397,16 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
         if (executeOptions) {
           entry = executeOptions;
         }
-        var request = _this5.getRequest(options);
+        const request = this.getRequest(options);
         request.execute(entry, {
-          success: function success(data) {
-            _this5.hideBusy();
-            var result = '';
+          success: data => {
+            this.hideBusy();
+            let result = '';
             try {
               result = data && data.response && data.response.Result ? JSON.parse(data.response.Result) : '';
               if (options.transform) {
-                var _resolve = resolve;
-                options.transform.call(_this5, result).then(function (tfdata) {
+                const _resolve = resolve;
+                options.transform.call(this, result).then(tfdata => {
                   _resolve(tfdata);
                 });
               } else {
@@ -424,15 +414,15 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
               }
             } catch (error) {
               reject(error);
-              _this5.hideBusy();
-              _this5.createAlertDialog(error);
+              this.hideBusy();
+              this.createAlertDialog(error);
               console.log(error); // eslint-disable-line
             }
           },
-          failure: function failure(error) {
-            _this5.hideBusy();
-            var response = JSON.parse(error.response)[0];
-            _this5.createAlertDialog(response.message);
+          failure: error => {
+            this.hideBusy();
+            const response = JSON.parse(error.response)[0];
+            this.createAlertDialog(response.message);
             reject(response);
           }
         });
@@ -440,7 +430,7 @@ define('crm/Integrations/BOE/PricingAvailabilityService', ['module', 'exports', 
       return promise;
     },
     getRequest: function getRequest(options) {
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind(options.resourceKind).setOperationName(options.operationName);
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind(options.resourceKind).setOperationName(options.operationName);
       return request;
     },
     getService: function getService() {

--- a/src-out/Integrations/BOE/Promote.js
+++ b/src-out/Integrations/BOE/Promote.js
@@ -48,9 +48,9 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('promote');
+  const resource = (0, _I18n2.default)('promote');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Promote', [_Widget3.default, _Templated3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Promote', [_Widget3.default, _Templated3.default], {
     widgetTemplate: new Simplate(['<div class="modal__content" data-dojo-attach-point="promoteNode">', '<div class="modal__header__title">{%: $.promoteTitle %}</div>', '<div class="modal__header__title">{%: $.searchResults %}</div>', '<p class="modal__content__text">{%: $.multiSystemDetected %}</p>', '<div class="modal__header__title">{%: $.createLink %}</div>', '<div class="promote__options">', '<div class="promote__row">', '<label class="promote__row__label">{%: $.backOffice %}</label>', '<div data-dojo-attach-point="backOfficeNode"></div>', '</div>', '<div class="promote__row">', '<label class="promote__row__label">{%: $.accountingEntity %}</label>', '<div data-dojo-attach-point="accountingNode"></div>', '</div>', '</div>', '</div>']),
 
     promoteTitle: resource.promoteTitle,
@@ -81,7 +81,7 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
     _operatingCompanyModel: null,
 
     initBackOfficeModel: function initBackOfficeModel() {
-      var model = this.getModel(_Names2.default.BACKOFFICE);
+      const model = this.getModel(_Names2.default.BACKOFFICE);
       if (model) {
         this._backOfficeModel = model;
         this._backOfficeModel.init();
@@ -89,14 +89,14 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
       }
     },
     getBackOfficeEntries: function getBackOfficeEntries() {
-      var query = this._backOfficeModel.getEntries(null, {
+      const query = this._backOfficeModel.getEntries(null, {
         returnQueryResults: true,
         queryModelName: 'list-active'
       });
       (0, _when2.default)(query, this.processBackOfficeEntries.bind(this), this._onQueryFailure.bind(this));
     },
     initAccountingEntitiesModel: function initAccountingEntitiesModel() {
-      var model = this.getModel(_Names2.default.BACKOFFICEACCOUNTINGENTITY);
+      const model = this.getModel(_Names2.default.BACKOFFICEACCOUNTINGENTITY);
       if (model) {
         this._accountingEntityModel = model;
         this._accountingEntityModel.init();
@@ -105,7 +105,7 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
     getAccountingEntitiesEntries: function getAccountingEntitiesEntries(backOfficeKey) {
       if (backOfficeKey) {
         if (this._backOfficeEntries.length) {
-          var query = this._accountingEntityModel.getEntries('BackOffice.$key eq "' + backOfficeKey + '"', {
+          const query = this._accountingEntityModel.getEntries(`BackOffice.$key eq "${backOfficeKey}"`, {
             returnQueryResults: true,
             queryModelName: 'list'
           });
@@ -119,7 +119,7 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
       App.modal.createSimpleDialog({ title: 'alert', content: this.noBackOfficesText });
     },
     initIntegrationMappingModel: function initIntegrationMappingModel() {
-      var model = this.getModel(_Names2.default.OPERATINGCOMPANY);
+      const model = this.getModel(_Names2.default.OPERATINGCOMPANY);
       if (model) {
         this._operatingCompanyModel = model;
         this._operatingCompanyModel.init();
@@ -129,77 +129,73 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
      * Returns a new instance of a model for the view.
      */
     getModel: function getModel(modelName) {
-      var model = _Adapter2.default.getModel(modelName);
+      const model = _Adapter2.default.getModel(modelName);
       return model;
     },
     _promote: function _promote(options, scope) {
-      var _this = this;
-
       if (options && scope) {
-        var entry = {
+        const entry = {
           $name: 'PromoteToBackOffice',
           request: options
         };
-        var request = new Sage.SData.Client.SDataServiceOperationRequest(scope.getService()).setResourceKind('backOffices').setContractName('dynamic').setOperationName('PromoteToBackOffice');
+        const request = new Sage.SData.Client.SDataServiceOperationRequest(scope.getService()).setResourceKind('backOffices').setContractName('dynamic').setOperationName('PromoteToBackOffice');
 
         request.execute(entry, {
-          success: function success() {
-            var toast = {
-              title: _this.promotionRequested,
-              message: _this.promotionText,
-              icon: _this.promoteIcon
+          success: () => {
+            const toast = {
+              title: this.promotionRequested,
+              message: this.promotionText,
+              icon: this.promoteIcon
             };
             App.toast.add(toast);
             scope._refreshClicked();
           },
-          failure: function failure(err) {
-            App.toast.add({ title: 'Error', message: _string2.default.substitute(_this.errorMessage, { reason: err.statusText }) });
+          failure: err => {
+            App.toast.add({ title: 'Error', message: _string2.default.substitute(this.errorMessage, { reason: err.statusText }) });
           },
           scope: this
         });
       }
     },
     promoteToBackOffice: function _promoteToBackOffice(entry, entityName, scope) {
-      var _this2 = this;
-
       if (!entry || !entityName || !scope) {
         return;
       }
-      var readyToPromote = this.checkEntryFor(entry, ['ErpLogicalId', 'ErpAccountingEntityId']);
+      const readyToPromote = this.checkEntryFor(entry, ['ErpLogicalId', 'ErpAccountingEntityId']);
       if (readyToPromote) {
         this._promote({
-          entityName: entityName,
+          entityName,
           entityId: entry.$key,
           logicalId: entry.ErpLogicalId,
           accountingEntityId: entry.ErpAccountingEntityId
         }, scope);
         return;
       }
-      this.getAccountingSystem().then(function (value) {
+      this.getAccountingSystem().then(value => {
         if (!value) {
           App.modal.showToolbar = true;
-          var toolbar = [{
+          const toolbar = [{
             action: 'cancel',
             className: 'button--flat button--flat--split',
-            text: _this2.cancelText
+            text: this.cancelText
           }, {
             action: 'resolve',
             className: 'button--flat button--flat--split',
-            text: _this2.promoteText
+            text: this.promoteText
           }];
 
-          App.modal.add(_this2, toolbar).then(function (data) {
-            _this2._promote({
-              entityName: entityName,
+          App.modal.add(this, toolbar).then(data => {
+            this._promote({
+              entityName,
               entityId: entry.$key,
               logicalId: data.ErpLogicalId,
               accountingEntityId: data.ErpAccountingEntityId
             }, scope);
           });
         } else {
-          var data = _this2.getContent();
-          _this2._promote({
-            entityName: entityName,
+          const data = this.getContent();
+          this._promote({
+            entityName,
             entityId: entry.$key,
             logicalId: data.ErpLogicalId,
             accountingEntityId: data.ErpAccountingEntityId
@@ -208,12 +204,10 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
       });
     },
     processBackOfficeEntries: function processBackOfficeEntries(entries) {
-      var _this3 = this;
-
       this._backOfficeEntries = entries;
       this._backOfficeSelections = [];
-      this._backOfficeEntries.forEach(function (entry) {
-        _this3._backOfficeSelections.push({
+      this._backOfficeEntries.forEach(entry => {
+        this._backOfficeSelections.push({
           value: entry.$key,
           text: entry.BackOfficeName
         });
@@ -225,12 +219,10 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
       }
     },
     processAccountingEntries: function processAccountingEntries(entries) {
-      var _this4 = this;
-
       this._accountingEntitiesEntries = entries;
       this._accountingSelections = [];
-      this._accountingEntitiesEntries.forEach(function (entry) {
-        _this4._accountingSelections.push({
+      this._accountingEntitiesEntries.forEach(entry => {
+        this._accountingSelections.push({
           value: entry.$key,
           text: entry.Name
         });
@@ -260,11 +252,9 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
       this.createAlertDialog(err);
       console.error(err); // eslint-disable-line
     },
-    checkEntryFor: function checkEntryFor(entry) {
-      var properties = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
-
-      var hasAllProperties = true;
-      properties.forEach(function (property) {
+    checkEntryFor: function checkEntryFor(entry, properties = []) {
+      let hasAllProperties = true;
+      properties.forEach(property => {
         if (!entry[property]) {
           hasAllProperties = false;
         }
@@ -279,7 +269,7 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
       App.modal.disableClose = false;
       App.modal.showToolbar = true;
       App.modal.resolveDeferred(true);
-      return App.modal.createSimpleDialog({ title: 'alert', content: err, getContent: function getContent() {
+      return App.modal.createSimpleDialog({ title: 'alert', content: err, getContent: () => {
           return;
         }, leftButton: 'cancel', rightButton: 'confirm' });
     },
@@ -303,8 +293,8 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
     },
     getAccountingSystem: function getAccountingSystem() {
       if (!this._busy) {
-        this._busy = new _BusyIndicator2.default({ id: this.id + '__busyIndicator' });
-        this._accountingBusy = new _BusyIndicator2.default({ id: this.id + '__busyIndicator__accounting', size: 'small', label: null, containerClass: 'busyField' });
+        this._busy = new _BusyIndicator2.default({ id: `${this.id}__busyIndicator` });
+        this._accountingBusy = new _BusyIndicator2.default({ id: `${this.id}__busyIndicator__accounting`, size: 'small', label: null, containerClass: 'busyField' });
         this._accountingBusy.start();
       }
       this._firstLoad = true;
@@ -319,14 +309,12 @@ define('crm/Integrations/BOE/Promote', ['module', 'exports', 'dojo/_base/declare
       return this._accountingDeferred.promise;
     },
     getContent: function getContent() {
-      var _this5 = this;
-
       return {
-        ErpLogicalId: this._backOfficeEntries.find(function (value) {
-          return value.$key === _this5._backOfficeDropdown.getValue();
+        ErpLogicalId: this._backOfficeEntries.find(value => {
+          return value.$key === this._backOfficeDropdown.getValue();
         }).LogicalId,
-        ErpAccountingEntityId: this._accountingEntitiesEntries.find(function (value) {
-          return value.$key === _this5._accountingDropdown.getValue();
+        ErpAccountingEntityId: this._accountingEntitiesEntries.find(value => {
+          return value.$key === this._accountingDropdown.getValue();
         }).AcctEntityExtId
       };
     },

--- a/src-out/Integrations/BOE/Utility.js
+++ b/src-out/Integrations/BOE/Utility.js
@@ -42,24 +42,24 @@ define('crm/Integrations/BOE/Utility', ['module', 'exports', 'dojo/_base/lang', 
   /**
    * @module crm/Integrations/BOE/Utility
    */
-  var __class = _lang2.default.setObject('crm.Integrations.BOE.Utility', /** @lends module:crm/Integrations/BOE/Utility */{
+  const __class = _lang2.default.setObject('crm.Integrations.BOE.Utility', /** @lends module:crm/Integrations/BOE/Utility */{
     // Lookup table for the aggregate functions used by DashboardWidget
     aggregateLookup: {
       calcProfit: function calcProfit(fn, widget, data) {
-        var revenue = data[0];
-        var cost = data[1];
+        const revenue = data[0];
+        const cost = data[1];
 
         return fn.call(widget, revenue, cost);
       },
       calcMargin: function calcMargin(fn, widget, data) {
-        var revenue = data[0];
-        var cost = data[1];
+        const revenue = data[0];
+        const cost = data[1];
 
         return fn.call(widget, revenue, cost);
       },
       calcYoYRevenue: function calcYoYRevenue(fn, widget, data) {
-        var pastYear = data[0];
-        var between = data[1];
+        const pastYear = data[0];
+        const between = data[1];
 
         return fn.call(widget, pastYear, between);
       },
@@ -82,35 +82,29 @@ define('crm/Integrations/BOE/Utility', ['module', 'exports', 'dojo/_base/lang', 
      * @return
      * Returns a promise that is resolved once all entries are returned
      */
-    setFieldsFromIds: function setFieldsFromIds() {
-      var mappedLookups = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-      var mappedProperties = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
-      var fields = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
-      var scope = arguments[3];
-      var entry = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
-
-      var promises = [];
-      fields.forEach(function (f, index) {
-        var temp = scope.options.entry ? scope.options.entry[f] : null;
-        var value = entry[f] || scope.entry[f] || temp;
+    setFieldsFromIds: function setFieldsFromIds(mappedLookups = [], mappedProperties = [], fields = [], scope, entry = {}) {
+      const promises = [];
+      fields.forEach((f, index) => {
+        const temp = scope.options.entry ? scope.options.entry[f] : null;
+        const value = entry[f] || scope.entry[f] || temp;
         if (!value) {
           return;
         }
-        var model = _Adapter2.default.getModel(_Names2.default[mappedLookups[index].toUpperCase()]);
+        const model = _Adapter2.default.getModel(_Names2.default[mappedLookups[index].toUpperCase()]);
         if (!model) {
           console.warn('Unable to locate model for ' + f); // eslint-disable-line
           return;
         }
         model.init();
-        var options = {
+        const options = {
           async: false,
           queryModelName: 'detail',
-          query: mappedProperties[index] + ' eq "' + value + '"'
+          query: `${mappedProperties[index]} eq "${value}"`
         };
-        var promise = model.getEntries(null, options);
+        const promise = model.getEntries(null, options);
         promises.push(promise);
-        promise.then(function (entries) {
-          var returned = entries[0];
+        promise.then(entries => {
+          const returned = entries[0];
           if (returned) {
             scope.fields[mappedLookups[index]].setSelection(returned);
             scope.fields[mappedLookups[index]].onChange(scope.fields[mappedLookups[index]].currentSelection, scope.fields[mappedLookups[index]]);
@@ -120,8 +114,8 @@ define('crm/Integrations/BOE/Utility', ['module', 'exports', 'dojo/_base/lang', 
       return Promise.all(promises);
     },
     formatMultiCurrency: function formatMultiCurrency(val, currencyCode) {
-      var result = null;
-      var tempVal = val || 0;
+      let result = null;
+      const tempVal = val || 0;
       if (App.hasMultiCurrency() && currencyCode) {
         result = _Format2.default.multiCurrency.call(null, tempVal, currencyCode);
       } else {
@@ -131,7 +125,7 @@ define('crm/Integrations/BOE/Utility', ['module', 'exports', 'dojo/_base/lang', 
     },
     getBaseCurrencyCode: function getBaseCurrencyCode() {
       if (App.context && App.context.systemOptions && App.context.systemOptions.BaseCurrency) {
-        var results = App.context.systemOptions.BaseCurrency;
+        const results = App.context.systemOptions.BaseCurrency;
         return results;
       }
 

--- a/src-out/Integrations/BOE/Views/Account/ActivityDashboardWidget.js
+++ b/src-out/Integrations/BOE/Views/Account/ActivityDashboardWidget.js
@@ -23,22 +23,22 @@ define('crm/Integrations/BOE/Views/Account/ActivityDashboardWidget', ['module', 
     };
   }
 
-  var resource = (0, _I18n2.default)('activityDashboardWidget'); /* Copyright 2017 Infor
-                                                                  *
-                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                  * you may not use this file except in compliance with the License.
-                                                                  * You may obtain a copy of the License at
-                                                                  *
-                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                  *
-                                                                  * Unless required by applicable law or agreed to in writing, software
-                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                  * See the License for the specific language governing permissions and
-                                                                  * limitations under the License.
-                                                                  */
+  const resource = (0, _I18n2.default)('activityDashboardWidget'); /* Copyright 2017 Infor
+                                                                    *
+                                                                    * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                    * you may not use this file except in compliance with the License.
+                                                                    * You may obtain a copy of the License at
+                                                                    *
+                                                                    *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                    *
+                                                                    * Unless required by applicable law or agreed to in writing, software
+                                                                    * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                    * See the License for the specific language governing permissions and
+                                                                    * limitations under the License.
+                                                                    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Account.ActivityDashboardWidget', [_DashboardWidget2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Account.ActivityDashboardWidget', [_DashboardWidget2.default], {
     // Localization
     recentText: resource.recentText,
     myPendingText: resource.myPendingText,
@@ -59,11 +59,11 @@ define('crm/Integrations/BOE/Views/Account/ActivityDashboardWidget', ['module', 
     resourceKind: 'accounts',
     querySelect: ['AccountName'],
     getWhere: function getWhere() {
-      return 'Id eq \'' + this.parentEntry.$key + '\'';
+      return `Id eq '${this.parentEntry.$key}'`;
     },
 
     createRangeLayout: function createRangeLayout() {
-      var rangeLayout = [{
+      const rangeLayout = [{
         value: 7
       }, {
         value: 14
@@ -75,12 +75,12 @@ define('crm/Integrations/BOE/Views/Account/ActivityDashboardWidget', ['module', 
       return rangeLayout;
     },
     createMetricLayout: function createMetricLayout(entry) {
-      var metricLayout = [{
+      const metricLayout = [{
         navTo: 'account_newquotes_related',
         formatter: 'bigNumber',
         title: this.recentText,
         queryArgs: {
-          _activeFilter: 'AccountId eq "' + entry.$key + '" and ' + this.pastDays('CreateDate'),
+          _activeFilter: `AccountId eq "${entry.$key}" and ${this.pastDays('CreateDate')}`,
           _filterName: 'ActivityType',
           _metricName: 'CountActivities'
         },
@@ -93,16 +93,16 @@ define('crm/Integrations/BOE/Views/Account/ActivityDashboardWidget', ['module', 
       return metricLayout;
     },
     pastDays: function pastDays(property) {
-      var now = moment();
+      const now = moment();
 
-      var pastWeekStart = now.clone().subtract(this.dayValue, 'days').startOf('day');
-      var today = now.clone().endOf('day');
+      const pastWeekStart = now.clone().subtract(this.dayValue, 'days').startOf('day');
+      const today = now.clone().endOf('day');
 
-      var queries = _string2.default.substitute('((' + property + ' between @${0}@ and @${1}@) or (' + property + ' between @${2}@ and @${3}@))', [_Convert2.default.toIsoStringFromDate(pastWeekStart.toDate()), _Convert2.default.toIsoStringFromDate(today.toDate()), pastWeekStart.format('YYYY-MM-DDT00:00:00[Z]'), today.format('YYYY-MM-DDT23:59:59[Z]')]);
+      const queries = _string2.default.substitute(`((${property} between @\${0}@ and @\${1}@) or (${property} between @\${2}@ and @\${3}@))`, [_Convert2.default.toIsoStringFromDate(pastWeekStart.toDate()), _Convert2.default.toIsoStringFromDate(today.toDate()), pastWeekStart.format('YYYY-MM-DDT00:00:00[Z]'), today.format('YYYY-MM-DDT23:59:59[Z]')]);
       return queries;
     }
   });
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('account_activity_dashboard_widget', __class);
   _lang2.default.setObject('icboe.Views.Account.ActivityDashboardWidget', __class);
   exports.default = __class;

--- a/src-out/Integrations/BOE/Views/Account/NewDashboardWidget.js
+++ b/src-out/Integrations/BOE/Views/Account/NewDashboardWidget.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/Account/NewDashboardWidget', ['module', 'expo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('newDashboardWidget');
+  const resource = (0, _I18n2.default)('newDashboardWidget');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Account.NewDashboardWidget', [_DashboardWidget2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Account.NewDashboardWidget', [_DashboardWidget2.default], {
     // Localization
     newQuotesText: resource.newQuotesText,
     newOrdersText: resource.newOrdersText,
@@ -129,11 +129,11 @@ define('crm/Integrations/BOE/Views/Account/NewDashboardWidget', ['module', 'expo
     querySelect: ['AccountName'],
     queryArgs: null,
     getWhere: function getWhere() {
-      return 'Id eq \'' + this.parentEntry.$key + '\'';
+      return `Id eq '${this.parentEntry.$key}'`;
     },
     // Creates the range widgets, timespan is based on three categories: d - day, m - month, y - year
     createRangeLayout: function createRangeLayout() {
-      var rangeLayout = [{
+      const rangeLayout = [{
         value: 7
       }, {
         value: 14
@@ -147,7 +147,7 @@ define('crm/Integrations/BOE/Views/Account/NewDashboardWidget', ['module', 'expo
     createMetricLayout: function createMetricLayout(entry) {
       this.setQueryArgs(entry);
 
-      var metricLayout = [{
+      const metricLayout = [{
         navTo: 'account_newquotes_related',
         formatter: 'bigNumber',
         formatterModule: _Format2.default,
@@ -190,23 +190,23 @@ define('crm/Integrations/BOE/Views/Account/NewDashboardWidget', ['module', 'expo
       this.queryArgs = [];
 
       this.queryArgs.push(['quotes', {
-        _activeFilter: 'Account.Id eq "' + entry.$key + '" and' + '(' + '((ErpExtId ne null) and ' + ('(ErpStatus ne "' + this.replacedCode + '") and ') + ('(ErpStatus ne "' + this.cancledCode + '") and ') + ('(ErpStatus ne "' + this.deletedCode + '") and ') + ('(' + this.pastDays('DocumentDate') + ')') + ')' + ' or ' + '((ErpExtId eq null) and ' + '(' + ('(Status ne "' + this.closedText + '") and ') + ('(Status ne "' + this.cancledText + '") and ') + ('(Status ne "' + this.replacedText + '") and ') + ('(Status ne "' + this.deletedText + '") and ') + ('(Status ne "' + this.unapprovedText + '") and ') + ('(' + this.pastDays('StartDate') + ')') + ')' + ')' + ')',
+        _activeFilter: `Account.Id eq "${entry.$key}" and` + '(' + '((ErpExtId ne null) and ' + `(ErpStatus ne "${this.replacedCode}") and ` + `(ErpStatus ne "${this.cancledCode}") and ` + `(ErpStatus ne "${this.deletedCode}") and ` + `(${this.pastDays('DocumentDate')})` + ')' + ' or ' + '((ErpExtId eq null) and ' + '(' + `(Status ne "${this.closedText}") and ` + `(Status ne "${this.cancledText}") and ` + `(Status ne "${this.replacedText}") and ` + `(Status ne "${this.deletedText}") and ` + `(Status ne "${this.unapprovedText}") and ` + `(${this.pastDays('StartDate')})` + ')' + ')' + ')',
         _filterName: 'AccountManager',
         _metricName: 'SumGrandTotal'
       }], ['salesOrders', {
-        _activeFilter: 'Account.Id eq "' + entry.$key + '" and IsQuote eq false and ' + '(' + '((ErpExtId ne null) and ' + ('(ERPSalesOrder.ERPStatus ne "' + this.cancledCode + '") and ') + ('(ERPSalesOrder.ERPStatus ne "' + this.deletedCode + '") and ') + ('(ERPSalesOrder.ERPStatus ne "' + this.unapprovedCode + '") and ') + ('(' + this.pastDays('ErpDocumentDate') + ')') + ')' + ' or ' + '((ErpExtId eq null) and ' + ('(Status ne "' + this.closedText + '") and ') + ('(Status ne "' + this.cancledText + '") and ') + ('(Status ne "' + this.deletedText + '") and ') + ('(Status ne "' + this.replacedText + '") and ') + ('(Status ne "' + this.unapprovedText + '") and ') + ('(' + this.pastDays('OrderDate') + ')') + ')' + ')',
+        _activeFilter: `Account.Id eq "${entry.$key}" and IsQuote eq false and ` + '(' + '((ErpExtId ne null) and ' + `(ERPSalesOrder.ERPStatus ne "${this.cancledCode}") and ` + `(ERPSalesOrder.ERPStatus ne "${this.deletedCode}") and ` + `(ERPSalesOrder.ERPStatus ne "${this.unapprovedCode}") and ` + `(${this.pastDays('ErpDocumentDate')})` + ')' + ' or ' + '((ErpExtId eq null) and ' + `(Status ne "${this.closedText}") and ` + `(Status ne "${this.cancledText}") and ` + `(Status ne "${this.deletedText}") and ` + `(Status ne "${this.replacedText}") and ` + `(Status ne "${this.unapprovedText}") and ` + `(${this.pastDays('OrderDate')})` + ')' + ')',
         _filterName: 'AccountManager',
         _metricName: 'SumGrandTotal'
       }], ['erpShipments', {
-        _activeFilter: 'Account.Id eq "' + entry.$key + '" and ' + ('ErpStatus ne "' + this.cancledCode + '" and ') + ('ErpStatus ne "' + this.deletedCode + '" and ') + ('ErpStatus ne "' + this.holdCode + '" and ' + this.pastDays('ErpDocumentDate')),
+        _activeFilter: `Account.Id eq "${entry.$key}" and ` + `ErpStatus ne "${this.cancledCode}" and ` + `ErpStatus ne "${this.deletedCode}" and ` + `ErpStatus ne "${this.holdCode}" and ${this.pastDays('ErpDocumentDate')}`,
         _filterName: 'ERPStatus',
         _metricName: 'SumTotalAmount'
       }], ['erpInvoices', {
-        _activeFilter: 'Account.Id eq "' + entry.$key + '" and ' + ('ErpStatus ne "' + this.proformaCode + '" and ') + ('ErpStatus ne "' + this.voidCode + '" and ') + ('ErpStatus ne "' + this.disputeCode + '" and ') + ('ErpStatus ne "' + this.writeOffCode + '" and ' + this.pastDays('ErpDocumentDate')),
+        _activeFilter: `Account.Id eq "${entry.$key}" and ` + `ErpStatus ne "${this.proformaCode}" and ` + `ErpStatus ne "${this.voidCode}" and ` + `ErpStatus ne "${this.disputeCode}" and ` + `ErpStatus ne "${this.writeOffCode}" and ${this.pastDays('ErpDocumentDate')}`,
         _filterName: 'ErpStatus',
         _metricName: 'SumGrandTotal'
       }], ['erpReceivables', {
-        _activeFilter: 'Account.Id eq "' + entry.$key + '" and ErpStatus ne "' + this.voidCode + '" and ' + this.pastDays('ErpDocumentDate'),
+        _activeFilter: `Account.Id eq "${entry.$key}" and ErpStatus ne "${this.voidCode}" and ${this.pastDays('ErpDocumentDate')}`,
         _filterName: 'ErpStatus',
         _metricName: 'SumGrandTotal'
       }]);
@@ -215,16 +215,16 @@ define('crm/Integrations/BOE/Views/Account/NewDashboardWidget', ['module', 'expo
     },
     setCountTitles: function setCountTitles() {},
     pastDays: function pastDays(property) {
-      var now = moment();
+      const now = moment();
 
-      var pastWeekStart = now.clone().subtract(this.dayValue, 'days').startOf('day');
-      var today = now.clone().endOf('day');
+      const pastWeekStart = now.clone().subtract(this.dayValue, 'days').startOf('day');
+      const today = now.clone().endOf('day');
 
-      var query = '((' + property + ' between @' + _Convert2.default.toIsoStringFromDate(pastWeekStart.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(today.toDate()) + '@) or (' + property + ' between @' + pastWeekStart.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + today.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
+      const query = `((${property} between @${_Convert2.default.toIsoStringFromDate(pastWeekStart.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(today.toDate())}@) or (${property} between @${pastWeekStart.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${today.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
       return query;
     }
   });
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('account_new_dashboard_widget', __class);
   _lang2.default.setObject('icboe.Views.Account.NewDashboardWidget', __class);
   exports.default = __class;

--- a/src-out/Integrations/BOE/Views/Account/OpenDashboardWidget.js
+++ b/src-out/Integrations/BOE/Views/Account/OpenDashboardWidget.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/Account/OpenDashboardWidget', ['module', 'exp
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('openDashboardWidget');
+  const resource = (0, _I18n2.default)('openDashboardWidget');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Account.OpenDashboardWidget', [_DashboardWidget2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Account.OpenDashboardWidget', [_DashboardWidget2.default], {
     // Localization
     openSalesOrdersText: resource.openSalesOrdersText,
     openQuotesText: resource.openQuotesText,
@@ -119,11 +119,11 @@ define('crm/Integrations/BOE/Views/Account/OpenDashboardWidget', ['module', 'exp
     resourceKind: 'accounts',
     querySelect: ['AccountName'],
     getWhere: function getWhere() {
-      return 'Id eq \'' + this.parentEntry.$key + '\'';
+      return `Id eq '${this.parentEntry.$key}'`;
     },
     // Creates the range widgets, value can have valueUnit to apply next to the number
     createRangeLayout: function createRangeLayout() {
-      var rangeLayout = [{
+      const rangeLayout = [{
         value: 0,
         valueUnit: '+'
       }, {
@@ -144,7 +144,7 @@ define('crm/Integrations/BOE/Views/Account/OpenDashboardWidget', ['module', 'exp
     createMetricLayout: function createMetricLayout(entry) {
       this.setQueryArgs(entry);
 
-      var metricLayout = [{
+      const metricLayout = [{
         navTo: 'account_openquotes_related',
         formatter: 'bigNumber',
         formatterModule: _Format2.default,
@@ -173,21 +173,21 @@ define('crm/Integrations/BOE/Views/Account/OpenDashboardWidget', ['module', 'exp
       this.queryArgs = [];
 
       this.queryArgs.push(['quotes', {
-        _activeFilter: 'Account.Id eq "' + entry.$key + '" and ' + '(' + '(' + '(ErpExtId ne null) and ' + ('(ErpStatus eq "' + this.openCode + '"') + (' or ErpStatus eq "' + this.pendingCode + '"') + (' or ErpStatus eq "' + this.approvedCode + '"') + (') and (' + this.pastDays('DocumentDate') + ')') + ')' + ' or ' + '(' + '(ErpExtId eq null) and ' + ('(Status eq "' + this.newText + '"') + (' or Status eq "' + this.openText + '"') + (' or Status eq "' + this.approvedText + '"') + (' or Status eq "' + this.pendingText + '"') + (' or Status eq "' + this.awardedText + '"') + (') and (' + this.pastDays('StartDate') + ')') + ')' + ')',
+        _activeFilter: `Account.Id eq "${entry.$key}" and ` + '(' + '(' + '(ErpExtId ne null) and ' + `(ErpStatus eq "${this.openCode}"` + ` or ErpStatus eq "${this.pendingCode}"` + ` or ErpStatus eq "${this.approvedCode}"` + `) and (${this.pastDays('DocumentDate')})` + ')' + ' or ' + '(' + '(ErpExtId eq null) and ' + `(Status eq "${this.newText}"` + ` or Status eq "${this.openText}"` + ` or Status eq "${this.approvedText}"` + ` or Status eq "${this.pendingText}"` + ` or Status eq "${this.awardedText}"` + `) and (${this.pastDays('StartDate')})` + ')' + ')',
         _filterName: 'AccountManager',
         _metricName: 'SumGrandTotal'
       }], ['erpInvoices', {
-        _activeFilter: 'Account.Id eq "' + entry.$key + '" and ' + '(' + ('(ErpStatus eq "' + this.openCode + '"') + (' or ErpStatus eq "' + this.partialPaidCode + '"') + (' or ErpStatus eq "' + this.disputeCode + '"') + ')' + (') and ' + this.pastDays('ErpDocumentDate')),
+        _activeFilter: `Account.Id eq "${entry.$key}" and ` + '(' + `(ErpStatus eq "${this.openCode}"` + ` or ErpStatus eq "${this.partialPaidCode}"` + ` or ErpStatus eq "${this.disputeCode}"` + ')' + `) and ${this.pastDays('ErpDocumentDate')}`,
         _filterName: 'ErpStatus',
         _metricName: 'SumGrandTotal'
       }], ['salesOrders', {
-        _activeFilter: 'Account.Id eq "' + entry.$key + '" and ' + '(' + '(' + '(ErpExtId ne null) and ' + '(' + ('(ERPSalesOrder.ERPStatus eq "' + this.openCode + '"') + (' or ERPSalesOrder.ERPStatus eq "' + this.holdCode + '"') + (' or ERPSalesOrder.ERPStatus eq "' + this.partialShipCode + '"') + (' or ERPSalesOrder.ERPStatus eq "' + this.approvedCode + '"') + (') and ' + this.pastDays('ErpDocumentDate') // ' and ' +
+        _activeFilter: `Account.Id eq "${entry.$key}" and ` + '(' + '(' + '(ErpExtId ne null) and ' + '(' + `(ERPSalesOrder.ERPStatus eq "${this.openCode}"` + ` or ERPSalesOrder.ERPStatus eq "${this.holdCode}"` + ` or ERPSalesOrder.ERPStatus eq "${this.partialShipCode}"` + ` or ERPSalesOrder.ERPStatus eq "${this.approvedCode}"` + `) and ${this.pastDays('ErpDocumentDate') // ' and ' +
         // '(SalesOrderItems.ErpStatus eq "' + this.openCode + '"' + // This does not work since it creates a cartesion duplicate result for each line
         //    ' or SalesOrderItems.ErpStatus eq "' + this.partialShipCode + '"' +
         //    ' or SalesOrderItems.ErpStatus eq "' + this.holdCode + '"' +
         //  ') and ' +
         //  this.pastDays('SalesOrderItems.ErpRequiredDeliveryDate') +
-        + ')') + ') or ' + '((ErpExtId eq null) and ' + ('(Status eq "' + this.openOrderText + '"') + (' or Status eq "' + this.salesOrderText + '"') + (' or Status eq "' + this.salesHoldText + '"') + (' or Status eq "' + this.creditHoldText + '"') + (' or Status eq "' + this.adminHoldText + '"') + (' or Status eq "' + this.holdText + '"') + (' or Status eq "' + this.orderedText + '"') + (' or Status eq "' + this.partiallyShippedText + '"') + (' or Status eq "' + this.pendingText + '"') + (') and (' + this.pastDays('OrderDate') + ')') + ')' + ')',
+        })` + ') or ' + '((ErpExtId eq null) and ' + `(Status eq "${this.openOrderText}"` + ` or Status eq "${this.salesOrderText}"` + ` or Status eq "${this.salesHoldText}"` + ` or Status eq "${this.creditHoldText}"` + ` or Status eq "${this.adminHoldText}"` + ` or Status eq "${this.holdText}"` + ` or Status eq "${this.orderedText}"` + ` or Status eq "${this.partiallyShippedText}"` + ` or Status eq "${this.pendingText}"` + `) and (${this.pastDays('OrderDate')})` + ')' + ')',
         _filterName: 'AccountManager',
         _metricName: 'SumGrandTotal'
       }]);
@@ -195,18 +195,18 @@ define('crm/Integrations/BOE/Views/Account/OpenDashboardWidget', ['module', 'exp
     },
     setCountTitles: function setCountTitles() {},
     pastDays: function pastDays(property) {
-      var now = moment();
+      const now = moment();
 
       if (this.dayValue === 0) {
         return '1 eq 1';
       }
-      var pastDay = now.clone().subtract(this.dayValue, 'days').startOf('day');
+      const pastDay = now.clone().subtract(this.dayValue, 'days').startOf('day');
 
-      var query = '(' + property + ' lt @' + _Convert2.default.toIsoStringFromDate(pastDay.toDate()) + '@ or (' + property + ' lt @' + pastDay.format('YYYY-MM-DDT00:00:00[Z]') + '@))';
+      const query = `(${property} lt @${_Convert2.default.toIsoStringFromDate(pastDay.toDate())}@ or (${property} lt @${pastDay.format('YYYY-MM-DDT00:00:00[Z]')}@))`;
       return query;
     }
   });
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('account_open_dashboard_widget', __class);
   _lang2.default.setObject('icboe.Views.Account.OpenDashboardWidget', __class);
   exports.default = __class;

--- a/src-out/Integrations/BOE/Views/Account/SalesDashboardWidget.js
+++ b/src-out/Integrations/BOE/Views/Account/SalesDashboardWidget.js
@@ -44,9 +44,9 @@ define('crm/Integrations/BOE/Views/Account/SalesDashboardWidget', ['module', 'ex
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('salesDashboardWidget');
+  const resource = (0, _I18n2.default)('salesDashboardWidget');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Account.SalesDashboardWidget', [_DashboardWidget2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Account.SalesDashboardWidget', [_DashboardWidget2.default], {
     // Localization
     recentRevenueText: resource.recentRevenueText,
     recentCostText: resource.recentCostText,
@@ -138,14 +138,14 @@ define('crm/Integrations/BOE/Views/Account/SalesDashboardWidget', ['module', 'ex
     querySelect: ['AccountName'],
     queryArgs: null,
     getWhere: function getWhere() {
-      return 'Id eq \'' + this.parentEntry.$key + '\'';
+      return `Id eq '${this.parentEntry.$key}'`;
     },
     getBaseQuery: function getBaseQuery(entry) {
-      var query = '(Account.Id eq "' + entry.$key + '" and (ErpStatus eq "' + this.openCode + '" or ErpStatus eq "' + this.partialPaidCode + '" or ErpStatus eq "' + this.pendingCode + '" or ErpStatus eq "' + this.paidCode + '"))';
+      const query = `(Account.Id eq "${entry.$key}" and (ErpStatus eq "${this.openCode}" or ErpStatus eq "${this.partialPaidCode}" or ErpStatus eq "${this.pendingCode}" or ErpStatus eq "${this.paidCode}"))`;
       return query;
     },
     createRangeLayout: function createRangeLayout() {
-      var rangeLayout = [{
+      const rangeLayout = [{
         value: 30
       }, {
         value: 60
@@ -168,7 +168,7 @@ define('crm/Integrations/BOE/Views/Account/SalesDashboardWidget', ['module', 'ex
          * title: title of the widget,
          * valueNeeded: value that the widget consumes
        */
-      var metricLayout = [{
+      const metricLayout = [{
         formatter: 'bigNumber',
         formatModule: this.formatModule,
         title: this.recentRevenueText,
@@ -212,30 +212,30 @@ define('crm/Integrations/BOE/Views/Account/SalesDashboardWidget', ['module', 'ex
       // This function builds the query args array in an order that matches the queryIndex values needed by the values array
       this.queryArgs = [];
       this.queryArgs.push(['erpInvoices', {
-        _activeFilter: this.getBaseQuery(entry) + ' and ' + this.pastDays('ErpDocumentDate', this.dayValue, null),
+        _activeFilter: `${this.getBaseQuery(entry)} and ${this.pastDays('ErpDocumentDate', this.dayValue, null)}`,
         _filterName: 'ErpStatus',
         _metricName: 'SumGrandTotal'
       }], ['erpInvoices', {
-        _activeFilter: this.getBaseQuery(entry) + ' and ' + this.pastDays('ErpDocumentDate', this.dayValue, null),
+        _activeFilter: `${this.getBaseQuery(entry)} and ${this.pastDays('ErpDocumentDate', this.dayValue, null)}`,
         _filterName: 'ErpStatus',
         _metricName: 'SumExtendedCost'
       }]);
 
       if (!this.queriedOnce) {
         this.queryArgs.push(['erpInvoices', {
-          _activeFilter: this.getBaseQuery(entry) + ' and ' + this.pastDays('ErpDocumentDate', this.yearDays, null),
+          _activeFilter: `${this.getBaseQuery(entry)} and ${this.pastDays('ErpDocumentDate', this.yearDays, null)}`,
           _filterName: 'ErpStatus',
           _metricName: 'SumGrandTotal'
         }], ['erpInvoices', {
-          _activeFilter: this.getBaseQuery(entry) + ' and ' + this.pastDays('ErpDocumentDate', 2 * this.yearDays, this.yearDays),
+          _activeFilter: `${this.getBaseQuery(entry)} and ${this.pastDays('ErpDocumentDate', 2 * this.yearDays, this.yearDays)}`,
           _filterName: 'ErpStatus',
           _metricName: 'SumGrandTotal'
         }], ['erpInvoices', {
-          _activeFilter: this.getBaseQuery(entry) + ' and ' + this.pastDays('ErpDocumentDate', this.yearDays, null),
+          _activeFilter: `${this.getBaseQuery(entry)} and ${this.pastDays('ErpDocumentDate', this.yearDays, null)}`,
           _filterName: 'ErpStatus',
           _metricName: 'SumExtendedCost'
         }], ['erpInvoices', {
-          _activeFilter: this.getBaseQuery(entry) + ' and ' + this.pastDays('ErpDocumentDate', 2 * this.yearDays, this.yearDays),
+          _activeFilter: `${this.getBaseQuery(entry)} and ${this.pastDays('ErpDocumentDate', 2 * this.yearDays, this.yearDays)}`,
           _filterName: 'ErpStatus',
           _metricName: 'SumExtendedCost'
         }]);
@@ -243,10 +243,10 @@ define('crm/Integrations/BOE/Views/Account/SalesDashboardWidget', ['module', 'ex
       this.queriedOnce = true;
     },
     pastDays: function pastDays(property, from, to) {
-      var now = moment();
+      const now = moment();
 
-      var pastWeekStart = now.clone().subtract(from, 'days').startOf('day');
-      var today = void 0;
+      const pastWeekStart = now.clone().subtract(from, 'days').startOf('day');
+      let today;
 
       if (!to) {
         today = now.clone().endOf('day');
@@ -254,11 +254,11 @@ define('crm/Integrations/BOE/Views/Account/SalesDashboardWidget', ['module', 'ex
         today = now.clone().subtract(to, 'days').endOf('day');
       }
 
-      var query = _string2.default.substitute('((' + property + ' between @${0}@ and @${1}@) or (' + property + ' between @${2}@ and @${3}@))', [_Convert2.default.toIsoStringFromDate(pastWeekStart.toDate()), _Convert2.default.toIsoStringFromDate(today.toDate()), pastWeekStart.format('YYYY-MM-DDT00:00:00[Z]'), today.format('YYYY-MM-DDT23:59:59[Z]')]);
+      const query = _string2.default.substitute(`((${property} between @\${0}@ and @\${1}@) or (${property} between @\${2}@ and @\${3}@))`, [_Convert2.default.toIsoStringFromDate(pastWeekStart.toDate()), _Convert2.default.toIsoStringFromDate(today.toDate()), pastWeekStart.format('YYYY-MM-DDT00:00:00[Z]'), today.format('YYYY-MM-DDT23:59:59[Z]')]);
       return query;
     }
   });
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('account_sales_dashboard_widget', __class);
   _lang2.default.setObject('icboe.Views.Account.SalesDashboardWidget', __class);
   exports.default = __class;

--- a/src-out/Integrations/BOE/Views/BackOfficeAccountingEntities/List.js
+++ b/src-out/Integrations/BOE/Views/BackOfficeAccountingEntities/List.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Views/BackOfficeAccountingEntities/List', ['module'
     };
   }
 
-  var resource = (0, _I18n2.default)('backOfficeAccountingEntitiesList'); /* Copyright 2017 Infor
-                                                                           *
-                                                                           * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                           * you may not use this file except in compliance with the License.
-                                                                           * You may obtain a copy of the License at
-                                                                           *
-                                                                           *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                           *
-                                                                           * Unless required by applicable law or agreed to in writing, software
-                                                                           * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                           * See the License for the specific language governing permissions and
-                                                                           * limitations under the License.
-                                                                           */
+  const resource = (0, _I18n2.default)('backOfficeAccountingEntitiesList'); /* Copyright 2017 Infor
+                                                                             *
+                                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                             * you may not use this file except in compliance with the License.
+                                                                             * You may obtain a copy of the License at
+                                                                             *
+                                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                             *
+                                                                             * Unless required by applicable law or agreed to in writing, software
+                                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                             * See the License for the specific language governing permissions and
+                                                                             * limitations under the License.
+                                                                             */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.BackOfficeAccountingEntities.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.BackOfficeAccountingEntities.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Name %}</p>']),
 
@@ -61,8 +61,8 @@ define('crm/Integrations/BOE/Views/BackOfficeAccountingEntities/List', ['module'
       return this.tools || (this.tools = {});
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Name) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Name) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/BackOffices/List.js
+++ b/src-out/Integrations/BOE/Views/BackOffices/List.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Views/BackOffices/List', ['module', 'exports', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('backOfficesList'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('backOfficesList'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.BackOffices.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.BackOffices.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.BackOfficeName %}</p>', '<p class="micro-text">{%: $.LogicalId %}</p>']),
 
@@ -61,8 +61,8 @@ define('crm/Integrations/BOE/Views/BackOffices/List', ['module', 'exports', 'doj
       return this.tools || (this.tools = {});
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(BackOfficeName) like "' + q + '%" or upper(LogicalId) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(BackOfficeName) like "${q}%" or upper(LogicalId) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/Carriers/List.js
+++ b/src-out/Integrations/BOE/Views/Carriers/List.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Views/Carriers/List', ['module', 'exports', 'dojo/_
     };
   }
 
-  var resource = (0, _I18n2.default)('carriersList'); /* Copyright 2017 Infor
-                                                       *
-                                                       * Licensed under the Apache License, Version 2.0 (the "License");
-                                                       * you may not use this file except in compliance with the License.
-                                                       * You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing, software
-                                                       * distributed under the License is distributed on an "AS IS" BASIS,
-                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                       * See the License for the specific language governing permissions and
-                                                       * limitations under the License.
-                                                       */
+  const resource = (0, _I18n2.default)('carriersList'); /* Copyright 2017 Infor
+                                                         *
+                                                         * Licensed under the Apache License, Version 2.0 (the "License");
+                                                         * you may not use this file except in compliance with the License.
+                                                         * You may obtain a copy of the License at
+                                                         *
+                                                         *    http://www.apache.org/licenses/LICENSE-2.0
+                                                         *
+                                                         * Unless required by applicable law or agreed to in writing, software
+                                                         * distributed under the License is distributed on an "AS IS" BASIS,
+                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                         * See the License for the specific language governing permissions and
+                                                         * limitations under the License.
+                                                         */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Carriers.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Carriers.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.CarrierName %}</p>', '<p class="micro-text">{%: $.LogicalId %}</p>']),
 
@@ -61,8 +61,8 @@ define('crm/Integrations/BOE/Views/Carriers/List', ['module', 'exports', 'dojo/_
       return this.tools || (this.tools = {});
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(CarrierName) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(CarrierName) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPAccountPersons/List.js
+++ b/src-out/Integrations/BOE/Views/ERPAccountPersons/List.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPAccountPersons/List', ['module', 'exports'
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpAccountPersonsList');
+  const resource = (0, _I18n2.default)('erpAccountPersonsList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPAccountPersons.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPAccountPersons.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     // TODO: Need template from PM
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.ErpPerson.Name %}</p>', '<p class="micro-text address">{%: $.ErpPerson.Address.FullAddress %}</p>']),
@@ -67,8 +67,8 @@ define('crm/Integrations/BOE/Views/ERPAccountPersons/List', ['module', 'exports'
     groupsEnabled: true,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ErpPerson.Name) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ErpPerson.Name) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPBillToAccounts/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPBillToAccounts/Detail.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/ERPBillToAccounts/Detail', ['module', 'export
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpBillToAccountsDetail');
+  const resource = (0, _I18n2.default)('erpBillToAccountsDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillToAccounts.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillToAccounts.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     actionsText: resource.actionsText,
@@ -138,42 +138,42 @@ define('crm/Integrations/BOE/Views/ERPBillToAccounts/Detail', ['module', 'export
           name: 'Accounts',
           label: this.accountsText,
           where: function where(entry) {
-            return 'ErpBillToAccounts.Id eq "' + entry.$key + '"';
+            return `ErpBillToAccounts.Id eq "${entry.$key}"`;
           },
           view: 'billtoaccount_accounts_related'
         }, {
           name: 'OpenQuotesList',
           label: this.openQuotesText,
           where: function where(entry) {
-            return 'BillTo.ErpBillToAccounts.Id eq "' + entry.$key + '" and (Status eq "' + this.openCode + '" or Status eq "' + this.newCode + '")';
+            return `BillTo.ErpBillToAccounts.Id eq "${entry.$key}" and (Status eq "${this.openCode}" or Status eq "${this.newCode}")`;
           },
           view: 'billtoaccount_openquotes_related'
         }, {
           name: 'SalesOrders',
           label: this.salesOrdersText,
           where: function where(entry) {
-            return 'ErpBillTo.ErpBillToAccounts.Id eq "' + entry.$key + '" and (Status eq "' + this.openCode + '" or Status eq "' + this.approvedCode + '" or Status eq "' + this.workingCode + '" or Status eq "' + this.partialShipCode + '")';
+            return `ErpBillTo.ErpBillToAccounts.Id eq "${entry.$key}" and (Status eq "${this.openCode}" or Status eq "${this.approvedCode}" or Status eq "${this.workingCode}" or Status eq "${this.partialShipCode}")`;
           },
           view: 'billtoaccount_salesorders_related'
         }, {
           name: 'OpenInvoices',
           label: this.invoicesText,
           where: function where(entry) {
-            return 'ErpBillTo.ErpBillToAccounts.Id eq "' + entry.$key + '" and (ErpStatus eq "' + this.openCode + '" or ErpStatus eq "' + this.partialPaidCode + '" or ErpStatus eq "' + this.disputeCode + '")';
+            return `ErpBillTo.ErpBillToAccounts.Id eq "${entry.$key}" and (ErpStatus eq "${this.openCode}" or ErpStatus eq "${this.partialPaidCode}" or ErpStatus eq "${this.disputeCode}")`;
           },
           view: 'billtoaccount_openinvoices_related'
         }, {
           name: 'Receivables',
           label: this.receivablesText,
           where: function where(entry) {
-            return 'ErpBillTo.ErpBillToAccounts.Id eq "' + entry.$key + '"';
+            return `ErpBillTo.ErpBillToAccounts.Id eq "${entry.$key}"`;
           },
           view: 'billtoaccount_receivables_related'
         }, {
           name: 'Returns',
           label: this.returnsText,
           where: function where(entry) {
-            return 'ErpBillTo.ErpBillToAccounts.Id eq "' + entry.$key + '"';
+            return `ErpBillTo.ErpBillToAccounts.Id eq "${entry.$key}"`;
           },
           view: 'billtoaccount_returns_related'
         }]

--- a/src-out/Integrations/BOE/Views/ERPBillToAccounts/Edit.js
+++ b/src-out/Integrations/BOE/Views/ERPBillToAccounts/Edit.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Views/ERPBillToAccounts/Edit', ['module', 'exports'
     };
   }
 
-  var resource = (0, _I18n2.default)('erpBillToAccountsEdit'); /* Copyright 2017 Infor
-                                                                *
-                                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                * you may not use this file except in compliance with the License.
-                                                                * You may obtain a copy of the License at
-                                                                *
-                                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                *
-                                                                * Unless required by applicable law or agreed to in writing, software
-                                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                * See the License for the specific language governing permissions and
-                                                                * limitations under the License.
-                                                                */
+  const resource = (0, _I18n2.default)('erpBillToAccountsEdit'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillToAccounts.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillToAccounts.Edit', [_Edit2.default], {
     // View Properties
     id: 'erpbilltoaccounts_edit',
     detailView: 'erpbilltoaccounts_detail',

--- a/src-out/Integrations/BOE/Views/ERPBillToAccounts/List.js
+++ b/src-out/Integrations/BOE/Views/ERPBillToAccounts/List.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPBillToAccounts/List', ['module', 'exports'
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpBillToAccountsList');
+  const resource = (0, _I18n2.default)('erpBillToAccountsList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillToAccounts.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillToAccounts.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     // TODO: Need template from PM
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.ErpBillTo.Name %}</p>', '<p class="micro-text address">{%: $.ErpBillTo.Address.FullAddress %}</p>']),
@@ -70,8 +70,8 @@ define('crm/Integrations/BOE/Views/ERPBillToAccounts/List', ['module', 'exports'
     groupsEnabled: true,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ErpBillTo.Name) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ErpBillTo.Name) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPBillTos/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPBillTos/Detail.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Detail', ['module', 'exports', 'do
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpBillTosDetail');
+  const resource = (0, _I18n2.default)('erpBillTosDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillTos.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillTos.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     relatedItemsText: resource.relatedItemsText,
@@ -139,56 +139,56 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Detail', ['module', 'exports', 'do
           name: 'Accounts',
           label: this.accountsText,
           where: function where(entry) {
-            return 'ErpBillToAccounts.ErpBillTo.Id eq "' + entry.$key + '"';
+            return `ErpBillToAccounts.ErpBillTo.Id eq "${entry.$key}"`;
           },
           view: 'billto_accounts_related'
         }, {
           name: 'ShipTos',
           label: this.shipToText,
-          where: function where(entry) {
-            return 'ErpBillToShipTos.ErpShipTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpBillToShipTos.ErpShipTo.Id eq "${entry.$key}"`;
           },
           view: 'billto_shiptos_related'
         }, {
           name: 'Quotes',
           label: this.quotesText,
-          where: function where(entry) {
-            return 'BillTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `BillTo.Id eq "${entry.$key}"`;
           },
           view: 'billto_quotes_related'
         }, {
           name: 'SalesOrders',
           label: this.salesOrdersText,
-          where: function where(entry) {
-            return 'ErpBillTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpBillTo.Id eq "${entry.$key}"`;
           },
           view: 'billto_orders_related'
         }, {
           name: 'Receivables',
           label: this.receivablesText,
-          where: function where(entry) {
-            return 'ErpBillTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpBillTo.Id eq "${entry.$key}"`;
           },
           view: 'billto_receivables_related'
         }, {
           name: 'Invoices',
           label: this.invoicesText,
-          where: function where(entry) {
-            return 'ErpBillTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpBillTo.Id eq "${entry.$key}"`;
           },
           view: 'billto_invoices_related'
         }, {
           name: 'Returns',
           label: this.returnsText,
-          where: function where(entry) {
-            return 'ErpBillTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpBillTo.Id eq "${entry.$key}"`;
           },
           view: 'billto_returns_related'
         }, {
           name: 'SyncHistory',
           label: this.syncHistoryText,
-          where: function where(entry) {
-            return 'EntityType eq "ERPBillTo" and EntityId eq "' + entry.$key + '"';
+          where: entry => {
+            return `EntityType eq "ERPBillTo" and EntityId eq "${entry.$key}"`;
           },
           view: 'billto_synchistory_related'
         }]

--- a/src-out/Integrations/BOE/Views/ERPBillTos/Edit.js
+++ b/src-out/Integrations/BOE/Views/ERPBillTos/Edit.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Edit', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpBillTosEdit');
+  const resource = (0, _I18n2.default)('erpBillTosEdit');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillTos.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPBillTos.Edit', [_Edit2.default], {
     // View Properties
     id: 'erpbillto_edit',
     detailView: 'erpbillto_detail',
@@ -77,17 +77,17 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Edit', ['module', 'exports', 'dojo
     applyContext: function applyContext() {
       this.inherited(applyContext, arguments);
 
-      var found = this._getNavContext();
-      var context = found && found.options && found.options.source || found;
-      var lookup = {
+      const found = this._getNavContext();
+      const context = found && found.options && found.options.source || found;
+      const lookup = {
         accounts: this.applyAccountContext,
         quotes: this.applyQuoteContext,
         salesOrders: this.applyOrderContext
       };
 
       if (context && lookup[context.resourceKind]) {
-        var view = App.getView(context.id);
-        var entry = context.entry || view && view.entry || context;
+        const view = App.getView(context.id);
+        const entry = context.entry || view && view.entry || context;
 
         if (!entry || !entry.$key) {
           return;
@@ -144,14 +144,14 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Edit', ['module', 'exports', 'dojo
         App.bars.tbar.enableTool('save');
       }
 
-      var message = this._buildRefreshMessage(entry, result);
+      const message = this._buildRefreshMessage(entry, result);
       _connect2.default.publish('/app/refresh', [message]);
 
       this.onInsertCompleted(result);
     },
     onInsertCompleted: function onInsertCompleted(results) {
       if (this.associationView) {
-        var view = App.getView(this.associationView);
+        const view = App.getView(this.associationView);
         if (view) {
           view.inserting = true;
           view.options = {
@@ -169,8 +169,8 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Edit', ['module', 'exports', 'dojo
       this.associationContext = null;
     },
     _getNavContext: function _getNavContext() {
-      var navContext = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      const navContext = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
 
         if (/^(accounts|quotes|salesOrders)$/.test(context.resourceKind) && context.key) {
           return true;
@@ -215,8 +215,8 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Edit', ['module', 'exports', 'dojo
           requireSelection: false,
           dependsOn: 'ErpLogicalId',
           storageMode: 'code',
-          where: function where(logicalId) {
-            return 'filter eq "' + logicalId + '"';
+          where: logicalId => {
+            return `filter eq "${logicalId}"`;
           }
         }, {
           label: this.statusText,
@@ -236,8 +236,8 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Edit', ['module', 'exports', 'dojo
           type: 'picklist',
           storageMode: 'code',
           dependsOn: 'ErpLogicalId',
-          where: function where(logicalId) {
-            return 'filter eq "' + logicalId + '"';
+          where: logicalId => {
+            return `filter eq "${logicalId}"`;
           }
         }, {
           label: this.paymentMethodText,
@@ -249,8 +249,8 @@ define('crm/Integrations/BOE/Views/ERPBillTos/Edit', ['module', 'exports', 'dojo
           type: 'picklist',
           storageMode: 'code',
           dependsOn: 'ErpLogicalId',
-          where: function where(logicalId) {
-            return 'filter eq "' + logicalId + '"';
+          where: logicalId => {
+            return `filter eq "${logicalId}"`;
           }
         }, {
           emptyText: '',

--- a/src-out/Integrations/BOE/Views/ERPBillTos/List.js
+++ b/src-out/Integrations/BOE/Views/ERPBillTos/List.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPBillTos/List', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpBillTosList');
+  const resource = (0, _I18n2.default)('erpBillTosList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ErpBillTos.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ErpBillTos.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Name %}</p>', '<p class="listview-heading address">{%: $.Address.FullAddress %}</p>']),
 
@@ -69,8 +69,8 @@ define('crm/Integrations/BOE/Views/ERPBillTos/List', ['module', 'exports', 'dojo
     groupsEnabled: true,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Name) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Name) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPContactAssociations/List.js
+++ b/src-out/Integrations/BOE/Views/ERPContactAssociations/List.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPContactAssociations/List', ['module', 'exp
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpContactAssociationsList');
+  const resource = (0, _I18n2.default)('erpContactAssociationsList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPContactAssociations.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPContactAssociations.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Contact.NameLF %}</p>', '<p class="micro-text">{%: $.Account.AccountName %}</p>']),
 
@@ -75,9 +75,9 @@ define('crm/Integrations/BOE/Views/ERPContactAssociations/List', ['module', 'exp
      */
     navigateToDetailView: function navigateToDetailView(key, descriptor, additionalOptions) {
       // Ignore ContactAssociation and navigate to contact detail view
-      var contact = this.entries[key].Contact;
-      var view = this.app.getView(this.detailView);
-      var options = {
+      const contact = this.entries[key].Contact;
+      const view = this.app.getView(this.detailView);
+      let options = {
         descriptor: contact.NameLF, // keep for backwards compat
         title: contact.NameLF,
         key: contact.$key,
@@ -93,8 +93,8 @@ define('crm/Integrations/BOE/Views/ERPContactAssociations/List', ['module', 'exp
       }
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Contact.NameLF) like "%' + q + '%" or upper(Account.AccountName) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Contact.NameLF) like "%${q}%" or upper(Account.AccountName) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPInvoiceItems/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPInvoiceItems/Detail.js
@@ -35,9 +35,9 @@ define('crm/Integrations/BOE/Views/ERPInvoiceItems/Detail', ['module', 'exports'
    * See the License for the specific language governing permissions and
    * limitations under the License.
    */
-  var resource = (0, _I18n2.default)('erpInvoiceItemsDetail');
+  const resource = (0, _I18n2.default)('erpInvoiceItemsDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvociesItems.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvociesItems.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     invoiceNumberText: resource.invoiceNumberText,

--- a/src-out/Integrations/BOE/Views/ERPInvoiceItems/List.js
+++ b/src-out/Integrations/BOE/Views/ERPInvoiceItems/List.js
@@ -23,22 +23,22 @@ define('crm/Integrations/BOE/Views/ERPInvoiceItems/List', ['module', 'exports', 
     };
   }
 
-  var resource = (0, _I18n2.default)('erpInvoiceItemsList'); /* Copyright 2017 Infor
-                                                              *
-                                                              * Licensed under the Apache License, Version 2.0 (the "License");
-                                                              * you may not use this file except in compliance with the License.
-                                                              * You may obtain a copy of the License at
-                                                              *
-                                                              *    http://www.apache.org/licenses/LICENSE-2.0
-                                                              *
-                                                              * Unless required by applicable law or agreed to in writing, software
-                                                              * distributed under the License is distributed on an "AS IS" BASIS,
-                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                              * See the License for the specific language governing permissions and
-                                                              * limitations under the License.
-                                                              */
+  const resource = (0, _I18n2.default)('erpInvoiceItemsList'); /* Copyright 2017 Infor
+                                                                *
+                                                                * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                * you may not use this file except in compliance with the License.
+                                                                * You may obtain a copy of the License at
+                                                                *
+                                                                *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                *
+                                                                * Unless required by applicable law or agreed to in writing, software
+                                                                * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                * See the License for the specific language governing permissions and
+                                                                * limitations under the License.
+                                                                */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvoiceItems.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvoiceItems.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     itemTemplate: new Simplate(['<p class="listview-heading"><label class="group-label">{%: $$.productNameText %}</label> {%: $.ProductName %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.invoiceIdText %}</label> {%: $.ErpInvoice.InvoiceNumber %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.descriptionText %}</label> {%: $.Description %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.lineText %}</label> {%: $.ErpLineNumber %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.quantityText %}</label> {%: $.Quantity %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.priceText %}</label> {%: $.Price %}</p>', '{% if ($.ErpLineTotalAmount) { %}', '<p class="micro-text"> <label class="group-label">{%: $$.amountText %}</label> <strong>', '{% if (App.hasMultiCurrency() && $.ErpInvoice.CurrencyCode) { %}', '{%: crm.Format.multiCurrency($.ErpLineTotalAmount, $.ErpInvoice.CurrencyCode) %}', '{% } else { %}', '{%: crm.Format.currency($.ErpLineTotalAmount) %}', '{% } %}', '</strong></p>', '{% } %}']),
 
     // Localization
@@ -63,8 +63,8 @@ define('crm/Integrations/BOE/Views/ERPInvoiceItems/List', ['module', 'exports', 
     itemIconClass: 'bullet-list',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ProductName) like "' + q + '%" or upper(ErpLineNumber) like "' + q + '%" or upper(Description) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ProductName) like "${q}%" or upper(ErpLineNumber) like "${q}%" or upper(Description) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPInvoicePersons/List.js
+++ b/src-out/Integrations/BOE/Views/ERPInvoicePersons/List.js
@@ -23,22 +23,22 @@ define('crm/Integrations/BOE/Views/ERPInvoicePersons/List', ['module', 'exports'
     };
   }
 
-  var resource = (0, _I18n2.default)('erpInvoicePersonsList'); /* Copyright 2017 Infor
-                                                                *
-                                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                * you may not use this file except in compliance with the License.
-                                                                * You may obtain a copy of the License at
-                                                                *
-                                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                *
-                                                                * Unless required by applicable law or agreed to in writing, software
-                                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                * See the License for the specific language governing permissions and
-                                                                * limitations under the License.
-                                                                */
+  const resource = (0, _I18n2.default)('erpInvoicePersonsList'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvoicePersons.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvoicePersons.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.ErpPerson.Name %}</p>', '<p class="micro-text address">{%: $.ErpPerson.Address.FullAddress %}</p>']),
 
@@ -62,8 +62,8 @@ define('crm/Integrations/BOE/Views/ERPInvoicePersons/List', ['module', 'exports'
     groupsEnabled: true,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ErpPerson.Name) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ErpPerson.Name) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPInvoices/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPInvoices/Detail.js
@@ -23,23 +23,23 @@ define('crm/Integrations/BOE/Views/ERPInvoices/Detail', ['module', 'exports', 'd
     };
   }
 
-  var resource = (0, _I18n2.default)('erpInvoicesDetail'); /* Copyright 2017 Infor
-                                                            *
-                                                            * Licensed under the Apache License, Version 2.0 (the "License");
-                                                            * you may not use this file except in compliance with the License.
-                                                            * You may obtain a copy of the License at
-                                                            *
-                                                            *    http://www.apache.org/licenses/LICENSE-2.0
-                                                            *
-                                                            * Unless required by applicable law or agreed to in writing, software
-                                                            * distributed under the License is distributed on an "AS IS" BASIS,
-                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                            * See the License for the specific language governing permissions and
-                                                            * limitations under the License.
-                                                            */
+  const resource = (0, _I18n2.default)('erpInvoicesDetail'); /* Copyright 2017 Infor
+                                                              *
+                                                              * Licensed under the Apache License, Version 2.0 (the "License");
+                                                              * you may not use this file except in compliance with the License.
+                                                              * You may obtain a copy of the License at
+                                                              *
+                                                              *    http://www.apache.org/licenses/LICENSE-2.0
+                                                              *
+                                                              * Unless required by applicable law or agreed to in writing, software
+                                                              * distributed under the License is distributed on an "AS IS" BASIS,
+                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                              * See the License for the specific language governing permissions and
+                                                              * limitations under the License.
+                                                              */
 
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvoices.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvoices.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     accountText: resource.accountText,
@@ -82,8 +82,6 @@ define('crm/Integrations/BOE/Views/ERPInvoices/Detail', ['module', 'exports', 'd
       return _Format2.default.picklist(this.app.picklistService, this._model, property);
     },
     createLayout: function createLayout() {
-      var _this = this;
-
       return this.layout || (this.layout = [{
         title: this.actionsText,
         list: true,
@@ -112,29 +110,29 @@ define('crm/Integrations/BOE/Views/ERPInvoices/Detail', ['module', 'exports', 'd
           label: this.extendedBaseAmountText,
           name: 'ErpExtendedBaseAmount',
           property: 'ErpExtendedBaseAmount',
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           label: this.extendedAmountText,
           name: 'ErpExtendedAmount',
           property: 'ErpExtendedAmount',
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           label: this.totalBaseAmountText,
           name: 'ErpTotalBaseAmount',
           property: 'ErpTotalBaseAmount',
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           label: this.totalAmountText,
           name: 'GrandTotal',
           property: 'GrandTotal',
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'ErpStatus',
@@ -175,7 +173,7 @@ define('crm/Integrations/BOE/Views/ERPInvoices/Detail', ['module', 'exports', 'd
           name: 'BillToAddress',
           property: 'ErpBillTo.Address',
           label: this.addressText,
-          renderer: function renderer(val) {
+          renderer: val => {
             if (val) {
               return _Format2.default.address(val);
             }
@@ -198,7 +196,7 @@ define('crm/Integrations/BOE/Views/ERPInvoices/Detail', ['module', 'exports', 'd
           name: 'ShipToAddress',
           property: 'ErpShipTo.Address',
           label: this.addressText,
-          renderer: function renderer(val) {
+          renderer: val => {
             if (val) {
               return _Format2.default.address(val);
             }

--- a/src-out/Integrations/BOE/Views/ERPInvoices/List.js
+++ b/src-out/Integrations/BOE/Views/ERPInvoices/List.js
@@ -31,22 +31,22 @@ define('crm/Integrations/BOE/Views/ERPInvoices/List', ['module', 'exports', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('erpInvoicesList'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('erpInvoicesList'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvoices.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPInvoices.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     formatter: _Format2.default,
     util: _Utility2.default,
     // Templates
@@ -101,8 +101,8 @@ define('crm/Integrations/BOE/Views/ERPInvoices/List', ['module', 'exports', 'doj
       }]);
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Account.AccountName) like "' + q + '%" or upper(InvoiceNumber) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Account.AccountName) like "${q}%" or upper(InvoiceNumber) like "${q}%"`;
     },
     formatStatusDate: function formatStatusDate(entry) {
       return entry && entry.ErpStatusDate ? this.formatter.relativeDate(entry.ErpStatusDate) : this.unknownText;

--- a/src-out/Integrations/BOE/Views/ERPReceivableItems/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPReceivableItems/Detail.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/ERPReceivableItems/Detail', ['module', 'expor
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpReceivableItemsDetail');
+  const resource = (0, _I18n2.default)('erpReceivableItemsDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPReceivableItems.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPReceivableItems.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     lineNumberText: resource.lineNumberText,

--- a/src-out/Integrations/BOE/Views/ERPReceivableItems/List.js
+++ b/src-out/Integrations/BOE/Views/ERPReceivableItems/List.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPReceivableItems/List', ['module', 'exports
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpReceivableItemsList');
+  const resource = (0, _I18n2.default)('erpReceivableItemsList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPReceivableItems.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPReceivableItems.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     formatter: _Format2.default,
     itemTemplate: new Simplate(['<p class="listview-heading"><label class="group-label">{%: $$.lineNumberText %}</label> {%: $.ErpLineNumber %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.receivablesIdText %}</label> {%: $.ErpReceivable.ErpExtId %}</p>', '{% if ($.ErpInvoice && $.ErpInvoice.ErpExtId) { %}', '<p class="micro-text"><label class="group-label">{%: $$.invoiceIDText %}</label> {%: $.ErpInvoice.ErpExtId %}</p>', '{% } %}', '<p class="micro-text"><label class="group-label">{%: $$.productNameText %}</label> {%: $.ProductName %}</p>', '{% if ($.ErpLineTotalAmount) { %}', '<p class="micro-text"><label class="group-label">{%: $$.lineTotalText %}</label> ', '{% if (App.hasMultiCurrency() && $.ErpReceivable.CurrencyCode) { %}', '{%: $$.formatter.multiCurrency($.ErpLineTotalAmount, $.ErpReceivable.CurrencyCode) %}', '{% } else { %}', '{%: $$.formatter.currency($.ErpLineTotalAmount) %} ', '{% } %}</p>', '{% } %}']),
 
@@ -69,8 +69,8 @@ define('crm/Integrations/BOE/Views/ERPReceivableItems/List', ['module', 'exports
     insertSecurity: 'Entities/Receivable/Add',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ErpReceivable.ErpExtId) like "%' + q + '%" or upper(ErpInvoice.ErpExtId) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ErpReceivable.ErpExtId) like "%${q}%" or upper(ErpInvoice.ErpExtId) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPReceivables/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPReceivables/Detail.js
@@ -23,22 +23,22 @@ define('crm/Integrations/BOE/Views/ERPReceivables/Detail', ['module', 'exports',
     };
   }
 
-  var resource = (0, _I18n2.default)('erpReceivablesDetail'); /* Copyright 2017 Infor
-                                                               *
-                                                               * Licensed under the Apache License, Version 2.0 (the "License");
-                                                               * you may not use this file except in compliance with the License.
-                                                               * You may obtain a copy of the License at
-                                                               *
-                                                               *    http://www.apache.org/licenses/LICENSE-2.0
-                                                               *
-                                                               * Unless required by applicable law or agreed to in writing, software
-                                                               * distributed under the License is distributed on an "AS IS" BASIS,
-                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                               * See the License for the specific language governing permissions and
-                                                               * limitations under the License.
-                                                               */
+  const resource = (0, _I18n2.default)('erpReceivablesDetail'); /* Copyright 2017 Infor
+                                                                 *
+                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                 * you may not use this file except in compliance with the License.
+                                                                 * You may obtain a copy of the License at
+                                                                 *
+                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                 *
+                                                                 * Unless required by applicable law or agreed to in writing, software
+                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                 * See the License for the specific language governing permissions and
+                                                                 * limitations under the License.
+                                                                 */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPReceivables.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPReceivables.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     receivablesIdText: resource.receivablesIdText,
@@ -68,12 +68,10 @@ define('crm/Integrations/BOE/Views/ERPReceivables/Detail', ['module', 'exports',
     enableOffline: true,
     _sdataProps: ['$key', '$url', '$uuid', '$lookup'],
     _hasNonEmptyAddress: function _hasNonEmptyAddress(address) {
-      var _this = this;
-
-      var keys = void 0;
+      let keys;
       if (address) {
-        keys = Object.keys(address).filter(function (key) {
-          return _this._sdataProps.indexOf(key) === -1;
+        keys = Object.keys(address).filter(key => {
+          return this._sdataProps.indexOf(key) === -1;
         });
       }
 
@@ -85,8 +83,6 @@ define('crm/Integrations/BOE/Views/ERPReceivables/Detail', ['module', 'exports',
       }
     },
     createLayout: function createLayout() {
-      var _this2 = this;
-
       return this.layout || (this.layout = [{
         title: this.detailsText,
         name: 'DetailsSection',
@@ -110,29 +106,29 @@ define('crm/Integrations/BOE/Views/ERPReceivables/Detail', ['module', 'exports',
           name: 'ReceivableBaseAmount',
           property: 'ReceivableBaseAmount',
           label: this.receivableBaseAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this2.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           name: 'ReceivableAmount',
           property: 'ReceivableAmount',
           label: this.receivableAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this2.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'ReceivedBaseAmount',
           property: 'ReceivedBaseAmount',
           label: this.receivedBaseAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this2.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           name: 'ReceivedAmount',
           property: 'ReceivedAmount',
           label: this.receivedAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this2.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'ErpStatus',
@@ -190,7 +186,7 @@ define('crm/Integrations/BOE/Views/ERPReceivables/Detail', ['module', 'exports',
           name: 'ERPReceivableItems',
           label: this.receivableItemsText,
           where: function where(entry) {
-            return 'ErpReceivable.Id eq "' + entry.$key + '"';
+            return `ErpReceivable.Id eq "${entry.$key}"`;
           },
           view: 'erpreceivable_items_related'
         }]

--- a/src-out/Integrations/BOE/Views/ERPReceivables/List.js
+++ b/src-out/Integrations/BOE/Views/ERPReceivables/List.js
@@ -44,9 +44,9 @@ define('crm/Integrations/BOE/Views/ERPReceivables/List', ['module', 'exports', '
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpReceivablesList');
+  const resource = (0, _I18n2.default)('erpReceivablesList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPReceivables.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPReceivables.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     formatter: _Format2.default,
     util: _Utility2.default,
     itemTemplate: new Simplate(['<p class="micro-text"><label class="group-label">{%: $$.receivableIDText %}</label> {%: $.ErpExtId %}</p>', '{% if ($.ErpInvoice && $.ErpInvoice.InvoiceNumber) { %}', '<p class="micro-text"><label class="group-label">{%: $$.invoiceIDText %}</label> {%: $.ErpInvoice.InvoiceNumber %}</p>', '{% } %}', '{% if ($.Account && $.Account.AccountName) { %}', '<p class="micro-text"><label class="group-label">{%: $$.accountNameText %}</label> {%: $.Account.AccountName %}</p>', '{% } %}', '<p class="micro-text"><label class="group-label">{%: $$.receivedBaseAmountText %}</label> ', '{%: $$.util.formatMultiCurrency($.ReceivedBaseAmount, $.BaseCurrencyCode) %}', '</p>', '<p class="micro-text"><label class="group-label">{%: $$.receivedAmountText %}</label> ', '{%: $$.util.formatMultiCurrency($.ReceivedAmount, $.CurrencyCode) %}', '</p>', '<p class="micro-text"><label class="group-label">{%: $$.receivableBaseAmountText %}</label> ', '{%: $$.util.formatMultiCurrency($.ReceivableBaseAmount, $.BaseCurrencyCode) %}', '</p>', '<p class="micro-text"><label class="group-label">{%: $$.receivableAmountText %}</label> ', '{%: $$.util.formatMultiCurrency($.ReceivableAmount, $.CurrencyCode) %}', '</p>', '<p class="micro-text"><label class="group-label">{%: $$.erpStatusText %}</label> {%: $.ErpStatus %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.erpStatusDateText %}</label> {%: $$.formatter.date($.ErpStatusDate) %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.documentDateText %}</label> {%: $$.formatter.date($.ErpDocumentDate) %}</p>']),
@@ -84,8 +84,8 @@ define('crm/Integrations/BOE/Views/ERPReceivables/List', ['module', 'exports', '
     entityName: 'ERPReceivable',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ErpExtId) like "%' + q + '%" or upper(Account.AccountName) like "%' + q + '%" or upper(ErpInvoice.InvoiceNumber) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ErpExtId) like "%${q}%" or upper(Account.AccountName) like "%${q}%" or upper(ErpInvoice.InvoiceNumber) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPSalesOrderPersons/List.js
+++ b/src-out/Integrations/BOE/Views/ERPSalesOrderPersons/List.js
@@ -23,22 +23,22 @@ define('crm/Integrations/BOE/Views/ERPSalesOrderPersons/List', ['module', 'expor
     };
   }
 
-  var resource = (0, _I18n2.default)('erpSalesOrderPersonsList'); /* Copyright 2017 Infor
-                                                                   *
-                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                   * you may not use this file except in compliance with the License.
-                                                                   * You may obtain a copy of the License at
-                                                                   *
-                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                   *
-                                                                   * Unless required by applicable law or agreed to in writing, software
-                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                   * See the License for the specific language governing permissions and
-                                                                   * limitations under the License.
-                                                                   */
+  const resource = (0, _I18n2.default)('erpSalesOrderPersonsList'); /* Copyright 2017 Infor
+                                                                     *
+                                                                     * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                     * you may not use this file except in compliance with the License.
+                                                                     * You may obtain a copy of the License at
+                                                                     *
+                                                                     *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                     *
+                                                                     * Unless required by applicable law or agreed to in writing, software
+                                                                     * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                     * See the License for the specific language governing permissions and
+                                                                     * limitations under the License.
+                                                                     */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPSalesOrderPersons.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPSalesOrderPersons.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     // Templates
     // TODO: Need template from PM
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.ErpPerson.Name %}</p>', '<p class="micro-text address">{%: $.ErpPerson.Address.FullAddress %}</p>']),
@@ -59,8 +59,8 @@ define('crm/Integrations/BOE/Views/ERPSalesOrderPersons/List', ['module', 'expor
     itemIconClass: 'user',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ErpPerson.Name) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ErpPerson.Name) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPShipToAccounts/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPShipToAccounts/Detail.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/ERPShipToAccounts/Detail', ['module', 'export
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpShipToAccountsDetail');
+  const resource = (0, _I18n2.default)('erpShipToAccountsDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipToAccounts.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipToAccounts.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     actionsText: resource.actionsText,
@@ -161,14 +161,14 @@ define('crm/Integrations/BOE/Views/ERPShipToAccounts/Detail', ['module', 'export
           name: 'OpenQuotesList',
           label: this.openQuotesText,
           where: function where(entry) {
-            return 'ShipTo.ErpShipToAccounts.Id eq "' + entry.$key + '" and (Status eq "' + this.openCode + '" or Status eq "' + this.newCode + '")';
+            return `ShipTo.ErpShipToAccounts.Id eq "${entry.$key}" and (Status eq "${this.openCode}" or Status eq "${this.newCode}")`;
           },
           view: 'erpshiptoaccount_quotes_related'
         }, {
           name: 'SalesOrders',
           label: this.salesOrdersText,
           where: function where(entry) {
-            return 'ErpShipTo.ErpShipToAccounts.Id eq "' + entry.$key + '" and (Status eq "' + this.openCode + '" or Status eq "' + this.approvedCode + '" or Status eq "' + this.workingCode + '" or Status eq "' + this.partialShipCode + '")';
+            return `ErpShipTo.ErpShipToAccounts.Id eq "${entry.$key}" and (Status eq "${this.openCode}" or Status eq "${this.approvedCode}" or Status eq "${this.workingCode}" or Status eq "${this.partialShipCode}")`;
           },
           view: 'erpshiptoaccount_salesorders_related'
         },
@@ -184,7 +184,7 @@ define('crm/Integrations/BOE/Views/ERPShipToAccounts/Detail', ['module', 'export
           name: 'Shipments',
           label: this.shipmentsText,
           where: function where(entry) {
-            return 'ErpShipTo.ErpShipToAccounts.Id eq "' + entry.$key + '" and (ErpStatus eq "' + this.openCode + '" or ErpStatus eq "' + this.partialShipCode + '" or ErpStatus eq "' + this.releasedCode + '" or ErpStatus eq "' + this.allocatedCode + '" or ErpStatus eq "' + this.stagedCode + '" or ErpStatus eq "' + this.loadedCode + '")';
+            return `ErpShipTo.ErpShipToAccounts.Id eq "${entry.$key}" and (ErpStatus eq "${this.openCode}" or ErpStatus eq "${this.partialShipCode}" or ErpStatus eq "${this.releasedCode}" or ErpStatus eq "${this.allocatedCode}" or ErpStatus eq "${this.stagedCode}" or ErpStatus eq "${this.loadedCode}")`;
           },
           view: 'erpshiptoaccount_shipments_related'
         },
@@ -200,14 +200,14 @@ define('crm/Integrations/BOE/Views/ERPShipToAccounts/Detail', ['module', 'export
           name: 'Returns',
           label: this.returnsText,
           where: function where(entry) {
-            return 'ErpShipTo.ErpShipToAccounts.Id eq "' + entry.$key + '"';
+            return `ErpShipTo.ErpShipToAccounts.Id eq "${entry.$key}"`;
           },
           view: 'erpshiptoaccount_returns_related'
         }, {
           name: 'ContactAssociations',
           label: this.contactAssociationText,
           where: function where(entry) {
-            return 'Account.ErpShipToAccounts.Id eq "' + entry.$key + '"';
+            return `Account.ErpShipToAccounts.Id eq "${entry.$key}"`;
           },
           view: 'erpshiptoaccount_contactassociations_related'
         }]

--- a/src-out/Integrations/BOE/Views/ERPShipToAccounts/Edit.js
+++ b/src-out/Integrations/BOE/Views/ERPShipToAccounts/Edit.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Views/ERPShipToAccounts/Edit', ['module', 'exports'
     };
   }
 
-  var resource = (0, _I18n2.default)('erpShipToAccountsEdit'); /* Copyright 2017 Infor
-                                                                *
-                                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                * you may not use this file except in compliance with the License.
-                                                                * You may obtain a copy of the License at
-                                                                *
-                                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                *
-                                                                * Unless required by applicable law or agreed to in writing, software
-                                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                * See the License for the specific language governing permissions and
-                                                                * limitations under the License.
-                                                                */
+  const resource = (0, _I18n2.default)('erpShipToAccountsEdit'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipToAccounts.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipToAccounts.Edit', [_Edit2.default], {
     // View Properties
     id: 'erpshiptoaccount_edit',
     detailView: 'erpshiptoaccount_detail',

--- a/src-out/Integrations/BOE/Views/ERPShipToAccounts/List.js
+++ b/src-out/Integrations/BOE/Views/ERPShipToAccounts/List.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPShipToAccounts/List', ['module', 'exports'
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpShipToAccountsList');
+  const resource = (0, _I18n2.default)('erpShipToAccountsList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipToAccounts.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipToAccounts.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.ErpShipTo.Name %}</p>', '<p class="micro-text address">{%: $.ErpShipTo.Address.FullAddress %}</p>']),
 
@@ -69,7 +69,7 @@ define('crm/Integrations/BOE/Views/ERPShipToAccounts/List', ['module', 'exports'
     itemIconClass: 'warehouse',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(ErpShipTo.Name) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(ErpShipTo.Name) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPShipTos/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPShipTos/Detail.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Detail', ['module', 'exports', 'do
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpShipTosDetail');
+  const resource = (0, _I18n2.default)('erpShipTosDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipTos.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipTos.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     relatedItemsText: resource.relatedItemsText,
@@ -139,56 +139,56 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Detail', ['module', 'exports', 'do
           name: 'Accounts',
           label: this.accountsText,
           where: function where(entry) {
-            return 'ErpShipToAccounts.ErpShipTo.Id eq "' + entry.$key + '"';
+            return `ErpShipToAccounts.ErpShipTo.Id eq "${entry.$key}"`;
           },
           view: 'shipto_accounts_related'
         }, {
           name: 'BillTos',
           label: this.billToText,
-          where: function where(entry) {
-            return 'ErpBillToShipTos.ErpShipTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpBillToShipTos.ErpShipTo.Id eq "${entry.$key}"`;
           },
           view: 'shipto_billtos_related'
         }, {
           name: 'Quotes',
           label: this.quotesText,
-          where: function where(entry) {
-            return 'ShipTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ShipTo.Id eq "${entry.$key}"`;
           },
           view: 'shipto_quotes_related'
         }, {
           name: 'SalesOrders',
           label: this.salesOrdersText,
-          where: function where(entry) {
-            return 'ErpShipTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpShipTo.Id eq "${entry.$key}"`;
           },
           view: 'shipto_orders_related'
         }, {
           name: 'Receivables',
           label: this.receivablesText,
-          where: function where(entry) {
-            return 'ErpShipTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpShipTo.Id eq "${entry.$key}"`;
           },
           view: 'shipto_receivables_related'
         }, {
           name: 'Invoices',
           label: this.invoicesText,
-          where: function where(entry) {
-            return 'ErpShipTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpShipTo.Id eq "${entry.$key}"`;
           },
           view: 'shipto_invoices_related'
         }, {
           name: 'Returns',
           label: this.returnsText,
-          where: function where(entry) {
-            return 'ErpShipTo.Id eq "' + entry.$key + '"';
+          where: entry => {
+            return `ErpShipTo.Id eq "${entry.$key}"`;
           },
           view: 'shipto_returns_related'
         }, {
           name: 'SyncHistory',
           label: this.syncHistoryText,
-          where: function where(entry) {
-            return 'EntityType eq "ERPShipTo" and EntityId eq "' + entry.$key + '"';
+          where: entry => {
+            return `EntityType eq "ERPShipTo" and EntityId eq "${entry.$key}"`;
           },
           view: 'shipto_synchistory_related'
         }]

--- a/src-out/Integrations/BOE/Views/ERPShipTos/Edit.js
+++ b/src-out/Integrations/BOE/Views/ERPShipTos/Edit.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Edit', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpShipTosEdit');
+  const resource = (0, _I18n2.default)('erpShipTosEdit');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipTos.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipTos.Edit', [_Edit2.default], {
     // View Properties
     id: 'erpshipto_edit',
     detailView: 'erpshipto_detail',
@@ -76,18 +76,18 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Edit', ['module', 'exports', 'dojo
     },
     applyContext: function applyContext() {
       this.inherited(applyContext, arguments);
-      var found = this._getNavContext();
+      const found = this._getNavContext();
 
-      var context = found && found.options && found.options.source || found;
-      var lookup = {
+      const context = found && found.options && found.options.source || found;
+      const lookup = {
         accounts: this.applyAccountContext,
         quotes: this.applyQuoteContext,
         salesOrders: this.applyOrderContext
       };
 
       if (context && lookup[context.resourceKind]) {
-        var view = App.getView(context.id);
-        var entry = context.entry || view && view.entry || context;
+        const view = App.getView(context.id);
+        const entry = context.entry || view && view.entry || context;
 
         if (!entry || !entry.$key) {
           return;
@@ -144,14 +144,14 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Edit', ['module', 'exports', 'dojo
         App.bars.tbar.enableTool('save');
       }
 
-      var message = this._buildRefreshMessage(entry, result);
+      const message = this._buildRefreshMessage(entry, result);
       _connect2.default.publish('/app/refresh', [message]);
 
       this.onInsertCompleted(result);
     },
     onInsertCompleted: function onInsertCompleted(results) {
       if (this.associationView) {
-        var view = App.getView(this.associationView);
+        const view = App.getView(this.associationView);
         if (view) {
           view.inserting = true;
           view.options = {
@@ -169,8 +169,8 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Edit', ['module', 'exports', 'dojo
       this.associationContext = null;
     },
     _getNavContext: function _getNavContext() {
-      var navContext = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      const navContext = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
 
         if (/^(accounts|quotes|salesOrders)$/.test(context.resourceKind) && context.key) {
           return true;
@@ -215,8 +215,8 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Edit', ['module', 'exports', 'dojo
           requireSelection: false,
           dependsOn: 'ErpLogicalId',
           storageMode: 'code',
-          where: function where(logicalId) {
-            return 'filter eq "' + logicalId + '"';
+          where: logicalId => {
+            return `filter eq "${logicalId}"`;
           }
         }, {
           label: this.statusText,
@@ -236,8 +236,8 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Edit', ['module', 'exports', 'dojo
           type: 'picklist',
           storageMode: 'code',
           dependsOn: 'ErpLogicalId',
-          where: function where(logicalId) {
-            return 'filter eq "' + logicalId + '"';
+          where: logicalId => {
+            return `filter eq "${logicalId}"`;
           }
         }, {
           label: this.paymentMethodText,
@@ -249,8 +249,8 @@ define('crm/Integrations/BOE/Views/ERPShipTos/Edit', ['module', 'exports', 'dojo
           type: 'picklist',
           storageMode: 'code',
           dependsOn: 'ErpLogicalId',
-          where: function where(logicalId) {
-            return 'filter eq "' + logicalId + '"';
+          where: logicalId => {
+            return `filter eq "${logicalId}"`;
           }
         }, {
           emptyText: '',

--- a/src-out/Integrations/BOE/Views/ERPShipTos/List.js
+++ b/src-out/Integrations/BOE/Views/ERPShipTos/List.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPShipTos/List', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpShipTosList');
+  const resource = (0, _I18n2.default)('erpShipTosList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ErpShipTos.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ErpShipTos.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Name %}</p>', '<p class="micro-text address">{%: $.Address.FullAddress %}</p>']),
 
@@ -69,8 +69,8 @@ define('crm/Integrations/BOE/Views/ERPShipTos/List', ['module', 'exports', 'dojo
     itemIconClass: '',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Name) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Name) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPShipmentItems/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPShipmentItems/Detail.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/ERPShipmentItems/Detail', ['module', 'exports
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpShipmentItemsDetail');
+  const resource = (0, _I18n2.default)('erpShipmentItemsDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipmentItems.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipmentItems.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     actionsText: resource.actionsText,

--- a/src-out/Integrations/BOE/Views/ERPShipmentItems/List.js
+++ b/src-out/Integrations/BOE/Views/ERPShipmentItems/List.js
@@ -40,9 +40,9 @@ define('crm/Integrations/BOE/Views/ERPShipmentItems/List', ['module', 'exports',
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('erpShipmentItemsList');
+  const resource = (0, _I18n2.default)('erpShipmentItemsList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipmentItems.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipmentItems.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     formatter: _Format2.default,
 
     // Templates
@@ -68,8 +68,8 @@ define('crm/Integrations/BOE/Views/ERPShipmentItems/List', ['module', 'exports',
     itemIconClass: 'warehouse',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ErpLineNumber) like "' + q + '%" or upper(SalesOrder.SalesOrderNumber) like "' + q + '%" or upper(ProductName) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ErpLineNumber) like "${q}%" or upper(SalesOrder.SalesOrderNumber) like "${q}%" or upper(ProductName) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/ERPShipments/Detail.js
+++ b/src-out/Integrations/BOE/Views/ERPShipments/Detail.js
@@ -23,22 +23,22 @@ define('crm/Integrations/BOE/Views/ERPShipments/Detail', ['module', 'exports', '
     };
   }
 
-  var resource = (0, _I18n2.default)('erpShipmentsDetail'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('erpShipmentsDetail'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipments.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipments.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     actionsText: resource.actionsText,
@@ -70,8 +70,6 @@ define('crm/Integrations/BOE/Views/ERPShipments/Detail', ['module', 'exports', '
     enableOffline: true,
 
     createLayout: function createLayout() {
-      var _this = this;
-
       return this.layout || (this.layout = [{
         title: this.actionsText,
         list: true,
@@ -165,22 +163,22 @@ define('crm/Integrations/BOE/Views/ERPShipments/Detail', ['module', 'exports', '
           name: 'DeclaredValue',
           property: 'ErpDeclaredValue',
           label: this.declaredValueText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'ShipmentTotalBaseAmount',
           property: 'ShipmentTotalBaseAmount',
           label: this.shipmentTotalBaseAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           name: 'ShipmentTotalAmount',
           property: 'ShipmentTotalAmount',
           label: this.shipmentTotalAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'PaymentTerm',
@@ -210,7 +208,7 @@ define('crm/Integrations/BOE/Views/ERPShipments/Detail', ['module', 'exports', '
           name: 'ShipmentLines',
           label: this.shipmentLinesText,
           where: function where(entry) {
-            return 'ErpShipment.Id eq "' + entry.$key + '"';
+            return `ErpShipment.Id eq "${entry.$key}"`;
           },
           view: 'shipment_lines_related'
         }]

--- a/src-out/Integrations/BOE/Views/ERPShipments/List.js
+++ b/src-out/Integrations/BOE/Views/ERPShipments/List.js
@@ -31,22 +31,22 @@ define('crm/Integrations/BOE/Views/ERPShipments/List', ['module', 'exports', 'do
     };
   }
 
-  var resource = (0, _I18n2.default)('erpShipmentsList'); /* Copyright 2017 Infor
-                                                           *
-                                                           * Licensed under the Apache License, Version 2.0 (the "License");
-                                                           * you may not use this file except in compliance with the License.
-                                                           * You may obtain a copy of the License at
-                                                           *
-                                                           *    http://www.apache.org/licenses/LICENSE-2.0
-                                                           *
-                                                           * Unless required by applicable law or agreed to in writing, software
-                                                           * distributed under the License is distributed on an "AS IS" BASIS,
-                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                           * See the License for the specific language governing permissions and
-                                                           * limitations under the License.
-                                                           */
+  const resource = (0, _I18n2.default)('erpShipmentsList'); /* Copyright 2017 Infor
+                                                             *
+                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                             * you may not use this file except in compliance with the License.
+                                                             * You may obtain a copy of the License at
+                                                             *
+                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                             *
+                                                             * Unless required by applicable law or agreed to in writing, software
+                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                             * See the License for the specific language governing permissions and
+                                                             * limitations under the License.
+                                                             */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipments.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.ERPShipments.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     formatter: _Format2.default,
     util: _Utility2.default,
 
@@ -98,8 +98,8 @@ define('crm/Integrations/BOE/Views/ERPShipments/List', ['module', 'exports', 'do
     },
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Account.AccountName) like "' + q + '%" or upper(ErpExtId) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Account.AccountName) like "${q}%" or upper(ErpExtId) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/Locations/List.js
+++ b/src-out/Integrations/BOE/Views/Locations/List.js
@@ -19,22 +19,22 @@ define('crm/Integrations/BOE/Views/Locations/List', ['module', 'exports', 'dojo/
     };
   }
 
-  var resource = (0, _I18n2.default)('locationsList'); /* Copyright 2017 Infor
-                                                        *
-                                                        * Licensed under the Apache License, Version 2.0 (the "License");
-                                                        * you may not use this file except in compliance with the License.
-                                                        * You may obtain a copy of the License at
-                                                        *
-                                                        *    http://www.apache.org/licenses/LICENSE-2.0
-                                                        *
-                                                        * Unless required by applicable law or agreed to in writing, software
-                                                        * distributed under the License is distributed on an "AS IS" BASIS,
-                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                        * See the License for the specific language governing permissions and
-                                                        * limitations under the License.
-                                                        */
+  const resource = (0, _I18n2.default)('locationsList'); /* Copyright 2017 Infor
+                                                          *
+                                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                                          * you may not use this file except in compliance with the License.
+                                                          * You may obtain a copy of the License at
+                                                          *
+                                                          *    http://www.apache.org/licenses/LICENSE-2.0
+                                                          *
+                                                          * Unless required by applicable law or agreed to in writing, software
+                                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                          * See the License for the specific language governing permissions and
+                                                          * limitations under the License.
+                                                          */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Locations.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Locations.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">{%: $.Name %}</p>', '<p class="listview-heading">{%: $.Description %}</p>', '<p class="micro-text">{%: $.ErpStatus %}</p>']),
 
@@ -59,8 +59,8 @@ define('crm/Integrations/BOE/Views/Locations/List', ['module', 'exports', 'dojo/
       return this.tools || (this.tools = {});
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Description) like "' + q + '%" or upper(ErpLogicalId) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Description) like "${q}%" or upper(ErpLogicalId) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/Locations/PricingAvailabilityList.js
+++ b/src-out/Integrations/BOE/Views/Locations/PricingAvailabilityList.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/Locations/PricingAvailabilityList', ['module'
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('locationsPricingAvailabilityList');
+  const resource = (0, _I18n2.default)('locationsPricingAvailabilityList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Locations.PricingAvailabilityList', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Locations.PricingAvailabilityList', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text"><label class="group-label">{%: $$.warehouseText %}: </label>{%: $.SlxLocation %}</p>', '<p class="listview-heading"><label class="group-label">{%: $$.availableToPromiseDateText %}: </label>{%: $$.formatATPDate($.ATPDate) %}</p>', '<p class="listview-heading"><label class="group-label">{%: $$.availableText %}: </label>{%: $.AvailableQuantity %}</p>', '<p class="micro-text">{%: $.UnitOfMeasure %}</p>']),
 
@@ -93,16 +93,16 @@ define('crm/Integrations/BOE/Views/Locations/PricingAvailabilityList', ['module'
       this.options.singleSelectAction = 'complete';
     },
     onSelectWarehouse: function onSelectWarehouse() {
-      var selection = this.getSelectedWarehouse();
-      this.processWarehouse(selection).then(function () {
+      const selection = this.getSelectedWarehouse();
+      this.processWarehouse(selection).then(() => {
         ReUI.back();
       });
     },
     getSelectedWarehouse: function getSelectedWarehouse() {
-      var selections = this.get('selectionModel').getSelections();
-      var selection = null;
+      const selections = this.get('selectionModel').getSelections();
+      let selection = null;
       if (this.options.singleSelect) {
-        for (var selectionKey in selections) {
+        for (const selectionKey in selections) {
           if (selections.hasOwnProperty(selectionKey)) {
             selection = selections[selectionKey].data;
             break;
@@ -112,13 +112,13 @@ define('crm/Integrations/BOE/Views/Locations/PricingAvailabilityList', ['module'
       return selection;
     },
     processWarehouse: function processWarehouse(warehouse) {
-      var promise = new Promise(function (resolve) {
+      const promise = new Promise(resolve => {
         resolve(warehouse);
       });
       return promise;
     },
     getAvailability: function getAvailability() {
-      var promise = new Promise(function (resolve) {
+      const promise = new Promise(resolve => {
         resolve([]);
       });
       return promise;
@@ -128,16 +128,14 @@ define('crm/Integrations/BOE/Views/Locations/PricingAvailabilityList', ['module'
       this.inherited(onTransitionAway, arguments);
     },
     requestData: function requestData() {
-      var _this = this;
-
-      this.getAvailability().then(function (entries) {
-        _this._onQueryComplete({ total: entries.length ? entries.length : 0 }, entries);
-      }, function () {
-        _this._onQueryComplete({ total: 0 }, []);
+      this.getAvailability().then(entries => {
+        this._onQueryComplete({ total: entries.length ? entries.length : 0 }, entries);
+      }, () => {
+        this._onQueryComplete({ total: 0 }, []);
       });
     },
     formatATPDate: function formatATPDate(atpDate) {
-      var value = '';
+      let value = '';
       if (_Convert2.default.isDateString(atpDate)) {
         value = _Convert2.default.toDateFromString(atpDate);
         return _Format2.default.date(value);
@@ -145,7 +143,7 @@ define('crm/Integrations/BOE/Views/Locations/PricingAvailabilityList', ['module'
       return value;
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(Description) like "' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(Description) like "${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/Locations/QuoteItemAvailabilityList.js
+++ b/src-out/Integrations/BOE/Views/Locations/QuoteItemAvailabilityList.js
@@ -19,28 +19,24 @@ define('crm/Integrations/BOE/Views/Locations/QuoteItemAvailabilityList', ['modul
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Locations.QuoteItemAvailabilityList', [_PricingAvailabilityList2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Locations.QuoteItemAvailabilityList', [_PricingAvailabilityList2.default], {
     // View Properties
     id: 'locations_quoteItemAvailabilityList',
     modelName: _Names2.default.QUOTEITEM,
     processWarehouse: function processWarehouse(warehouse) {
-      var _this = this;
-
-      var promise = new Promise(function (resolve) {
-        _this._model.updateItemWithWarehouse(_this.options.quoteItem, warehouse).then(function (result) {
+      const promise = new Promise(resolve => {
+        this._model.updateItemWithWarehouse(this.options.quoteItem, warehouse).then(result => {
           resolve(result);
         });
       });
       return promise;
     },
     getAvailability: function getAvailability() {
-      var _this2 = this;
-
-      var promise = new Promise(function (resolve) {
-        if (_this2.options && _this2.options.quoteItem) {
-          _PricingAvailabilityService2.default.getQuoteItemAvailability(_this2.options.quoteItem).then(function (entries) {
+      const promise = new Promise(resolve => {
+        if (this.options && this.options.quoteItem) {
+          _PricingAvailabilityService2.default.getQuoteItemAvailability(this.options.quoteItem).then(entries => {
             resolve(entries);
-          }, function () {
+          }, () => {
             resolve([]);
           });
         }

--- a/src-out/Integrations/BOE/Views/Locations/SalesOrderItemAvailabilityList.js
+++ b/src-out/Integrations/BOE/Views/Locations/SalesOrderItemAvailabilityList.js
@@ -19,28 +19,24 @@ define('crm/Integrations/BOE/Views/Locations/SalesOrderItemAvailabilityList', ['
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Locations.SalesOrderItemAvailabilityList', [_PricingAvailabilityList2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Locations.SalesOrderItemAvailabilityList', [_PricingAvailabilityList2.default], {
     // View Properties
     id: 'locations_salesOrderItemAvailabilityList',
     modelName: _Names2.default.SALESORDERITEM,
     processWarehouse: function processWarehouse(warehouse) {
-      var _this = this;
-
-      var promise = new Promise(function (resolve) {
-        _this._model.updateItemWithWarehouse(_this.options.orderItem, warehouse).then(function (result) {
+      const promise = new Promise(resolve => {
+        this._model.updateItemWithWarehouse(this.options.orderItem, warehouse).then(result => {
           resolve(result);
         });
       });
       return promise;
     },
     getAvailability: function getAvailabilityy() {
-      var _this2 = this;
-
-      var promise = new Promise(function (resolve) {
-        if (_this2.options && _this2.options.orderItem) {
-          _PricingAvailabilityService2.default.getOrderItemAvailability(_this2.options.orderItem).then(function (entries) {
+      const promise = new Promise(resolve => {
+        if (this.options && this.options.orderItem) {
+          _PricingAvailabilityService2.default.getOrderItemAvailability(this.options.orderItem).then(entries => {
             resolve(entries);
-          }, function () {
+          }, () => {
             resolve([]);
           });
         }

--- a/src-out/Integrations/BOE/Views/Products/List.js
+++ b/src-out/Integrations/BOE/Views/Products/List.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/Products/List', ['module', 'exports', 'dojo/_
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('productsList');
+  const resource = (0, _I18n2.default)('productsList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Products.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Products.List', [_List2.default], {
     formatter: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Name %}</p>', '{% if ($.Description) { %}', '<p class="micro-text">{%: $.Description %}</p>', '{% } %}', '{% if ($.Family) { %}', '<p class="micro-text"><label class="group-label">{%: $$.familyText %}</label> {%: $.Family %}</p>', '{% } %}', '{% if ($.Status) { %}', '<p class="micro-text"><label class="group-label">{%: $$.statusText %}</label> {%: $.Status %}</p>', '{% } %}', '{% if ($.Price) { %}', '<p class="micro-text"><label class="group-label">{%: $$.priceText %} </label>', '{% if (App.hasMultiCurrency() && $.CurrencyCode) { %}', '{%: $$.formatter.multiCurrency($.Price, $.CurrencyCode) %}', '{% } else { %}', '{%: $$.formatter.currency($.Price) %} ', '{% } %}</p>', '{% } %}']),
@@ -69,8 +69,8 @@ define('crm/Integrations/BOE/Views/Products/List', ['module', 'exports', 'dojo/_
       return this.tools || (this.tools = {});
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Name) like "' + q + '%" or upper(Family) like "' + q + '%" or ActualId like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Name) like "${q}%" or upper(Family) like "${q}%" or ActualId like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/QuoteLines/Detail.js
+++ b/src-out/Integrations/BOE/Views/QuoteLines/Detail.js
@@ -27,47 +27,23 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
     };
   }
 
-  var _slicedToArray = function () {
-    function sliceIterator(arr, i) {
-      var _arr = [];
-      var _n = true;
-      var _d = false;
-      var _e = undefined;
+  const resource = (0, _I18n2.default)('quoteItemsDetail'); /* Copyright 2017 Infor
+                                                             *
+                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                             * you may not use this file except in compliance with the License.
+                                                             * You may obtain a copy of the License at
+                                                             *
+                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                             *
+                                                             * Unless required by applicable law or agreed to in writing, software
+                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                             * See the License for the specific language governing permissions and
+                                                             * limitations under the License.
+                                                             */
 
-      try {
-        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-          _arr.push(_s.value);
 
-          if (i && _arr.length === i) break;
-        }
-      } catch (err) {
-        _d = true;
-        _e = err;
-      } finally {
-        try {
-          if (!_n && _i["return"]) _i["return"]();
-        } finally {
-          if (_d) throw _e;
-        }
-      }
-
-      return _arr;
-    }
-
-    return function (arr, i) {
-      if (Array.isArray(arr)) {
-        return arr;
-      } else if (Symbol.iterator in Object(arr)) {
-        return sliceIterator(arr, i);
-      } else {
-        throw new TypeError("Invalid attempt to destructure non-iterable instance");
-      }
-    };
-  }();
-
-  var resource = (0, _I18n2.default)('quoteItemsDetail');
-
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.QuoteLines.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.QuoteLines.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     lineText: resource.lineText,
@@ -106,7 +82,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
     enableOffline: true,
 
     createEntryForDelete: function createEntryForDelete(e) {
-      var entry = {
+      const entry = {
         $key: e.$key,
         $etag: e.$etag,
         $name: e.$name
@@ -123,47 +99,39 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
       }
     },
     removeQuoteLine: function removeQuoteLine() {
-      var _this = this;
-
       // TODO: [INFORCRM-7712] Implement this in the model (model needs remove call)
       App.modal.createSimpleDialog({
         title: 'alert',
         content: this.confirmDeleteText,
-        getContent: function getContent() {}
-      }).then(function () {
-        var entry = _this.createEntryForDelete(_this.entry);
-        var request = _this.store._createEntryRequest(_this.entry.$key, {});
+        getContent: () => {}
+      }).then(() => {
+        const entry = this.createEntryForDelete(this.entry);
+        const request = this.store._createEntryRequest(this.entry.$key, {});
 
         if (request) {
           request.delete(entry, {
-            success: _this.onDeleteSuccess,
-            failure: _this.onRequestDataFailure,
-            scope: _this
+            success: this.onDeleteSuccess,
+            failure: this.onRequestDataFailure,
+            scope: this
           });
         }
       });
     },
     onAvailability: function onAvailability() {
-      var _this2 = this;
-
-      _PricingAvailabilityService2.default.getQuoteItemAvailability(this.entry).then(function (result) {
-        var _result = _slicedToArray(result, 1),
-            warehouse = _result[0];
-
-        var ErrorCode = warehouse.ErrorCode,
-            AvailableQuantity = warehouse.AvailableQuantity;
-
+      _PricingAvailabilityService2.default.getQuoteItemAvailability(this.entry).then(result => {
+        const [warehouse] = result;
+        const { ErrorCode, AvailableQuantity } = warehouse;
         if (ErrorCode) {
           App.modal.createSimpleAlert({ title: ErrorCode });
         } else if (AvailableQuantity) {
-          App.modal.createSimpleAlert({ title: _this2.availableQuantityText + AvailableQuantity });
+          App.modal.createSimpleAlert({ title: this.availableQuantityText + AvailableQuantity });
         }
       });
     },
     onDeleteSuccess: function onDeleteSuccess() {
-      var views = [App.getView('quote_lines_related'), App.getView('quote_detail'), App.getView('quote_list')];
+      const views = [App.getView('quote_lines_related'), App.getView('quote_detail'), App.getView('quote_list')];
 
-      views.forEach(function (view) {
+      views.forEach(view => {
         if (view) {
           view.refreshRequired = true;
         }
@@ -185,7 +153,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
       if (this.tools) {
         return this.tools;
       }
-      var tools = this.inherited(createToolLayout, arguments);
+      const tools = this.inherited(createToolLayout, arguments);
       if (tools && tools.tbar) {
         tools.tbar.push({
           id: 'removeQuoteLine',
@@ -198,10 +166,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
       return tools;
     },
     createLayout: function createLayout() {
-      var _this3 = this;
-
-      var _App$getBaseExchangeR = App.getBaseExchangeRate(),
-          baseCurrencyCode = _App$getBaseExchangeR.code;
+      const { code: baseCurrencyCode } = App.getBaseExchangeRate();
 
       return this.layout || (this.layout = [{
         title: this.actionsText,
@@ -214,7 +179,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
           label: this.checkWarehouseAvailabilityText,
           iconClass: 'redo', // check for a better icon
           action: 'onAvailability',
-          disabled: function disabled() {
+          disabled: () => {
             return App.warehouseDiscovery === 'auto';
           },
           security: 'Entities/SalesOrder/Add'
@@ -248,33 +213,31 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
           name: 'Price',
           property: 'Price',
           label: this.priceText,
-          renderer: function renderer(value) {
-            var code = _this3.entry.Quote.BaseCurrencyCode || baseCurrencyCode;
+          renderer: value => {
+            const code = this.entry.Quote.BaseCurrencyCode || baseCurrencyCode;
             return _Utility2.default.formatMultiCurrency(value, code);
           }
         }, {
           name: 'Discount',
           property: 'Discount',
           label: this.discountText,
-          renderer: function renderer(value) {
-            var code = _this3.entry.Quote.BaseCurrencyCode || baseCurrencyCode;
+          renderer: value => {
+            const code = this.entry.Quote.BaseCurrencyCode || baseCurrencyCode;
             return _Utility2.default.formatMultiCurrency(value, code);
           }
         }, {
           name: 'CalculatedPrice',
           property: 'CalculatedPrice',
           label: this.baseAdjustedPriceText,
-          renderer: function renderer(value) {
-            var code = _this3.entry.Quote.BaseCurrencyCode || baseCurrencyCode;
+          renderer: value => {
+            const code = this.entry.Quote.BaseCurrencyCode || baseCurrencyCode;
             return _Utility2.default.formatMultiCurrency(value, code);
           }
         }, {
           name: 'DocCalculatedPrice',
           property: 'DocCalculatedPrice',
           label: this.adjustedPriceText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this3.entry.Quote.CurrencyCode);
-          }
+          renderer: value => _Utility2.default.formatMultiCurrency(value, this.entry.Quote.CurrencyCode)
         }, {
           name: 'Quantity',
           property: 'Quantity',
@@ -296,24 +259,20 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
           label: this.baseExtendedAmountText,
           name: 'ExtendedPrice',
           property: 'ExtendedPrice',
-          renderer: function renderer(value) {
-            var code = _this3.entry.Quote.BaseCurrencyCode || baseCurrencyCode;
+          renderer: value => {
+            const code = this.entry.Quote.BaseCurrencyCode || baseCurrencyCode;
             return _Utility2.default.formatMultiCurrency(value, code);
           }
         }, {
           name: 'DocExtendedPrice',
           property: 'DocExtendedPrice',
           label: this.extendedAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this3.entry.Quote.CurrencyCode);
-          }
+          renderer: value => _Utility2.default.formatMultiCurrency(value, this.entry.Quote.CurrencyCode)
         }, {
           name: 'DocTotalAmount',
           property: 'DocTotalAmount',
           label: this.totalAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this3.entry.Quote.CurrencyCode);
-          }
+          renderer: value => _Utility2.default.formatMultiCurrency(value, this.entry.Quote.CurrencyCode)
         }, {
           name: 'Status',
           property: 'Status',
@@ -340,9 +299,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/Detail', ['module', 'exports', 'do
           name: 'FixedPrice',
           property: 'FixedPrice',
           label: this.fixedPriceText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this3.entry.Quote.CurrencyCode);
-          }
+          renderer: value => _Utility2.default.formatMultiCurrency(value, this.entry.Quote.CurrencyCode)
         }, {
           name: 'RushRequest',
           property: 'RushRequest',

--- a/src-out/Integrations/BOE/Views/QuoteLines/Edit.js
+++ b/src-out/Integrations/BOE/Views/QuoteLines/Edit.js
@@ -44,9 +44,9 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('quoteItemEdit');
+  const resource = (0, _I18n2.default)('quoteItemEdit');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.QuoteLines.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.QuoteLines.Edit', [_Edit2.default], {
     // View Properties
     id: 'quote_line_edit',
     detailView: 'quote_line_detail',
@@ -83,7 +83,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
       this.connect(this.fields.Quantity, 'onChange', this.onQuantityChange);
     },
     _applyLogicValues: function _applyLogicValues(values) {
-      var product = this.fields.Product.getSelection();
+      const product = this.fields.Product.getSelection();
       values.ProductName = product.Name;
       values.Family = product.Family;
       values.ActualId = product.ActualId;
@@ -108,20 +108,18 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
       return ['UnitOfMeasure'];
     },
     setProductDependentFields: function setProductDependentFields(product) {
-      var _this = this;
-
-      var dependants = this.getProductDependants();
+      const dependants = this.getProductDependants();
       if (product) {
-        dependants.forEach(function (f) {
-          _this.fields[f].enable();
-          _this.fields[f].dependsOn = 'Product';
-          _this.fields[f].where = 'Product.Id eq "' + product.$key + '"';
+        dependants.forEach(f => {
+          this.fields[f].enable();
+          this.fields[f].dependsOn = 'Product';
+          this.fields[f].where = `Product.Id eq "${product.$key}"`;
         });
       } else {
-        dependants.forEach(function (f) {
-          _this.fields[f].disable();
-          _this.fields[f].dependsOn = null;
-          _this.fields[f].where = null;
+        dependants.forEach(f => {
+          this.fields[f].disable();
+          this.fields[f].dependsOn = null;
+          this.fields[f].where = null;
         });
       }
     },
@@ -138,9 +136,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
       return entry;
     },
     requestProductPricing: function requestProductPricing(product, quantity, slxLocation, unitOfMeasure) {
-      var _this2 = this;
-
-      var quote = null;
+      let quote = null;
       if (this.options && this.options.context && this.options.context.Quote) {
         quote = this.options.context.Quote;
       } else {
@@ -151,23 +147,21 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
       if (quote && quote.$key && !this.isProcessingPricingRequest) {
         this.isProcessingPricingRequest = true;
         this.enablePricingControls(false);
-        _PricingAvailabilityService2.default.getQuoteItemPricing(this.entry, quote, product, quantity, slxLocation, unitOfMeasure).then(function (results) {
-          _this2.onProductPricingSuccess(results);
-        }, function (error) {
-          _this2.onProductPricingFailed(error);
+        _PricingAvailabilityService2.default.getQuoteItemPricing(this.entry, quote, product, quantity, slxLocation, unitOfMeasure).then(results => {
+          this.onProductPricingSuccess(results);
+        }, error => {
+          this.onProductPricingFailed(error);
         });
       }
     },
     onProductPricingSuccess: function onProductPricingSuccess(result) {
-      var _this3 = this;
-
-      this.processProductPricing(result).then(function () {
-        _this3.reCalculate();
-        _this3.isProcessingPricingRequest = false;
-        _this3.enablePricingControls(true);
-      }, function () {
-        _this3.isProcessingPricingRequest = false;
-        _this3.enablePricingControls(true);
+      this.processProductPricing(result).then(() => {
+        this.reCalculate();
+        this.isProcessingPricingRequest = false;
+        this.enablePricingControls(true);
+      }, () => {
+        this.isProcessingPricingRequest = false;
+        this.enablePricingControls(true);
       });
     },
     onProductPricingFailed: function onProductPricingFailed(result) {
@@ -179,20 +173,18 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
       });
     },
     setUomFromCode: function setUomFromCode(uomCode) {
-      var _this4 = this;
-
-      var curremtUom = this.fields.UnitOfMeasure.getValue();
-      var product = this.fields.Product.getValue();
-      var promise = new Promise(function (resolve, reject) {
-        if (!_this4._uomModel) {
-          _this4._uomModel = App.ModelManager.getModel(_Names2.default.UNITOFMEASURE, _Types2.default.SDATA);
+      const curremtUom = this.fields.UnitOfMeasure.getValue();
+      const product = this.fields.Product.getValue();
+      const promise = new Promise((resolve, reject) => {
+        if (!this._uomModel) {
+          this._uomModel = App.ModelManager.getModel(_Names2.default.UNITOFMEASURE, _Types2.default.SDATA);
         }
-        if (_this4._uomModel && product) {
+        if (this._uomModel && product) {
           if (curremtUom && curremtUom.Name !== uomCode || !curremtUom) {
-            _this4._uomModel.getUnitOfMeasureFromCode(uomCode, product.$key).then(function (uom) {
-              _this4.fields.UnitOfMeasure.setValue(uom);
+            this._uomModel.getUnitOfMeasureFromCode(uomCode, product.$key).then(uom => {
+              this.fields.UnitOfMeasure.setValue(uom);
               resolve(true);
-            }, function (error) {
+            }, error => {
               reject(error);
             });
           } else {
@@ -205,29 +197,27 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
       return promise;
     },
     processProductPricing: function processProductPricing(pricingData) {
-      var _this5 = this;
-
-      var promise = new Promise(function (resolve, reject) {
+      const promise = new Promise((resolve, reject) => {
         if (pricingData) {
           if (pricingData.DocCalculatedPrice) {
-            _this5.fields.DocCalculatedPrice.setValue(pricingData.DocCalculatedPrice.value);
+            this.fields.DocCalculatedPrice.setValue(pricingData.DocCalculatedPrice.value);
           }
           if (pricingData.DocExtendedPrice) {
-            _this5.fields.DocExtendedPrice.setValue(pricingData.DocExtendedPrice.value);
+            this.fields.DocExtendedPrice.setValue(pricingData.DocExtendedPrice.value);
           }
           if (pricingData.DocTotalAmount) {
-            _this5.fields.DocTotalAmount.setValue(pricingData.DocTotalAmount.value);
+            this.fields.DocTotalAmount.setValue(pricingData.DocTotalAmount.value);
           }
           if (pricingData.SlxLocationId) {
-            _this5.fields.SlxLocation.setValue({
+            this.fields.SlxLocation.setValue({
               $key: pricingData.SlxLocationId.value,
               Name: pricingData.SlxLocationCode.value
             });
           }
           if (pricingData.UnitOfMeasure) {
-            _this5.setUomFromCode(pricingData.UnitOfMeasure.value).then(function () {
+            this.setUomFromCode(pricingData.UnitOfMeasure.value).then(() => {
               resolve(true);
-            }, function (error) {
+            }, error => {
               reject(error);
             });
           } else {
@@ -287,8 +277,8 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
       return false;
     },
     reCalculate: function reCalculate() {
-      var price = this.fields.CalculatedPrice.getValue();
-      var quantity = this.fields.Quantity.getValue();
+      const price = this.fields.CalculatedPrice.getValue();
+      const quantity = this.fields.Quantity.getValue();
       this.fields.ExtendedPrice.setValue(quantity * price);
     },
     onUpdateCompleted: function onUpdateCompleted() {
@@ -300,17 +290,15 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
       this.inherited(onInsertCompleted, arguments);
     },
     _refreshRelatedViews: function _refreshRelatedViews() {
-      var views = [App.getView('quote_line_detail'), App.getView('quote_lines_list')];
+      const views = [App.getView('quote_line_detail'), App.getView('quote_lines_list')];
 
-      views.forEach(function (view) {
+      views.forEach(view => {
         if (view) {
           view.refreshRequired = true;
         }
       }, this);
     },
     createLayout: function createLayout() {
-      var _this6 = this;
-
       return this.layout || (this.layout = [{
         title: this.detailsText,
         name: 'DetailsSection',
@@ -338,13 +326,13 @@ define('crm/Integrations/BOE/Views/QuoteLines/Edit', ['module', 'exports', 'dojo
           autoFocus: true,
           required: true,
           validator: _Validator2.default.exists,
-          where: function where() {
-            var logicalIdFromSelection = _this6.fields.Quote.currentSelection && _this6.fields.Quote.currentSelection.ErpLogicalId;
-            var logicalIdFromOptions = _this6.options && _this6.options.context && _this6.options.context.Quote && _this6.options.context.Quote.ErpLogicalId;
-            var logicalIdFromEntry = _this6.entry && _this6.entry.Quote && _this6.entry.Quote.ErpLogicalId;
-            var logicalId = logicalIdFromSelection || logicalIdFromOptions || logicalIdFromEntry;
+          where: () => {
+            const logicalIdFromSelection = this.fields.Quote.currentSelection && this.fields.Quote.currentSelection.ErpLogicalId;
+            const logicalIdFromOptions = this.options && this.options.context && this.options.context.Quote && this.options.context.Quote.ErpLogicalId;
+            const logicalIdFromEntry = this.entry && this.entry.Quote && this.entry.Quote.ErpLogicalId;
+            const logicalId = logicalIdFromSelection || logicalIdFromOptions || logicalIdFromEntry;
             if (logicalId) {
-              return 'ErpLogicalId eq "' + logicalId + '"';
+              return `ErpLogicalId eq "${logicalId}"`;
             }
             return null;
           }

--- a/src-out/Integrations/BOE/Views/QuoteLines/List.js
+++ b/src-out/Integrations/BOE/Views/QuoteLines/List.js
@@ -31,22 +31,22 @@ define('crm/Integrations/BOE/Views/QuoteLines/List', ['module', 'exports', 'dojo
     };
   }
 
-  var resource = (0, _I18n2.default)('quoteItemsList'); /* Copyright 2017 Infor
-                                                         *
-                                                         * Licensed under the Apache License, Version 2.0 (the "License");
-                                                         * you may not use this file except in compliance with the License.
-                                                         * You may obtain a copy of the License at
-                                                         *
-                                                         *    http://www.apache.org/licenses/LICENSE-2.0
-                                                         *
-                                                         * Unless required by applicable law or agreed to in writing, software
-                                                         * distributed under the License is distributed on an "AS IS" BASIS,
-                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                         * See the License for the specific language governing permissions and
-                                                         * limitations under the License.
-                                                         */
+  const resource = (0, _I18n2.default)('quoteItemsList'); /* Copyright 2017 Infor
+                                                           *
+                                                           * Licensed under the Apache License, Version 2.0 (the "License");
+                                                           * you may not use this file except in compliance with the License.
+                                                           * You may obtain a copy of the License at
+                                                           *
+                                                           *    http://www.apache.org/licenses/LICENSE-2.0
+                                                           *
+                                                           * Unless required by applicable law or agreed to in writing, software
+                                                           * distributed under the License is distributed on an "AS IS" BASIS,
+                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                           * See the License for the specific language governing permissions and
+                                                           * limitations under the License.
+                                                           */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.QuoteLines.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.QuoteLines.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     formatter: _Format2.default,
     util: _Utility2.default,
     // Localization
@@ -88,7 +88,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/List', ['module', 'exports', 'dojo
     readOnly: false,
 
     transitionTo: function transitionTo() {
-      var entry = this.options && this.options.fromContext && this.options.fromContext.entry;
+      const entry = this.options && this.options.fromContext && this.options.fromContext.entry;
       if (entry && entry.IsClosed) {
         if (App.bars && App.bars.tbar) {
           App.bars.tbar.disableTool('new');
@@ -102,7 +102,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/List', ['module', 'exports', 'dojo
         id: 'assignWarehouse',
         cls: 'warehouse',
         label: this.assignWarehouseText,
-        enabled: function enabled(layoutAction, selection) {
+        enabled: (layoutAction, selection) => {
           return App.warehouseDiscovery === 'auto' && _Action2.default.hasProperty(layoutAction, selection, 'Quote.ErpLogicalId');
         },
         action: 'assignWarehouseAction'
@@ -119,7 +119,7 @@ define('crm/Integrations/BOE/Views/QuoteLines/List', ['module', 'exports', 'dojo
       });
     },
     preNavigateToInsert: function preNavigateToInsert() {
-      var options = {};
+      let options = {};
       if (this.options && this.options.fromContext && this.options.fromContext.entry) {
         options = {
           context: {
@@ -130,19 +130,19 @@ define('crm/Integrations/BOE/Views/QuoteLines/List', ['module', 'exports', 'dojo
       this.navigateToInsertView(options);
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Description) like "' + q + '%") or (upper(ProductName) like "' + q + '%") or (upper(Quote.QuoteNumber) like "' + q + '%") or (upper(ErpLineNumber) like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Description) like "${q}%") or (upper(ProductName) like "${q}%") or (upper(Quote.QuoteNumber) like "${q}%") or (upper(ErpLineNumber) like "${q}%")`;
     },
     assignWarehouseAction: function assignWarehouseAction(theAction, selection) {
-      var quote = this.options.fromContext.entry;
-      var quoteItemKey = selection.tag.attributes['data-key'].value;
-      var quoteItem = this.entries[quoteItemKey];
+      const quote = this.options.fromContext.entry;
+      const quoteItemKey = selection.tag.attributes['data-key'].value;
+      const quoteItem = this.entries[quoteItemKey];
       if (quoteItem) {
-        var view = this.getAvailabilityView();
+        const view = this.getAvailabilityView();
         if (view) {
-          var options = {
-            quoteItem: quoteItem,
-            quote: quote
+          const options = {
+            quoteItem,
+            quote
           };
           this.refreshRequired = true;
           view.show(options);
@@ -150,8 +150,8 @@ define('crm/Integrations/BOE/Views/QuoteLines/List', ['module', 'exports', 'dojo
       }
     },
     getAvailabilityView: function getAvailabilityView() {
-      var viewId = 'locations_quoteItemAvailabilityList';
-      var view = App.getView(viewId);
+      const viewId = 'locations_quoteItemAvailabilityList';
+      let view = App.getView(viewId);
       if (view) {
         return view;
       }

--- a/src-out/Integrations/BOE/Views/QuotePersons/List.js
+++ b/src-out/Integrations/BOE/Views/QuotePersons/List.js
@@ -27,22 +27,22 @@ define('crm/Integrations/BOE/Views/QuotePersons/List', ['module', 'exports', 'do
     };
   }
 
-  var resource = (0, _I18n2.default)('quotePersonList'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('quotePersonList'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.QuotePersons.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.QuotePersons.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     formatter: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text"><label class="group-label">{%: $$.personNameText %}</label> {%: $.Person.Name %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.quoteNumberText %}</label> {%: $.Quote.QuoteNumber %}</p>']),
@@ -73,8 +73,8 @@ define('crm/Integrations/BOE/Views/QuotePersons/List', ['module', 'exports', 'do
     entityName: 'Quote Person',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Quote.QuoteNumber) like "' + q + '%" or upper(Person.Name) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Quote.QuoteNumber) like "${q}%" or upper(Person.Name) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/Quotes/Detail.js
+++ b/src-out/Integrations/BOE/Views/Quotes/Detail.js
@@ -44,9 +44,9 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('quoteDetail');
+  const resource = (0, _I18n2.default)('quoteDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Quotes.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Quotes.Detail', [_Detail2.default], {
     // View Properties
     id: 'quote_detail',
     editView: 'quote_edit',
@@ -121,68 +121,64 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
       }
     },
     _canPromote: function _canPromote() {
-      var _this = this;
-
-      var promise = new Promise(function (resolve) {
-        _this.showBusy();
-        var entry = {
+      const promise = new Promise(resolve => {
+        this.showBusy();
+        const entry = {
           $name: 'CanPromoteQuote',
           request: {
-            quoteId: _this.entry.$key
+            quoteId: this.entry.$key
           }
         };
-        var request = new Sage.SData.Client.SDataServiceOperationRequest(_this.getService()).setResourceKind('quotes').setContractName('dynamic').setOperationName('CanPromoteQuote');
+        const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind('quotes').setContractName('dynamic').setOperationName('CanPromoteQuote');
 
-        var canPromote = {
+        const canPromote = {
           value: false,
           result: ''
         };
 
         request.execute(entry, {
-          success: function success(result) {
+          success: result => {
             canPromote.value = result.response.Result;
             resolve(canPromote);
           },
-          failure: function failure(err) {
-            var response = JSON.parse(err.response)[0];
+          failure: err => {
+            const response = JSON.parse(err.response)[0];
             canPromote.result = response.message;
             resolve(canPromote);
           },
-          scope: _this
+          scope: this
         });
       });
 
       return promise;
     },
     _convertToSalesOrder: function _convertToSalesOrder() {
-      var _this2 = this;
-
       this.showBusy();
-      var convertQuoteEntry = {
+      const convertQuoteEntry = {
         $name: 'ConvertQuoteToOrder',
         request: {
           QuoteId: this.entry.$key
         }
       };
 
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind('quotes').setContractName('dynamic').setOperationName('ConvertQuoteToOrder');
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind('quotes').setContractName('dynamic').setOperationName('ConvertQuoteToOrder');
 
       request.execute(convertQuoteEntry, {
-        success: function success(result) {
-          _this2.hideBusy();
-          _this2.refreshRequired = true;
-          var view = App.getView('salesorder_detail');
-          var options = {
+        success: result => {
+          this.hideBusy();
+          this.refreshRequired = true;
+          const view = App.getView('salesorder_detail');
+          const options = {
             key: result.response.Result,
-            fromContext: _this2
+            fromContext: this
           };
           if (view) {
             view.show(options);
           }
         },
-        failure: function failure(err) {
-          _this2.hideBusy();
-          var options = {
+        failure: err => {
+          this.hideBusy();
+          const options = {
             title: 'alert',
             content: err.statusText,
             getContent: null
@@ -212,30 +208,28 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
       }
     },
     addLineItems: function addLineItems() {
-      var _this3 = this;
-
       if (!this.entry.ErpLogicalId) {
         App.modal.createSimpleDialog({
           title: 'alert',
           content: this.accountingEntityRequiredText,
-          getContent: function getContent() {
+          getContent: () => {
             return;
           }
-        }).then(function () {
-          _this3.navigateToEditView();
+        }).then(() => {
+          this.navigateToEditView();
         });
         return;
       }
-      var view = App.getView('quote_line_edit');
+      const view = App.getView('quote_line_edit');
       if (view) {
-        var quoteItemView = App.getView('quote_lines_related');
-        var count = 0;
+        const quoteItemView = App.getView('quote_lines_related');
+        let count = 0;
         if (quoteItemView) {
-          quoteItemView.getListCount({ where: 'Quote.$key eq "' + this.entry.$key + '"' }).then(function (result) {
+          quoteItemView.getListCount({ where: `Quote.$key eq "${this.entry.$key}"` }).then(result => {
             count = result;
           });
         }
-        var options = {
+        const options = {
           insert: true,
           context: {
             Quote: this.entry,
@@ -256,7 +250,7 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
         return;
       }
       if (!this.entry.Account.ErpExtId) {
-        var options = {
+        const options = {
           title: 'warning',
           content: resource.needToPromoteAccount,
           getContent: null
@@ -272,8 +266,6 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
       return result;
     },
     onGetOrderTotal: function onGetOrderTotal() {
-      var _this4 = this;
-
       if (this.entry) {
         if (!this.options.context) {
           this.options.context = {
@@ -282,17 +274,15 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
         } else {
           this.options.context.Quote = this.entry;
         }
-        _PricingAvailabilityService2.default.getQuotePricing(this.entry).then(function (result) {
-          _this4.handlePricingSuccess(result);
+        _PricingAvailabilityService2.default.getQuotePricing(this.entry).then(result => {
+          this.handlePricingSuccess(result);
         });
       }
     },
     onRePrice: function onRePrice() {
-      var _this5 = this;
-
       if (this.entry) {
         if (this.isQuoteClosed()) {
-          var options = {
+          const options = {
             title: 'alert',
             content: this.pricingUnavailableText,
             getContent: null
@@ -307,34 +297,32 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
         } else {
           this.options.context.Quote = this.entry;
         }
-        _PricingAvailabilityService2.default.quoteRePrice(this.entry).then(function (result) {
-          _this5.handlePricingSuccess(result);
+        _PricingAvailabilityService2.default.quoteRePrice(this.entry).then(result => {
+          this.handlePricingSuccess(result);
         });
       }
     },
     onPromoteQuote: function onPromoteQuote() {
-      var _this6 = this;
-
-      var canPromotePromise = this._canPromote();
-      canPromotePromise.then(function (val) {
-        _this6.hideBusy();
+      const canPromotePromise = this._canPromote();
+      canPromotePromise.then(val => {
+        this.hideBusy();
         if (!val.value) {
           App.modal.createSimpleDialog({
             title: 'alert',
             content: val.result,
-            getContent: function getContent() {
+            getContent: () => {
               return;
             }
           });
           return;
         }
-        var promote = new _Promote2.default();
-        promote.promoteToBackOffice(_this6.entry, 'Quote', _this6);
+        const promote = new _Promote2.default();
+        promote.promoteToBackOffice(this.entry, 'Quote', this);
       });
     },
     showBusy: function showBusy() {
       if (!this._busyIndicator || this._busyIndicator._destroyed) {
-        this._busyIndicator = new _BusyIndicator2.default({ id: this.id + '-busyIndicator' });
+        this._busyIndicator = new _BusyIndicator2.default({ id: `${this.id}-busyIndicator` });
       }
       this._busyIndicator.start();
       App.modal.disableClose = true;
@@ -345,8 +333,6 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
       return _Format2.default.picklist(this.app.picklistService, this._model, property);
     },
     createLayout: function createLayout() {
-      var _this7 = this;
-
       return this.layout || (this.layout = [{
         title: this.actionsText,
         list: true,
@@ -358,8 +344,8 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
           label: this.convertQuoteText,
           iconClass: 'cart',
           action: 'convertQuote',
-          disabled: function disabled() {
-            return _this7.isQuoteClosed();
+          disabled: () => {
+            return this.isQuoteClosed();
           },
           security: 'Entities/Quote/ConvertToSalesOrder'
         }, {
@@ -513,29 +499,29 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
           name: 'SubTotal',
           property: 'Total',
           label: this.baseSubTotalText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this7.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           name: 'GrandTotal',
           property: 'GrandTotal',
           label: this.baseGrandTotalText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this7.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           name: 'DocSubTotal',
           property: 'DocTotal',
           label: this.subTotalText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this7.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'DocGrandTotal',
           property: 'DocGrandTotal',
           label: this.grandTotalText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this7.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'Comments',
@@ -659,28 +645,28 @@ define('crm/Integrations/BOE/Views/Quotes/Detail', ['module', 'exports', 'dojo/_
           name: 'QuoteLines',
           label: this.quoteLinesText,
           where: function where(entry) {
-            return 'Quote.$key eq "' + entry.$key + '"';
+            return `Quote.$key eq "${entry.$key}"`;
           },
           view: 'quote_lines_related'
         }, {
           name: 'Attachments',
           label: this.attachmentsText,
           where: function where(entry) {
-            return 'quoteId eq "' + entry.$key + '"';
+            return `quoteId eq "${entry.$key}"`;
           },
           view: 'quote_attachments_related'
         }, {
           name: 'QuotePersons',
           label: this.salesPersonsText,
           where: function where(entry) {
-            return 'Quote.Id eq "' + entry.$key + '"';
+            return `Quote.Id eq "${entry.$key}"`;
           },
           view: 'quotepersons_related'
         }, {
           name: 'SyncHistory',
           label: this.syncHistoryText,
-          where: function where(entry) {
-            return 'EntityType eq "Quote" and EntityId eq "' + entry.$key + '"';
+          where: entry => {
+            return `EntityType eq "Quote" and EntityId eq "${entry.$key}"`;
           },
           view: 'quote_syncresult_related'
         }]

--- a/src-out/Integrations/BOE/Views/Quotes/Edit.js
+++ b/src-out/Integrations/BOE/Views/Quotes/Edit.js
@@ -48,11 +48,11 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('quoteEdit');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var dtFormatResource = (0, _I18n2.default)('quoteEditDateTimeFormat');
+  const resource = (0, _I18n2.default)('quoteEdit');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const dtFormatResource = (0, _I18n2.default)('quoteEditDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Quotes.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Quotes.Edit', [_Edit2.default], {
     // Localization
     titleText: resource.titleText,
     quoteNumberText: resource.quoteNumberText,
@@ -185,30 +185,28 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
       return values;
     },
     processEntry: function processEntry(entry) {
-      var _this = this;
-
       this.inherited(processEntry, arguments);
       if (entry && entry.Account) {
-        ['RequestedBy', 'Opportunity'].forEach(function (f) {
-          _this.fields[f].dependsOn = 'Account';
-          _this.fields[f].where = 'Account.Id eq "' + (entry.Account.AccountId || entry.Account.$key || entry.Account.key) + '"';
+        ['RequestedBy', 'Opportunity'].forEach(f => {
+          this.fields[f].dependsOn = 'Account';
+          this.fields[f].where = `Account.Id eq "${entry.Account.AccountId || entry.Account.$key || entry.Account.key}"`;
           if (f === 'Opportunity') {
-            _this.fields[f].where = _this.fields[f].where + ' and Status eq "' + _this.opportunityOpenCode + '"';
+            this.fields[f].where = `${this.fields[f].where} and Status eq "${this.opportunityOpenCode}"`;
           }
         });
       }
-      var warehouseField = this.fields.Warehouse;
-      var locationField = this.fields.Location;
+      const warehouseField = this.fields.Warehouse;
+      const locationField = this.fields.Location;
       if (entry && entry.ErpLogicalId) {
         warehouseField.enable();
         warehouseField.dependsOn = 'ErpLogicalId';
-        warehouseField.where = function (logicalId) {
-          return 'ErpLogicalId eq "' + logicalId + '" and LocationType eq "' + _this.warehouseCode + '"';
+        warehouseField.where = logicalId => {
+          return `ErpLogicalId eq "${logicalId}" and LocationType eq "${this.warehouseCode}"`;
         };
         locationField.enable();
         locationField.dependsOn = 'ErpLogicalId';
-        locationField.where = function (logicalId) {
-          return 'ErpLogicalId eq "' + logicalId + '" and (LocationType eq "' + _this.officeCode + '" or LocationType eq "' + _this.siteCode + '")';
+        locationField.where = logicalId => {
+          return `ErpLogicalId eq "${logicalId}" and (LocationType eq "${this.officeCode}" or LocationType eq "${this.siteCode}")`;
         };
       } else {
         warehouseField.disable();
@@ -233,7 +231,7 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
       this.inherited(setValues, arguments);
 
       if (!this.fields.CurrencyCode.getValue()) {
-        var account = this.fields.Account.currentSelection;
+        const account = this.fields.Account.currentSelection;
         if (account && account.CurrencyCode) {
           this.fields.CurrencyCode.setValue(account.CurrencyCode);
         } else {
@@ -242,12 +240,10 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
       }
     },
     onRefresh: function onRefresh() {
-      var _this2 = this;
-
       this.inherited(onRefresh, arguments);
-      ['RequestedBy', 'Opportunity', 'BackOfficeAccountingEntity', 'Warehouse', 'Location'].forEach(function (f) {
-        _this2.fields[f].dependsOn = null;
-        _this2.fields[f].where = null;
+      ['RequestedBy', 'Opportunity', 'BackOfficeAccountingEntity', 'Warehouse', 'Location'].forEach(f => {
+        this.fields[f].dependsOn = null;
+        this.fields[f].where = null;
       });
     },
     onRefreshInsert: function onRefreshInsert() {
@@ -255,20 +251,16 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
       this.enableBackOfficeData();
     },
     getEntriesFromIds: function getEntriesFromIds() {
-      var _this3 = this;
-
-      var mappedLookups = ['BackOffice', 'BackOfficeAccountingEntity'];
-      var mappedProperties = ['LogicalId', 'AcctEntityExtId'];
-      var fields = ['ErpLogicalId', 'ErpAccountingEntityId'];
-      _Utility4.default.setFieldsFromIds(mappedLookups, mappedProperties, fields, this).then(function () {
-        _this3.hideBusy();
+      const mappedLookups = ['BackOffice', 'BackOfficeAccountingEntity'];
+      const mappedProperties = ['LogicalId', 'AcctEntityExtId'];
+      const fields = ['ErpLogicalId', 'ErpAccountingEntityId'];
+      _Utility4.default.setFieldsFromIds(mappedLookups, mappedProperties, fields, this).then(() => {
+        this.hideBusy();
       });
     },
     getPrimaryContact: function getPrimaryContact(entry) {
-      var _this4 = this;
-
-      var accountModel = _Adapter2.default.getModel(_Names2.default.ACCOUNT);
-      var relationship = {
+      const accountModel = _Adapter2.default.getModel(_Names2.default.ACCOUNT);
+      const relationship = {
         name: 'Contacts',
         displayName: contactResource.entityDisplayNamePlural,
         type: 'OneToMany',
@@ -277,13 +269,13 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
         relatedPropertyType: 'object',
         where: 'IsPrimary eq true'
       };
-      accountModel.getRelatedRequest(entry, relationship).then(function (result) {
+      accountModel.getRelatedRequest(entry, relationship).then(result => {
         if (result && result.entities && result.entities.length) {
-          var contactField = _this4.fields.RequestedBy;
+          const contactField = this.fields.RequestedBy;
           if (!contactField.currentSelection || contactField.currentSelection.Account && contactField.currentSelection.Account.$key !== entry.$key) {
             contactField.setSelection(result.entities[0]);
-            if (_this4.fields.Account.currentSelection && !_this4.fields.Account.currentSelection.ErpExtId) {
-              _this4.populateUnpromotedFields(contactField.currentSelection);
+            if (this.fields.Account.currentSelection && !this.fields.Account.currentSelection.ErpExtId) {
+              this.populateUnpromotedFields(contactField.currentSelection);
             }
           }
         }
@@ -302,15 +294,13 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
       this.fields.ShippingContact.setSelection(contact);
     },
     onAccountChange: function onAccountChange(value, field) {
-      var _this5 = this;
-
-      var entry = field.currentSelection;
-      ['RequestedBy', 'Opportunity'].forEach(function (f) {
+      const entry = field.currentSelection;
+      ['RequestedBy', 'Opportunity'].forEach(f => {
         if (value) {
-          _this5.fields[f].dependsOn = 'Account';
-          _this5.fields[f].where = 'Account.Id eq "' + (value.AccountId || value.$key || value.key) + '"';
+          this.fields[f].dependsOn = 'Account';
+          this.fields[f].where = `Account.Id eq "${value.AccountId || value.$key || value.key}"`;
           if (f === 'Opportunity') {
-            _this5.fields[f].where = _this5.fields[f].where + ' and Status eq "' + _this5.opportunityOpenCode + '"';
+            this.fields[f].where = `${this.fields[f].where} and Status eq "${this.opportunityOpenCode}"`;
           }
         }
       });
@@ -326,7 +316,7 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
           this.hidePromotedFields();
         }
         if (entry.AccountManager) {
-          var accountManagerField = this.fields.AccountManager;
+          const accountManagerField = this.fields.AccountManager;
           accountManagerField.setSelection({
             $key: entry.AccountManager.$key
           });
@@ -334,47 +324,45 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
         field.setValue(field.currentSelection);
         this.showBusy();
         this.getPrimaryContact(entry);
-        _Utility4.default.setFieldsFromIds(['BackOffice', 'BackOfficeAccountingEntity'], ['LogicalId', 'AcctEntityExtId'], ['ErpLogicalId', 'ErpAccountingEntityId'], this, entry).then(function () {
-          _this5.hideBusy();
+        _Utility4.default.setFieldsFromIds(['BackOffice', 'BackOfficeAccountingEntity'], ['LogicalId', 'AcctEntityExtId'], ['ErpLogicalId', 'ErpAccountingEntityId'], this, entry).then(() => {
+          this.hideBusy();
         });
       }
     },
     onAccountDependentChange: function onAccountDependentChange(value, field) {
       if (value && !field.dependsOn && field.currentSelection && field.currentSelection.Account) {
-        var accountField = this.fields.Account;
+        const accountField = this.fields.Account;
         accountField.setSelection(field.currentSelection.Account);
         this.onAccountChange(accountField.getValue(), accountField);
       }
     },
     onBackOfficeChange: function onBackOfficeChange(value, field) {
-      var _this6 = this;
-
       this.fields.BackOffice.setValue(field.currentSelection);
       this.fields.ErpLogicalId.setValue(field.currentSelection.LogicalId);
-      var accountingField = this.fields.BackOfficeAccountingEntity;
-      accountingField.where = 'BackOffice.Id eq "' + field.currentSelection.$key + '"';
-      var accountingIsToBackOffice = accountingField.currentSelection && accountingField.currentSelection.BackOffice && accountingField.currentSelection.BackOffice.$key === field.currentSelection.$key;
+      const accountingField = this.fields.BackOfficeAccountingEntity;
+      accountingField.where = `BackOffice.Id eq "${field.currentSelection.$key}"`;
+      const accountingIsToBackOffice = accountingField.currentSelection && accountingField.currentSelection.BackOffice && accountingField.currentSelection.BackOffice.$key === field.currentSelection.$key;
       if (field.currentSelection.BackOfficeAccountingEntities.$resources && !accountingIsToBackOffice) {
-        var entry = field.currentSelection.BackOfficeAccountingEntities.$resources[0];
+        const entry = field.currentSelection.BackOfficeAccountingEntities.$resources[0];
         if (entry) {
           accountingField.setSelection(entry);
           this.onBackOfficeAccountingEntityChange(accountingField.getValue(), accountingField);
         }
       }
-      var warehouseField = this.fields.Warehouse;
+      const warehouseField = this.fields.Warehouse;
       if (warehouseField.isDisabled) {
         warehouseField.enable();
         warehouseField.dependsOn = 'ErpLogicalId';
-        warehouseField.where = function (logicalId) {
-          return 'ErpLogicalId eq "' + logicalId + '" and LocationType eq "' + _this6.warehouseCode + '"';
+        warehouseField.where = logicalId => {
+          return `ErpLogicalId eq "${logicalId}" and LocationType eq "${this.warehouseCode}"`;
         };
       }
-      var locationField = this.fields.Location;
+      const locationField = this.fields.Location;
       if (locationField.isDisabled) {
         locationField.enable();
         locationField.dependsOn = 'ErpLogicalId';
-        locationField.where = function (logicalId) {
-          return 'ErpLogicalId eq "' + logicalId + '" and (LocationType eq "' + _this6.officeCode + '" or LocationType eq "' + _this6.siteCode + '")';
+        locationField.where = logicalId => {
+          return `ErpLogicalId eq "${logicalId}" and (LocationType eq "${this.officeCode}" or LocationType eq "${this.siteCode}")`;
         };
       }
     },
@@ -406,13 +394,13 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
     },
     applyContext: function applyContext() {
       this.inherited(applyContext, arguments);
-      var found = this._getNavContext();
+      const found = this._getNavContext();
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       this.onAccountChange(accountField.getValue(), accountField);
 
-      var context = found && found.options && found.options.source || found;
-      var lookup = {
+      const context = found && found.options && found.options.source || found;
+      const lookup = {
         accounts: this.applyAccountContext,
         contacts: this.applyContactContext,
         opportunities: this.applyOpportunityContext
@@ -432,8 +420,8 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
       }
     },
     _getNavContext: function _getNavContext() {
-      var navContext = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      const navContext = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
 
         if (/^(accounts|contacts|opportunities)$/.test(context.resourceKind) && context.key) {
           return true;
@@ -444,38 +432,38 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
       return navContext;
     },
     applyAccountContext: function applyAccountContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setSelection(entry);
       this.onAccountChange(accountField.getValue(), accountField);
     },
     applyContactContext: function applyContactContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var contactField = this.fields.RequestedBy;
+      const contactField = this.fields.RequestedBy;
       contactField.setSelection(entry);
       this.onAccountDependentChange(contactField.getValue(), contactField);
     },
     applyOpportunityContext: function applyOpportunityContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var opportunityField = this.fields.Opportunity;
+      const opportunityField = this.fields.Opportunity;
       opportunityField.setSelection(entry);
       this.onAccountDependentChange(opportunityField.getValue(), opportunityField);
     },
@@ -488,7 +476,7 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
     },
     showBusy: function showBusy() {
       if (!this._busyIndicator || this._busyIndicator._destroyed) {
-        this._busyIndicator = new _BusyIndicator2.default({ id: this.id + '-busyIndicator' });
+        this._busyIndicator = new _BusyIndicator2.default({ id: `${this.id}-busyIndicator` });
       }
       this._busyIndicator.start();
       App.modal.disableClose = true;
@@ -528,7 +516,7 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
           emptyText: '',
           valueTextProperty: 'Description',
           view: 'opportunity_related',
-          where: 'Status eq "' + this.opportunityOpenCode + '"'
+          where: `Status eq "${this.opportunityOpenCode}"`
         }, {
           label: this.backOfficeText,
           name: 'BackOffice',
@@ -687,8 +675,8 @@ define('crm/Integrations/BOE/Views/Quotes/Edit', ['module', 'exports', 'dojo/_ba
           emptyText: '',
           valueTextProperty: 'CarrierName',
           view: 'quote_carriers',
-          where: function where(value) {
-            return 'ErpLogicalId eq "' + value + '"';
+          where: value => {
+            return `ErpLogicalId eq "${value}"`;
           }
         }, {
           dependsOn: 'Account',

--- a/src-out/Integrations/BOE/Views/Quotes/List.js
+++ b/src-out/Integrations/BOE/Views/Quotes/List.js
@@ -48,9 +48,9 @@ define('crm/Integrations/BOE/Views/Quotes/List', ['module', 'exports', 'dojo/_ba
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('quotesList');
+  const resource = (0, _I18n2.default)('quotesList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Quotes.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Quotes.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     formatter: _Format2.default,
     util: _Utility2.default,
     // Templates
@@ -111,28 +111,26 @@ define('crm/Integrations/BOE/Views/Quotes/List', ['module', 'exports', 'dojo/_ba
       }]);
     },
     onAddLineItems: function onAddLineItems(evt, selection) {
-      var _this = this;
-
-      var key = selection && selection.data && selection.data.$key;
+      const key = selection && selection.data && selection.data.$key;
       if (key) {
-        var quoteModel = App.ModelManager.getModel(_Names2.default.QUOTE, _Types2.default.SDATA);
-        var isClosedPromise = quoteModel.isClosed(key);
-        isClosedPromise.then(function (isClosed) {
+        const quoteModel = App.ModelManager.getModel(_Names2.default.QUOTE, _Types2.default.SDATA);
+        const isClosedPromise = quoteModel.isClosed(key);
+        isClosedPromise.then(isClosed => {
           if (isClosed) {
             App.modal.createSimpleAlert({
               title: 'alert',
-              content: _this.quoteClosedText
+              content: this.quoteClosedText
             });
             return;
           }
-          _this.navigateToLineItems(evt, selection);
+          this.navigateToLineItems(evt, selection);
         });
       }
     },
     navigateToLineItems: function navigateToLineItems(evt, selection) {
-      var view = App.getView('quote_line_edit');
+      const view = App.getView('quote_line_edit');
       if (view) {
-        var options = {
+        const options = {
           insert: true,
           context: {
             Quote: selection.data
@@ -142,11 +140,11 @@ define('crm/Integrations/BOE/Views/Quotes/List', ['module', 'exports', 'dojo/_ba
       }
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(QuoteNumber) like "' + q + '%" or Account.AccountName like "' + q + '%" or ErpExtId like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(QuoteNumber) like "${q}%" or Account.AccountName like "${q}%" or ErpExtId like "${q}%"`;
     },
     formatErpStatus: function formatErpStatus(value) {
-      var text = App.picklistService.getPicklistItemTextByCode('ErpQuoteStatus', value);
+      const text = App.picklistService.getPicklistItemTextByCode('ErpQuoteStatus', value);
       if (text) {
         return text;
       }

--- a/src-out/Integrations/BOE/Views/Returns/List.js
+++ b/src-out/Integrations/BOE/Views/Returns/List.js
@@ -23,22 +23,22 @@ define('crm/Integrations/BOE/Views/Returns/List', ['module', 'exports', 'dojo/_b
     };
   }
 
-  var resource = (0, _I18n2.default)('returnsList'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('returnsList'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Returns.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.Returns.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     // TODO: Need template from PM
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.$descriptor %}</p>']),
@@ -66,8 +66,8 @@ define('crm/Integrations/BOE/Views/Returns/List', ['module', 'exports', 'dojo/_b
     entityName: 'Return',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(ReturnNumber) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(ReturnNumber) like "%${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/SalesOrderItems/Detail.js
+++ b/src-out/Integrations/BOE/Views/SalesOrderItems/Detail.js
@@ -27,47 +27,23 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Detail', ['module', 'exports'
     };
   }
 
-  var _slicedToArray = function () {
-    function sliceIterator(arr, i) {
-      var _arr = [];
-      var _n = true;
-      var _d = false;
-      var _e = undefined;
+  const resource = (0, _I18n2.default)('salesOrderItemsDetail'); /* Copyright 2017 Infor
+                                                                  *
+                                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                  * you may not use this file except in compliance with the License.
+                                                                  * You may obtain a copy of the License at
+                                                                  *
+                                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                  *
+                                                                  * Unless required by applicable law or agreed to in writing, software
+                                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                  * See the License for the specific language governing permissions and
+                                                                  * limitations under the License.
+                                                                  */
 
-      try {
-        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-          _arr.push(_s.value);
 
-          if (i && _arr.length === i) break;
-        }
-      } catch (err) {
-        _d = true;
-        _e = err;
-      } finally {
-        try {
-          if (!_n && _i["return"]) _i["return"]();
-        } finally {
-          if (_d) throw _e;
-        }
-      }
-
-      return _arr;
-    }
-
-    return function (arr, i) {
-      if (Array.isArray(arr)) {
-        return arr;
-      } else if (Symbol.iterator in Object(arr)) {
-        return sliceIterator(arr, i);
-      } else {
-        throw new TypeError("Invalid attempt to destructure non-iterable instance");
-      }
-    };
-  }();
-
-  var resource = (0, _I18n2.default)('salesOrderItemsDetail');
-
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrderItems.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrderItems.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     lineText: resource.lineText,
@@ -109,7 +85,7 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Detail', ['module', 'exports'
     enableOffline: true,
 
     createEntryForDelete: function createEntryForDelete(e) {
-      var entry = {
+      const entry = {
         $key: e.$key,
         $etag: e.$etag,
         $name: e.$name
@@ -126,30 +102,28 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Detail', ['module', 'exports'
       }
     },
     removeOrderLine: function removeOrderLine() {
-      var _this = this;
-
       // TODO: [INFORCRM-7712] Implement this in the model (model needs remove call)
       App.modal.createSimpleDialog({
         title: 'alert',
         content: this.confirmDeleteText,
-        getContent: function getContent() {}
-      }).then(function () {
-        var entry = _this.createEntryForDelete(_this.entry);
-        var request = _this.store._createEntryRequest(_this.entry.$key, {});
+        getContent: () => {}
+      }).then(() => {
+        const entry = this.createEntryForDelete(this.entry);
+        const request = this.store._createEntryRequest(this.entry.$key, {});
 
         if (request) {
           request.delete(entry, {
-            success: _this.onDeleteSuccess,
-            failure: _this.onRequestDataFailure,
-            scope: _this
+            success: this.onDeleteSuccess,
+            failure: this.onRequestDataFailure,
+            scope: this
           });
         }
       });
     },
     onDeleteSuccess: function onDeleteSuccess() {
-      var views = [App.getView('salesorder_items_related'), App.getView('salesorder_detail'), App.getView('salesorder_list')];
+      const views = [App.getView('salesorder_items_related'), App.getView('salesorder_detail'), App.getView('salesorder_list')];
 
-      views.forEach(function (view) {
+      views.forEach(view => {
         if (view) {
           view.refreshRequired = true;
         }
@@ -171,7 +145,7 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Detail', ['module', 'exports'
       if (this.tools) {
         return this.tools;
       }
-      var tools = this.inherited(createToolLayout, arguments);
+      const tools = this.inherited(createToolLayout, arguments);
       if (tools && tools.tbar) {
         tools.tbar.push({
           id: 'removeOrderLine',
@@ -184,27 +158,18 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Detail', ['module', 'exports'
       return tools;
     },
     onAvailability: function onAvailability() {
-      var _this2 = this;
-
-      _PricingAvailabilityService2.default.getOrderItemAvailability(this.entry).then(function (result) {
-        var _result = _slicedToArray(result, 1),
-            warehouse = _result[0];
-
-        var ErrorCode = warehouse.ErrorCode,
-            AvailableQuantity = warehouse.AvailableQuantity;
-
+      _PricingAvailabilityService2.default.getOrderItemAvailability(this.entry).then(result => {
+        const [warehouse] = result;
+        const { ErrorCode, AvailableQuantity } = warehouse;
         if (ErrorCode) {
           App.modal.createSimpleAlert({ title: ErrorCode });
         } else if (AvailableQuantity) {
-          App.modal.createSimpleAlert({ title: _this2.availableQuantityText + AvailableQuantity });
+          App.modal.createSimpleAlert({ title: this.availableQuantityText + AvailableQuantity });
         }
       });
     },
     createLayout: function createLayout() {
-      var _this3 = this;
-
-      var _App$getBaseExchangeR = App.getBaseExchangeRate(),
-          baseCurrencyCode = _App$getBaseExchangeR.code;
+      const { code: baseCurrencyCode } = App.getBaseExchangeRate();
 
       return this.layout || (this.layout = [{
         title: this.actionsText,
@@ -217,7 +182,7 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Detail', ['module', 'exports'
           label: this.checkWarehouseAvailabilityText,
           iconClass: 'redo', // TODO: look for a better icon
           action: 'onAvailability',
-          disabled: function disabled() {
+          disabled: () => {
             return App.warehouseDiscovery === 'auto';
           },
           security: 'Entities/SalesOrder/Add'
@@ -251,33 +216,31 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Detail', ['module', 'exports'
           name: 'Price',
           property: 'Price',
           label: this.priceText,
-          renderer: function renderer(value) {
-            var code = _this3.entry.SalesOrder.BaseCurrencyCode || baseCurrencyCode;
+          renderer: value => {
+            const code = this.entry.SalesOrder.BaseCurrencyCode || baseCurrencyCode;
             return _Utility2.default.formatMultiCurrency(value, code);
           }
         }, {
           name: 'Discount',
           property: 'Discount',
           label: this.discountText,
-          renderer: function renderer(value) {
-            var code = _this3.entry.SalesOrder.BaseCurrencyCode || baseCurrencyCode;
+          renderer: value => {
+            const code = this.entry.SalesOrder.BaseCurrencyCode || baseCurrencyCode;
             return _Utility2.default.formatMultiCurrency(value, code);
           }
         }, {
           name: 'CalculatedPrice',
           property: 'CalculatedPrice',
           label: this.baseAdjustedPriceText,
-          renderer: function renderer(value) {
-            var code = _this3.entry.SalesOrder.BaseCurrencyCode || baseCurrencyCode;
+          renderer: value => {
+            const code = this.entry.SalesOrder.BaseCurrencyCode || baseCurrencyCode;
             return _Utility2.default.formatMultiCurrency(value, code);
           }
         }, {
           name: 'DocCalculatedPrice',
           property: 'DocCalculatedPrice',
           label: this.adjustedPriceText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this3.entry.SalesOrder.CurrencyCode);
-          }
+          renderer: value => _Utility2.default.formatMultiCurrency(value, this.entry.SalesOrder.CurrencyCode)
         }, {
           name: 'Quantity',
           property: 'Quantity',
@@ -299,24 +262,20 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Detail', ['module', 'exports'
           label: this.baseExtendedAmountText,
           name: 'ExtendedPrice',
           property: 'ExtendedPrice',
-          renderer: function renderer(value) {
-            var code = _this3.entry.SalesOrder.BaseCurrencyCode || baseCurrencyCode;
+          renderer: value => {
+            const code = this.entry.SalesOrder.BaseCurrencyCode || baseCurrencyCode;
             return _Utility2.default.formatMultiCurrency(value, code);
           }
         }, {
           name: 'DocExtendedPrice',
           property: 'DocExtendedPrice',
           label: this.extendedAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this3.entry.SalesOrder.CurrencyCode);
-          }
+          renderer: value => _Utility2.default.formatMultiCurrency(value, this.entry.SalesOrder.CurrencyCode)
         }, {
           name: 'DocTotalAmount',
           property: 'DocTotalAmount',
           label: this.totalAmountText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this3.entry.SalesOrder.CurrencyCode);
-          }
+          renderer: value => _Utility2.default.formatMultiCurrency(value, this.entry.SalesOrder.CurrencyCode)
         }, {
           name: 'ErpStatus',
           property: 'ErpStatus',

--- a/src-out/Integrations/BOE/Views/SalesOrderItems/Edit.js
+++ b/src-out/Integrations/BOE/Views/SalesOrderItems/Edit.js
@@ -44,9 +44,9 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('salesOrderItemEdit');
+  const resource = (0, _I18n2.default)('salesOrderItemEdit');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrderItems.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrderItems.Edit', [_Edit2.default], {
     // View Properties
     id: 'salesorder_item_edit',
     detailView: 'salesorder_item_detail',
@@ -87,7 +87,7 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
       this.connect(this.fields.Quantity, 'onChange', this.onQuantityChange);
     },
     _applyLogicValues: function _applyLogicValues(values) {
-      var product = this.fields.Product.getSelection();
+      const product = this.fields.Product.getSelection();
       values.ProductName = product.Name;
       values.Family = product.Family;
       values.ActualID = product.ActualId;
@@ -109,20 +109,18 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
       this.setProductDependentFields();
     },
     setProductDependentFields: function setProductDependentFields(product) {
-      var _this = this;
-
-      var dependants = this.getProductDependants();
+      const dependants = this.getProductDependants();
       if (product) {
-        dependants.forEach(function (f) {
-          _this.fields[f].enable();
-          _this.fields[f].dependsOn = 'Product';
-          _this.fields[f].where = 'Product.Id eq "' + product.$key + '"';
+        dependants.forEach(f => {
+          this.fields[f].enable();
+          this.fields[f].dependsOn = 'Product';
+          this.fields[f].where = `Product.Id eq "${product.$key}"`;
         });
       } else {
-        dependants.forEach(function (f) {
-          _this.fields[f].disable();
-          _this.fields[f].dependsOn = null;
-          _this.fields[f].where = null;
+        dependants.forEach(f => {
+          this.fields[f].disable();
+          this.fields[f].dependsOn = null;
+          this.fields[f].where = null;
         });
       }
     },
@@ -142,9 +140,7 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
       return entry;
     },
     requestProductPricing: function requestProductPricing(product, quantity, slxLocation, unitOfMeasure) {
-      var _this2 = this;
-
-      var salesOrder = null;
+      let salesOrder = null;
       if (this.options && this.options.context && this.options.context.SalesOrder) {
         salesOrder = this.options.context.SalesOrder;
       } else {
@@ -155,23 +151,21 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
       if (salesOrder && salesOrder.$key && !this.isProcessingPricingRequest) {
         this.isProcessingPricingRequest = true;
         this.enablePricingControls(false);
-        _PricingAvailabilityService2.default.getOrderItemPricing(this.entry, salesOrder, product, quantity, slxLocation, unitOfMeasure).then(function (results) {
-          _this2.onProductPricingSuccess(results);
-        }, function (error) {
-          _this2.onProductPricingFailed(error);
+        _PricingAvailabilityService2.default.getOrderItemPricing(this.entry, salesOrder, product, quantity, slxLocation, unitOfMeasure).then(results => {
+          this.onProductPricingSuccess(results);
+        }, error => {
+          this.onProductPricingFailed(error);
         });
       }
     },
     onProductPricingSuccess: function onProductPricingSuccess(result) {
-      var _this3 = this;
-
-      this.processProductPricing(result).then(function () {
-        _this3.reCalculate();
-        _this3.isProcessingPricingRequest = false;
-        _this3.enablePricingControls(true);
-      }, function () {
-        _this3.isProcessingPricingRequest = false;
-        _this3.enablePricingControls(true);
+      this.processProductPricing(result).then(() => {
+        this.reCalculate();
+        this.isProcessingPricingRequest = false;
+        this.enablePricingControls(true);
+      }, () => {
+        this.isProcessingPricingRequest = false;
+        this.enablePricingControls(true);
       });
     },
     onProductPricingFailed: function onProductPricingFailed(result) {
@@ -183,20 +177,18 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
       });
     },
     setUomFromCode: function setUomFromCode(uomCode) {
-      var _this4 = this;
-
-      var curremtUom = this.fields.UnitOfMeasure.getValue();
-      var product = this.fields.Product.getValue();
-      var promise = new Promise(function (resolve, reject) {
-        if (!_this4._uomModel) {
-          _this4._uomModel = App.ModelManager.getModel(_Names2.default.UNITOFMEASURE, _Types2.default.SDATA);
+      const curremtUom = this.fields.UnitOfMeasure.getValue();
+      const product = this.fields.Product.getValue();
+      const promise = new Promise((resolve, reject) => {
+        if (!this._uomModel) {
+          this._uomModel = App.ModelManager.getModel(_Names2.default.UNITOFMEASURE, _Types2.default.SDATA);
         }
-        if (_this4._uomModel && product) {
+        if (this._uomModel && product) {
           if (curremtUom && curremtUom.Name !== uomCode || !curremtUom) {
-            _this4._uomModel.getUnitOfMeasureFromCode(uomCode, product.$key).then(function (uom) {
-              _this4.fields.UnitOfMeasure.setValue(uom);
+            this._uomModel.getUnitOfMeasureFromCode(uomCode, product.$key).then(uom => {
+              this.fields.UnitOfMeasure.setValue(uom);
               resolve(true);
-            }, function (error) {
+            }, error => {
               reject(error);
             });
           } else {
@@ -209,29 +201,27 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
       return promise;
     },
     processProductPricing: function processProductPricing(pricingData) {
-      var _this5 = this;
-
-      var promise = new Promise(function (resolve, reject) {
+      const promise = new Promise((resolve, reject) => {
         if (pricingData) {
           if (pricingData.DocCalculatedPrice) {
-            _this5.fields.DocCalculatedPrice.setValue(pricingData.DocCalculatedPrice.value);
+            this.fields.DocCalculatedPrice.setValue(pricingData.DocCalculatedPrice.value);
           }
           if (pricingData.DocExtendedPrice) {
-            _this5.fields.DocExtendedPrice.setValue(pricingData.DocExtendedPrice.value);
+            this.fields.DocExtendedPrice.setValue(pricingData.DocExtendedPrice.value);
           }
           if (pricingData.DocTotalAmount) {
-            _this5.fields.DocTotalAmount.setValue(pricingData.DocTotalAmount.value);
+            this.fields.DocTotalAmount.setValue(pricingData.DocTotalAmount.value);
           }
           if (pricingData.SlxLocationId) {
-            _this5.fields.SlxLocation.setValue({
+            this.fields.SlxLocation.setValue({
               $key: pricingData.SlxLocationId.value,
               Name: pricingData.SlxLocationCode.value
             });
           }
           if (pricingData.UnitOfMeasure) {
-            _this5.setUomFromCode(pricingData.UnitOfMeasure.value).then(function () {
+            this.setUomFromCode(pricingData.UnitOfMeasure.value).then(() => {
               resolve(true);
-            }, function (error) {
+            }, error => {
               reject(error);
             });
           } else {
@@ -280,8 +270,8 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
       return false;
     },
     reCalculate: function reCalculate() {
-      var price = this.fields.CalculatedPrice.getValue();
-      var quantity = this.fields.Quantity.getValue();
+      const price = this.fields.CalculatedPrice.getValue();
+      const quantity = this.fields.Quantity.getValue();
       this.fields.ExtendedPrice.setValue(quantity * price);
     },
     formatDependentQuery: function formatDependentQuery(dependentValue, theFormat, property) {
@@ -296,17 +286,15 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
       this.inherited(onInsertCompleted, arguments);
     },
     _refreshRelatedViews: function _refreshRelatedViews() {
-      var views = [App.getView('salesorder_item_detail'), App.getView('salesorder_items_list')];
+      const views = [App.getView('salesorder_item_detail'), App.getView('salesorder_items_list')];
 
-      views.forEach(function (view) {
+      views.forEach(view => {
         if (view) {
           view.refreshRequired = true;
         }
       });
     },
     createLayout: function createLayout() {
-      var _this6 = this;
-
       return this.layout || (this.layout = [{
         title: this.detailsText,
         name: 'DetailsSection',
@@ -333,9 +321,9 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/Edit', ['module', 'exports', 
           view: 'salesorder_product_related',
           autoFocus: true,
           required: true,
-          where: function where() {
-            if (_this6.fields.SalesOrder.currentSelection && _this6.fields.SalesOrder.currentSelection.ErpLogicalId || _this6.options && _this6.options.context && _this6.options.context.SalesOrder && _this6.options.context.SalesOrder.ErpLogicalId) {
-              return 'ErpLogicalId eq "' + (_this6.fields.SalesOrder.currentSelection.ErpLogicalId || _this6.options.context.SalesOrder.ErpLogicalId) + '"';
+          where: () => {
+            if (this.fields.SalesOrder.currentSelection && this.fields.SalesOrder.currentSelection.ErpLogicalId || this.options && this.options.context && this.options.context.SalesOrder && this.options.context.SalesOrder.ErpLogicalId) {
+              return `ErpLogicalId eq "${this.fields.SalesOrder.currentSelection.ErpLogicalId || this.options.context.SalesOrder.ErpLogicalId}"`;
             }
             return null;
           }

--- a/src-out/Integrations/BOE/Views/SalesOrderItems/List.js
+++ b/src-out/Integrations/BOE/Views/SalesOrderItems/List.js
@@ -31,22 +31,22 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/List', ['module', 'exports', 
     };
   }
 
-  var resource = (0, _I18n2.default)('salesOrderItemsList'); /* Copyright 2017 Infor
-                                                              *
-                                                              * Licensed under the Apache License, Version 2.0 (the "License");
-                                                              * you may not use this file except in compliance with the License.
-                                                              * You may obtain a copy of the License at
-                                                              *
-                                                              *    http://www.apache.org/licenses/LICENSE-2.0
-                                                              *
-                                                              * Unless required by applicable law or agreed to in writing, software
-                                                              * distributed under the License is distributed on an "AS IS" BASIS,
-                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                              * See the License for the specific language governing permissions and
-                                                              * limitations under the License.
-                                                              */
+  const resource = (0, _I18n2.default)('salesOrderItemsList'); /* Copyright 2017 Infor
+                                                                *
+                                                                * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                * you may not use this file except in compliance with the License.
+                                                                * You may obtain a copy of the License at
+                                                                *
+                                                                *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                *
+                                                                * Unless required by applicable law or agreed to in writing, software
+                                                                * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                * See the License for the specific language governing permissions and
+                                                                * limitations under the License.
+                                                                */
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrderItems.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrderItems.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     formatter: _Format2.default,
     util: _Utility2.default,
     // Localization
@@ -88,7 +88,7 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/List', ['module', 'exports', 
     readOnly: false,
 
     transitionTo: function transitionTo() {
-      var entry = this.options && this.options.fromContext && this.options.fromContext.entry;
+      const entry = this.options && this.options.fromContext && this.options.fromContext.entry;
       if (entry && entry.IsClosed) {
         if (App.bars && App.bars.tbar) {
           App.bars.tbar.disableTool('new');
@@ -102,7 +102,7 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/List', ['module', 'exports', 
         id: 'assignWarehouse',
         cls: 'warehouse',
         label: this.assignWarehouseText,
-        enabled: function enabled(layoutAction, selection) {
+        enabled: (layoutAction, selection) => {
           return App.warehouseDiscovery === 'auto' && _Action2.default.hasProperty(layoutAction, selection, 'SalesOrder.ErpLogicalId');
         },
         action: 'assignWarehouseAction'
@@ -119,7 +119,7 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/List', ['module', 'exports', 
       });
     },
     preNavigateToInsert: function preNavigateToInsert() {
-      var options = {};
+      let options = {};
       if (this.options && this.options.fromContext && this.options.fromContext.entry) {
         options = {
           context: {
@@ -130,15 +130,15 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/List', ['module', 'exports', 
       this.navigateToInsertView(options);
     },
     assignWarehouseAction: function assignWarehouseAction(theAction, selection) {
-      var order = this.options.fromContext.entry;
-      var orderItemKey = selection.tag.attributes['data-key'].value;
-      var orderItem = this.entries[orderItemKey];
+      const order = this.options.fromContext.entry;
+      const orderItemKey = selection.tag.attributes['data-key'].value;
+      const orderItem = this.entries[orderItemKey];
       if (orderItem) {
-        var view = this.getAvailabilityView();
+        const view = this.getAvailabilityView();
         if (view) {
-          var options = {
-            orderItem: orderItem,
-            order: order
+          const options = {
+            orderItem,
+            order
           };
           this.refreshRequired = true;
           view.show(options);
@@ -146,8 +146,8 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/List', ['module', 'exports', 
       }
     },
     getAvailabilityView: function getAvailabilityView() {
-      var viewId = 'locations_salesOrderItemAvailabilityList';
-      var view = App.getView(viewId);
+      const viewId = 'locations_salesOrderItemAvailabilityList';
+      let view = App.getView(viewId);
       if (view) {
         return view;
       }
@@ -157,8 +157,8 @@ define('crm/Integrations/BOE/Views/SalesOrderItems/List', ['module', 'exports', 
       return view;
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Description) like "' + q + '%") or (upper(ProductName) like "' + q + '%") or (upper(SalesOrder.SalesOrderNumber) like "' + q + '%") or (upper(ErpLineNumber) like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Description) like "${q}%") or (upper(ProductName) like "${q}%") or (upper(SalesOrder.SalesOrderNumber) like "${q}%") or (upper(ErpLineNumber) like "${q}%")`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/SalesOrders/Detail.js
+++ b/src-out/Integrations/BOE/Views/SalesOrders/Detail.js
@@ -44,9 +44,9 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('salesOrdersDetail');
+  const resource = (0, _I18n2.default)('salesOrdersDetail');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrders.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrders.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     actionsText: resource.actionsText,
@@ -120,56 +120,52 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
       }
     },
     _canPromote: function _canPromote() {
-      var _this = this;
-
-      var promise = new Promise(function (resolve) {
-        _this.showBusy();
-        var entry = {
+      const promise = new Promise(resolve => {
+        this.showBusy();
+        const entry = {
           $name: 'CanPromoteSalesOrder',
           request: {
-            salesOrderId: _this.entry.$key
+            salesOrderId: this.entry.$key
           }
         };
-        var request = new Sage.SData.Client.SDataServiceOperationRequest(_this.getService()).setResourceKind('salesOrders').setContractName('dynamic').setOperationName('CanPromoteSalesOrder');
+        const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setResourceKind('salesOrders').setContractName('dynamic').setOperationName('CanPromoteSalesOrder');
 
-        var canPromote = {
+        const canPromote = {
           value: false,
           result: ''
         };
 
         request.execute(entry, {
-          success: function success(result) {
+          success: result => {
             canPromote.value = result.response.Result;
             resolve(canPromote);
           },
-          failure: function failure(err) {
-            var response = JSON.parse(err.response)[0];
+          failure: err => {
+            const response = JSON.parse(err.response)[0];
             canPromote.result = response.message;
             resolve(canPromote);
           },
-          scope: _this
+          scope: this
         });
       });
       return promise;
     },
     addLineItems: function addLineItems() {
-      var _this2 = this;
-
       if (!this.entry.ErpLogicalId) {
         App.modal.createSimpleDialog({
           title: 'alert',
           content: this.accountingEntityRequiredText,
-          getContent: function getContent() {
+          getContent: () => {
             return;
           }
-        }).then(function () {
-          _this2.navigateToEditView();
+        }).then(() => {
+          this.navigateToEditView();
         });
         return;
       }
-      var view = App.getView('salesorder_item_edit');
+      const view = App.getView('salesorder_item_edit');
       if (view) {
-        var options = {
+        const options = {
           insert: true,
           context: {
             SalesOrder: this.entry
@@ -184,8 +180,6 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
       return result;
     },
     onGetOrderTotal: function onGetOrderTotal() {
-      var _this3 = this;
-
       if (this.entry) {
         if (!this.options.context) {
           this.options.context = {
@@ -194,17 +188,15 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
         } else {
           this.options.context.SalesOrder = this.entry;
         }
-        _PricingAvailabilityService2.default.getOrderPricing(this.entry).then(function (result) {
-          _this3.handlePricingSuccess(result);
+        _PricingAvailabilityService2.default.getOrderPricing(this.entry).then(result => {
+          this.handlePricingSuccess(result);
         });
       }
     },
     onRePrice: function onRePrice() {
-      var _this4 = this;
-
       if (this.entry) {
         if (this.isSalesOrderClosed()) {
-          var options = {
+          const options = {
             title: 'alert',
             content: this.pricingUnavailableText,
             getContent: null
@@ -219,29 +211,27 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
         } else {
           this.options.context.SalesOrder = this.entry;
         }
-        _PricingAvailabilityService2.default.salesOrderRePrice(this.entry).then(function (result) {
-          _this4.handlePricingSuccess(result);
+        _PricingAvailabilityService2.default.salesOrderRePrice(this.entry).then(result => {
+          this.handlePricingSuccess(result);
         });
       }
     },
     onPromoteOrder: function onPromoteOrder() {
-      var _this5 = this;
-
-      var canPromotePromise = this._canPromote();
-      canPromotePromise.then(function (val) {
-        _this5.hideBusy();
+      const canPromotePromise = this._canPromote();
+      canPromotePromise.then(val => {
+        this.hideBusy();
         if (!val.value) {
           App.modal.createSimpleDialog({
             title: 'alert',
             content: val.result,
-            getContent: function getContent() {
+            getContent: () => {
               return;
             }
           });
           return;
         }
-        var promote = new _Promote2.default();
-        promote.promoteToBackOffice(_this5.entry, 'SalesOrder', _this5);
+        const promote = new _Promote2.default();
+        promote.promoteToBackOffice(this.entry, 'SalesOrder', this);
       });
     },
     isSalesOrderClosed: function isSalesOrderClosed() {
@@ -268,7 +258,7 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
     showBusy: function showBusy() {
       if (!this._busyIndicator || this._busyIndicator._destroyed) {
         this._busyIndicator = new _BusyIndicator2.default({
-          id: this.id + '-busyIndicator'
+          id: `${this.id}-busyIndicator`
         });
       }
       this._busyIndicator.start();
@@ -280,8 +270,6 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
       return _Format2.default.picklist(this.app.picklistService, this._model, property);
     },
     createLayout: function createLayout() {
-      var _this6 = this;
-
       return this.layout || (this.layout = [{
         title: this.actionsText,
         list: true,
@@ -426,29 +414,29 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
           name: 'SubTotal',
           property: 'OrderTotal',
           label: this.baseSubTotalText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this6.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           name: 'GrandTotal',
           property: 'GrandTotal',
           label: this.baseGrandTotalText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this6.entry.BaseCurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.BaseCurrencyCode);
           }
         }, {
           name: 'DocSubTotal',
           property: 'DocOrderTotal',
           label: this.subTotalText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this6.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'DocGrandTotal',
           property: 'DocGrandTotal',
           label: this.grandTotalText,
-          renderer: function renderer(value) {
-            return _Utility2.default.formatMultiCurrency(value, _this6.entry.CurrencyCode);
+          renderer: value => {
+            return _Utility2.default.formatMultiCurrency(value, this.entry.CurrencyCode);
           }
         }, {
           name: 'CreateDate',
@@ -602,42 +590,42 @@ define('crm/Integrations/BOE/Views/SalesOrders/Detail', ['module', 'exports', 'd
           name: 'OrderItems',
           label: this.orderItemsText,
           where: function where(entry) {
-            return 'SalesOrder.Id eq "' + entry.$key + '"';
+            return `SalesOrder.Id eq "${entry.$key}"`;
           },
           view: 'salesorder_items_related'
         }, {
           name: 'ERPInvoiceItemsRelated',
           label: this.invoiceItemsText,
           where: function where(entry) {
-            return 'SalesOrder.Id eq "' + entry.$key + '"';
+            return `SalesOrder.Id eq "${entry.$key}"`;
           },
           view: 'salesorder_invoice_items_related'
         }, {
           name: 'ERPShipmentItemsRelated',
           label: this.shipmentItemsText,
           where: function where(entry) {
-            return 'SalesOrder.Id eq "' + entry.$key + '"';
+            return `SalesOrder.Id eq "${entry.$key}"`;
           },
           view: 'salesorder_shipment_items_related'
         }, {
           name: 'Attachments',
           label: this.attachmentsText,
           where: function where(entry) {
-            return 'salesOrderId eq "' + entry.$key + '"';
+            return `salesOrderId eq "${entry.$key}"`;
           },
           view: 'salesorder_attachments_related'
         }, {
           name: 'SyncHistory',
           label: this.syncHistoryText,
-          where: function where(entry) {
-            return 'EntityType eq "SalesOrder" and EntityId eq "' + entry.$key + '"';
+          where: entry => {
+            return `EntityType eq "SalesOrder" and EntityId eq "${entry.$key}"`;
           },
           view: 'order_syncresult_related'
         }, {
           name: 'SalesPersons',
           label: this.salesPersonsText,
           where: function where(entry) {
-            return 'SalesOrder.Id eq "' + entry.$key + '"';
+            return `SalesOrder.Id eq "${entry.$key}"`;
           },
           view: 'salesorder_salesperson_related'
         }]

--- a/src-out/Integrations/BOE/Views/SalesOrders/Edit.js
+++ b/src-out/Integrations/BOE/Views/SalesOrders/Edit.js
@@ -48,11 +48,11 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('salesOrderEdit');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var dtFormatResource = (0, _I18n2.default)('salesOrderEditDateTimeFormat');
+  const resource = (0, _I18n2.default)('salesOrderEdit');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const dtFormatResource = (0, _I18n2.default)('salesOrderEditDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrders.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrders.Edit', [_Edit2.default], {
     // View Properties
     id: 'salesorder_edit',
     detailView: 'salesorder_detail',
@@ -173,29 +173,27 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
       return values;
     },
     processEntry: function processEntry(entry) {
-      var _this = this;
-
       if (entry && entry.Account) {
-        ['RequestedBy', 'Opportunity'].forEach(function (f) {
-          _this.fields[f].dependsOn = 'Account';
-          _this.fields[f].where = 'Account.Id eq "' + (entry.Account.AccountId || entry.Account.$key || entry.Account.key) + '"';
+        ['RequestedBy', 'Opportunity'].forEach(f => {
+          this.fields[f].dependsOn = 'Account';
+          this.fields[f].where = `Account.Id eq "${entry.Account.AccountId || entry.Account.$key || entry.Account.key}"`;
           if (f === 'Opportunity') {
-            _this.fields[f].where = _this.fields[f].where + ' and Status eq "' + _this.opportunityOpenCode + '"';
+            this.fields[f].where = `${this.fields[f].where} and Status eq "${this.opportunityOpenCode}"`;
           }
         });
       }
-      var warehouseField = this.fields.Warehouse;
-      var locationField = this.fields.Location;
+      const warehouseField = this.fields.Warehouse;
+      const locationField = this.fields.Location;
       if (entry && entry.ErpLogicalId) {
         warehouseField.enable();
         warehouseField.dependsOn = 'ErpLogicalId';
-        warehouseField.where = function (logicalId) {
-          return 'ErpLogicalId eq "' + logicalId + '" and LocationType eq "' + _this.warehouseCode + '"';
+        warehouseField.where = logicalId => {
+          return `ErpLogicalId eq "${logicalId}" and LocationType eq "${this.warehouseCode}"`;
         };
         locationField.enable();
         locationField.dependsOn = 'ErpLogicalId';
-        locationField.where = function (logicalId) {
-          return 'ErpLogicalId eq "' + logicalId + '" and (LocationType eq "' + _this.officeCode + '" or LocationType eq "' + _this.siteCode + '")';
+        locationField.where = logicalId => {
+          return `ErpLogicalId eq "${logicalId}" and (LocationType eq "${this.officeCode}" or LocationType eq "${this.siteCode}")`;
         };
       } else {
         warehouseField.disable();
@@ -220,7 +218,7 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
       this.inherited(setValues, arguments);
 
       if (!this.fields.CurrencyCode.getValue()) {
-        var account = this.fields.Account.currentSelection;
+        const account = this.fields.Account.currentSelection;
         if (account && account.CurrencyCode) {
           this.fields.CurrencyCode.setValue(account.CurrencyCode);
         } else {
@@ -229,12 +227,10 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
       }
     },
     onRefresh: function onRefresh() {
-      var _this2 = this;
-
       this.inherited(onRefresh, arguments);
-      ['RequestedBy', 'Opportunity', 'Warehouse', 'Location'].forEach(function (f) {
-        _this2.fields[f].dependsOn = null;
-        _this2.fields[f].where = null;
+      ['RequestedBy', 'Opportunity', 'Warehouse', 'Location'].forEach(f => {
+        this.fields[f].dependsOn = null;
+        this.fields[f].where = null;
       });
     },
     onRefreshInsert: function onRefreshInsert() {
@@ -242,20 +238,16 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
       this.enableBackOfficeData();
     },
     getEntriesFromIds: function getEntriesFromIds() {
-      var _this3 = this;
-
-      var mappedLookups = ['BackOffice', 'BackOfficeAccountingEntity'];
-      var mappedProperties = ['LogicalId', 'AcctEntityExtId'];
-      var fields = ['ErpLogicalId', 'ErpAccountingEntityId'];
-      _Utility4.default.setFieldsFromIds(mappedLookups, mappedProperties, fields, this).then(function () {
-        _this3.hideBusy();
+      const mappedLookups = ['BackOffice', 'BackOfficeAccountingEntity'];
+      const mappedProperties = ['LogicalId', 'AcctEntityExtId'];
+      const fields = ['ErpLogicalId', 'ErpAccountingEntityId'];
+      _Utility4.default.setFieldsFromIds(mappedLookups, mappedProperties, fields, this).then(() => {
+        this.hideBusy();
       });
     },
     getPrimaryContact: function getPrimaryContact(entry) {
-      var _this4 = this;
-
-      var accountModel = _Adapter2.default.getModel(_Names4.default.ACCOUNT);
-      var relationship = {
+      const accountModel = _Adapter2.default.getModel(_Names4.default.ACCOUNT);
+      const relationship = {
         name: 'Contacts',
         displayName: contactResource.entityDisplayNamePlural,
         type: 'OneToMany',
@@ -264,9 +256,9 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
         relatedPropertyType: 'object',
         where: 'IsPrimary eq true'
       };
-      accountModel.getRelatedRequest(entry, relationship).then(function (result) {
+      accountModel.getRelatedRequest(entry, relationship).then(result => {
         if (result && result.entities && result.entities.length) {
-          var contactField = _this4.fields.RequestedBy;
+          const contactField = this.fields.RequestedBy;
           if (!contactField.currentSelection || contactField.currentSelection.Account && contactField.currentSelection.Account.$key !== entry.$key) {
             contactField.setSelection(result.entities[0]);
           }
@@ -274,13 +266,11 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
       });
     },
     onAccountChange: function onAccountChange(value, field) {
-      var _this5 = this;
-
-      var entry = field.currentSelection;
-      ['RequestedBy', 'Opportunity'].forEach(function (f) {
+      const entry = field.currentSelection;
+      ['RequestedBy', 'Opportunity'].forEach(f => {
         if (value) {
-          _this5.fields[f].dependsOn = 'Account';
-          _this5.fields[f].where = 'Account.Id eq "' + (value.AccountId || value.$key || value.key) + '"';
+          this.fields[f].dependsOn = 'Account';
+          this.fields[f].where = `Account.Id eq "${value.AccountId || value.$key || value.key}"`;
         }
       });
       if (entry) {
@@ -290,7 +280,7 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
           this.fields.ShipTo.enable();
         }
         if (entry.AccountManager) {
-          var accountManagerField = this.fields.AccountManager;
+          const accountManagerField = this.fields.AccountManager;
           accountManagerField.setSelection({
             $key: entry.AccountManager.$key
           });
@@ -298,48 +288,46 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
         field.setValue(field.currentSelection);
         this.showBusy();
         this.getPrimaryContact(entry);
-        _Utility4.default.setFieldsFromIds(['BackOffice', 'BackOfficeAccountingEntity'], ['LogicalId', 'AcctEntityExtId'], ['ErpLogicalId', 'ErpAccountingEntityId'], this, entry).then(function () {
-          _this5.hideBusy();
+        _Utility4.default.setFieldsFromIds(['BackOffice', 'BackOfficeAccountingEntity'], ['LogicalId', 'AcctEntityExtId'], ['ErpLogicalId', 'ErpAccountingEntityId'], this, entry).then(() => {
+          this.hideBusy();
         });
       }
     },
     onAccountDependentChange: function onAccountDependentChange(value, field) {
       if (value && !field.dependsOn && field.currentSelection && field.currentSelection.Account) {
-        var accountField = this.fields.Account;
+        const accountField = this.fields.Account;
         accountField.setSelection(field.currentSelection.Account);
         this.onAccountChange(accountField.getValue(), accountField);
       }
     },
     onBackOfficeChange: function onBackOfficeChange(value, field) {
-      var _this6 = this;
-
       this.fields.BackOffice.setValue(field.currentSelection);
       this.fields.ErpLogicalId.setValue(field.currentSelection.LogicalId);
-      var accountingField = this.fields.BackOfficeAccountingEntity;
-      accountingField.where = 'BackOffice.Id eq "' + field.currentSelection.$key + '"';
+      const accountingField = this.fields.BackOfficeAccountingEntity;
+      accountingField.where = `BackOffice.Id eq "${field.currentSelection.$key}"`;
 
-      var accountingIsToBackOffice = accountingField.currentSelection && accountingField.currentSelection.BackOffice && accountingField.currentSelection.BackOffice.$key === field.currentSelection.$key;
+      const accountingIsToBackOffice = accountingField.currentSelection && accountingField.currentSelection.BackOffice && accountingField.currentSelection.BackOffice.$key === field.currentSelection.$key;
       if (field.currentSelection.BackOfficeAccountingEntities.$resources && !accountingIsToBackOffice) {
-        var entry = field.currentSelection.BackOfficeAccountingEntities.$resources[0];
+        const entry = field.currentSelection.BackOfficeAccountingEntities.$resources[0];
         if (entry) {
           accountingField.setSelection(entry);
           this.onBackOfficeAccountingEntityChange(accountingField.getValue(), accountingField);
         }
       }
-      var warehouseField = this.fields.Warehouse;
+      const warehouseField = this.fields.Warehouse;
       if (warehouseField.isDisabled) {
         warehouseField.enable();
         warehouseField.dependsOn = 'ErpLogicalId';
-        warehouseField.where = function (logicalId) {
-          return 'ErpLogicalId eq "' + logicalId + '" and LocationType eq "' + _this6.warehouseCode + '"';
+        warehouseField.where = logicalId => {
+          return `ErpLogicalId eq "${logicalId}" and LocationType eq "${this.warehouseCode}"`;
         };
       }
-      var locationField = this.fields.Location;
+      const locationField = this.fields.Location;
       if (locationField.isDisabled) {
         locationField.enable();
         locationField.dependsOn = 'ErpLogicalId';
-        locationField.where = function (logicalId) {
-          return 'ErpLogicalId eq "' + logicalId + '" and (LocationType eq "' + _this6.officeCode + '" or LocationType eq "' + _this6.siteCode + '")';
+        locationField.where = logicalId => {
+          return `ErpLogicalId eq "${logicalId}" and (LocationType eq "${this.officeCode}" or LocationType eq "${this.siteCode}")`;
         };
       }
     },
@@ -371,13 +359,13 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
     },
     applyContext: function applyContext() {
       this.inherited(applyContext, arguments);
-      var found = this._getNavContext();
+      const found = this._getNavContext();
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       this.onAccountChange(accountField.getValue(), accountField);
 
-      var context = found && found.options && found.options.source || found;
-      var lookup = {
+      const context = found && found.options && found.options.source || found;
+      const lookup = {
         accounts: this.applyAccountContext,
         contacts: this.applyContactContext,
         opportunities: this.applyOpportunityContext
@@ -397,8 +385,8 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
       }
     },
     _getNavContext: function _getNavContext() {
-      var navContext = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      const navContext = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
 
         if (/^(accounts|contacts|opportunities)$/.test(context.resourceKind) && context.key) {
           return true;
@@ -409,38 +397,38 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
       return navContext;
     },
     applyAccountContext: function applyAccountContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setSelection(entry);
       this.onAccountChange(accountField.getValue(), accountField);
     },
     applyContactContext: function applyContactContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var contactField = this.fields.RequestedBy;
+      const contactField = this.fields.RequestedBy;
       contactField.setSelection(entry);
       this.onAccountDependentChange(contactField.getValue(), contactField);
     },
     applyOpportunityContext: function applyOpportunityContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var opportunityField = this.fields.Opportunity;
+      const opportunityField = this.fields.Opportunity;
       opportunityField.setSelection(entry);
       this.onAccountDependentChange(opportunityField.getValue(), opportunityField);
     },
@@ -453,7 +441,7 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
     },
     showBusy: function showBusy() {
       if (!this._busyIndicator || this._busyIndicator._destroyed) {
-        this._busyIndicator = new _BusyIndicator2.default({ id: this.id + '-busyIndicator' });
+        this._busyIndicator = new _BusyIndicator2.default({ id: `${this.id}-busyIndicator` });
       }
       this._busyIndicator.start();
       App.modal.disableClose = true;
@@ -619,8 +607,8 @@ define('crm/Integrations/BOE/Views/SalesOrders/Edit', ['module', 'exports', 'doj
           emptyText: '',
           valueTextProperty: 'CarrierName',
           view: 'salesorder_carriers',
-          where: function where(value) {
-            return 'ErpLogicalId eq "' + value + '"';
+          where: value => {
+            return `ErpLogicalId eq "${value}"`;
           }
         }, {
           label: this.backOrderedText,

--- a/src-out/Integrations/BOE/Views/SalesOrders/List.js
+++ b/src-out/Integrations/BOE/Views/SalesOrders/List.js
@@ -48,9 +48,9 @@ define('crm/Integrations/BOE/Views/SalesOrders/List', ['module', 'exports', 'doj
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('salesOrdersList');
+  const resource = (0, _I18n2.default)('salesOrdersList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrders.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SalesOrders.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     formatter: _Format2.default,
     util: _Utility2.default,
     // Templates
@@ -110,28 +110,26 @@ define('crm/Integrations/BOE/Views/SalesOrders/List', ['module', 'exports', 'doj
       }]);
     },
     onAddLineItems: function onAddLineItems(evt, selection) {
-      var _this = this;
-
-      var key = selection && selection.data && selection.data.$key;
+      const key = selection && selection.data && selection.data.$key;
       if (key) {
-        var salesOrderModel = App.ModelManager.getModel(_Names2.default.SALESORDER, _Types2.default.SDATA);
-        var isClosedPromise = salesOrderModel.isClosed(key);
-        isClosedPromise.then(function (isClosed) {
+        const salesOrderModel = App.ModelManager.getModel(_Names2.default.SALESORDER, _Types2.default.SDATA);
+        const isClosedPromise = salesOrderModel.isClosed(key);
+        isClosedPromise.then(isClosed => {
           if (isClosed) {
             App.modal.createSimpleAlert({
               title: 'alert',
-              content: _this.statusLabelText + ': ' + (selection.data.Status || '')
+              content: `${this.statusLabelText}: ${selection.data.Status || ''}`
             });
             return;
           }
-          _this.navigateToLineItems(evt, selection);
+          this.navigateToLineItems(evt, selection);
         });
       }
     },
     navigateToLineItems: function navigateToLineItems(evt, selection) {
-      var view = App.getView('salesorder_item_edit');
+      const view = App.getView('salesorder_item_edit');
       if (view) {
-        var options = {
+        const options = {
           insert: true,
           context: {
             SalesOrder: selection.data
@@ -141,11 +139,11 @@ define('crm/Integrations/BOE/Views/SalesOrders/List', ['module', 'exports', 'doj
       }
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(SalesOrderNumber) like "' + q + '%" ) or (upper(ErpExtId) like "' + 0 + '%" ) or (upper(CustomerPurchaseOrderNumber) like "' + q + '%" ) or (upper(Account.AccountName) like "' + q + '%" ) ';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(SalesOrderNumber) like "${q}%" ) or (upper(ErpExtId) like "${0}%" ) or (upper(CustomerPurchaseOrderNumber) like "${q}%" ) or (upper(Account.AccountName) like "${q}%" ) `;
     },
     formatErpStatus: function formatErpStatus(value) {
-      var text = App.picklistService.getPicklistItemTextByCode('ErpSalesOrderStatus', value);
+      const text = App.picklistService.getPicklistItemTextByCode('ErpSalesOrderStatus', value);
       if (text) {
         return text;
       }

--- a/src-out/Integrations/BOE/Views/SyncResults/List.js
+++ b/src-out/Integrations/BOE/Views/SyncResults/List.js
@@ -36,10 +36,10 @@ define('crm/Integrations/BOE/Views/SyncResults/List', ['module', 'exports', 'doj
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('syncResultsList');
-  var dtFormatResource = (0, _I18n2.default)('syncResultsListDateTimeFormat');
+  const resource = (0, _I18n2.default)('syncResultsList');
+  const dtFormatResource = (0, _I18n2.default)('syncResultsListDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SyncResults.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.SyncResults.List', [_List2.default], {
     formatter: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading"><label class="group-label">{%: $$.directionText %}: </label>{%: $.RunName %}</p>', '<p class="micro-text"><label class="group-label">{%: $$.statusText %}: </label>{%: $.HttpStatus %}</p>', '{% if ($.ErrorMessage) { %}', '<p class="micro-text"><label class="group-label">{%: $$.errorMessageText %}: </label>{%: $.ErrorMessage %}</p>', '{% } %}', '{% if ($.SyncedFrom) { %}', '<p class="micro-text"><label class="group-label">{%: $$.sentFromText %}: </label>{%: $.SyncedFrom.Name %}</p>', '{% } %}', '{% if ($.SyncedTo) { %}', '<p class="micro-text"><label class="group-label">{%: $$.processedByText %}: </label>{%: $.SyncedTo.Name %}</p>', '{% } %}', '<p class="micro-text"><label class="group-label">{%: $$.loggedText %}: </label>{%: $$.formatter.date($.Stamp, $$.dateFormatText) %}</p>']),
@@ -75,8 +75,8 @@ define('crm/Integrations/BOE/Views/SyncResults/List', ['module', 'exports', 'doj
       return this.tools || (this.tools = {});
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(HttpStatus) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(HttpStatus) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/Views/UnitsOfMeasure/List.js
+++ b/src-out/Integrations/BOE/Views/UnitsOfMeasure/List.js
@@ -36,9 +36,9 @@ define('crm/Integrations/BOE/Views/UnitsOfMeasure/List', ['module', 'exports', '
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('unitsOfMeasureList');
+  const resource = (0, _I18n2.default)('unitsOfMeasureList');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE.Views.UnitsOfMeasure.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE.Views.UnitsOfMeasure.List', [_List2.default], {
     formatter: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Name %}</p>']),
@@ -64,8 +64,8 @@ define('crm/Integrations/BOE/Views/UnitsOfMeasure/List', ['module', 'exports', '
       return this.tools || (this.tools = {});
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Name) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Name) like "${q}%"`;
     }
   });
 

--- a/src-out/Integrations/BOE/_DashboardWidgetBase.js
+++ b/src-out/Integrations/BOE/_DashboardWidgetBase.js
@@ -52,9 +52,9 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('dashboardWidgetBase');
+  const resource = (0, _I18n2.default)('dashboardWidgetBase');
 
-  var __class = (0, _declare2.default)('crm.Integrations.BOE._DashboardWidgetBase', [_RelatedViewWidgetBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.BOE._DashboardWidgetBase', [_RelatedViewWidgetBase3.default], {
     owner: null,
     id: 'dashboard-widget-base',
     titleText: resource.titleText,
@@ -124,7 +124,19 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
     dashboardTemplate: new Simplate(['<div class="dashboard-widget">', '{%! $$.dashboardHeaderTemplateStart %}', '<div class="node-container accordion-pane">', '{%! $$.dashboardRangeTemplate %}', '<div data-dojo-attach-point="metricsNode" class="dashboard-metric-list"></div>', '</div>', '</div>', '{%! $$.dashboardHeaderTemplateEnd %}']),
     dashboardIconTemplate: new Simplate(['{% if($.titleText) { %}', '<span class="dashboard-icon round info badge" style="background-color:{%= $$.getColor($) %}" >', '{%: $$.getAbrv($) %}', '</span>', '{% } %}']),
     dashboardHeaderTemplateEnd: new Simplate(['{% if($.titleText || $.categoryText) { %}', '</div>', '{% } %}']),
-    dashboardHeaderTemplateStart: new Simplate(['{% if($.titleText || $.categoryText) { %}', '<div class="dashboard-header accordion" data-dojo-attach-point="dashboardHeaderNode">\n      <div class="accordion-header is-selected">\n        <a href="#" class="dashboard-header-text">\n        {%! $$.dashboardIconTemplate %}\n        {% if($.titleText) { %}\n          <div class="dashboard-title">{%: ($.titleText) %} {%: $$.getFormattedCurrencyCodeForTitle() %}</div>\n        {% } %}\n        {% if($.categoryText) { %}\n         <div class="dashboard-category">{%: ($.categoryText) %}</div>\n        {% } %}\n        </a>\n      </div>\n    ', '{% } %}']),
+    dashboardHeaderTemplateStart: new Simplate(['{% if($.titleText || $.categoryText) { %}', `<div class="dashboard-header accordion" data-dojo-attach-point="dashboardHeaderNode">
+      <div class="accordion-header is-selected">
+        <a href="#" class="dashboard-header-text">
+        {%! $$.dashboardIconTemplate %}
+        {% if($.titleText) { %}
+          <div class="dashboard-title">{%: ($.titleText) %} {%: $$.getFormattedCurrencyCodeForTitle() %}</div>
+        {% } %}
+        {% if($.categoryText) { %}
+         <div class="dashboard-category">{%: ($.categoryText) %}</div>
+        {% } %}
+        </a>
+      </div>
+    `, '{% } %}']),
     dashboardRangeTemplate: new Simplate(['{% if($.createRangeLayout) { %}', '<div data-dojo-attach-point="rangeNode" class="dashboard-range-list"></div>', '{% } %}']),
     rangeItemTemplate: new Simplate(['<div class="dashboard-range-item" style="background-color:{%= $$.getColor($) %}">', '</div>']),
     metricItemTemplate: new Simplate(['<div class="dashboard-metric-item {%: $.cls %}" style="background-color:{%= $$.getMetricColor($) %}">', '</div>']),
@@ -139,9 +151,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       return this.parentEntry ? true : false;
     },
     onLoad: function onLoad() {
-      var _this = this;
-
-      var promise = void 0;
+      let promise;
       if (!this.enabled) {
         return promise;
       }
@@ -152,15 +162,15 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       }
       if (this.hasParentEntry()) {
         promise = this.getData();
-        promise.then(function (data) {
+        promise.then(data => {
           if (data && data.length > 0) {
-            _this.entry = data[0];
-            _this.processEntry(_this.entry);
+            this.entry = data[0];
+            this.processEntry(this.entry);
           } else {
-            _this.buildNoDataView({ message: 'no data found' });
+            this.buildNoDataView({ message: 'no data found' });
           }
-        }, function (data) {
-          _this.buildErrorView(data);
+        }, data => {
+          this.buildErrorView(data);
         });
       } else {
         this.buildErrorView({});
@@ -172,16 +182,16 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       this.buildView(entry);
     },
     getData: function getData() {
-      var deferred = new _Deferred2.default();
-      var store = this.getStore();
+      const deferred = new _Deferred2.default();
+      const store = this.getStore();
 
       if (store) {
-        var queryOptions = {};
-        var queryResults = store.query(null, queryOptions);
-        (0, _when2.default)(queryResults, function (feed) {
+        const queryOptions = {};
+        const queryResults = store.query(null, queryOptions);
+        (0, _when2.default)(queryResults, feed => {
           deferred.resolve(feed);
-        }, function (err) {
-          deferred.reject({ message: 'error:' + err });
+        }, err => {
+          deferred.reject({ message: `error:${err}` });
         });
         return deferred.promise;
       }
@@ -189,35 +199,33 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       return deferred.promise;
     },
     getFormattedCurrencyCodeForTitle: function getFormattedCurrencyCodeForTitle() {
-      var result = '';
-      var baseCurrencyCode = _Utility2.default.getBaseCurrencyCode();
+      let result = '';
+      const baseCurrencyCode = _Utility2.default.getBaseCurrencyCode();
 
       if (baseCurrencyCode) {
-        result = '(' + baseCurrencyCode + ')';
+        result = `(${baseCurrencyCode})`;
       }
 
       return result;
     },
     getQueryData: function getQueryData() {
-      var _this2 = this;
-
-      var queryOptions = {
+      const queryOptions = {
         count: this.pageSize,
         start: 0
       };
-      var queryResults = [];
-      var store = this.getQueryStore();
+      const queryResults = [];
+      const store = this.getQueryStore();
 
-      store.forEach(function (storeInstance) {
+      store.forEach(storeInstance => {
         queryResults.push(storeInstance.query(null, queryOptions));
       }, this);
 
       // Maintain the query order in the data from the resolve
-      (0, _all2.default)(queryResults).then(function (results) {
+      (0, _all2.default)(queryResults).then(results => {
         if (results.length > 1) {
-          _this2.sendValues(results);
+          this.sendValues(results);
         } else {
-          _this2.sendValues(results[0]);
+          this.sendValues(results[0]);
         }
       });
     },
@@ -225,13 +233,11 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       this.metricWidgets.push(widget);
     },
     sendValues: function sendValues(results) {
-      var _this3 = this;
-
-      this.metricWidgets.forEach(function (widget) {
-        var obj = _this3.values.filter(_this3.checkForValue, widget)[0];
-        var valueFn = void 0;
-        var values = void 0;
-        var valueIndex = [];
+      this.metricWidgets.forEach(widget => {
+        const obj = this.values.filter(this.checkForValue, widget)[0];
+        let valueFn;
+        let values;
+        const valueIndex = [];
         if (!obj.value) {
           if (obj.aggregate) {
             if (obj.aggregateModule) {
@@ -244,37 +250,35 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
             // Single query, so get the single index value from the results
             valueIndex.push(obj.queryIndex);
             values = results[obj.queryIndex];
-            (0, _when2.default)(valueFn, function (fn) {
-              _this3.applyValue(widget, fn, values, valueIndex, obj);
+            (0, _when2.default)(valueFn, fn => {
+              this.applyValue(widget, fn, values, valueIndex, obj);
             }, function onError(error) {
               this._onQueryError(error, widget);
             });
           } else {
             // Multi query, so pull the indices and add them to a result array to pass to the aggregate function
             values = [];
-            for (var j = 0; j < obj.queryIndex.length; j++) {
+            for (let j = 0; j < obj.queryIndex.length; j++) {
               values.push(results[obj.queryIndex[j]]);
               valueIndex.push(obj.queryIndex[j]);
             }
-            (0, _when2.default)(valueFn, function (fn) {
-              _this3.applyValue(widget, fn, values, valueIndex, obj);
+            (0, _when2.default)(valueFn, fn => {
+              this.applyValue(widget, fn, values, valueIndex, obj);
             }, function onError(error) {
               this._onQueryError(error, widget);
             });
           }
         } else {
-          _this3.applyValue(widget, null, null, valueIndex, obj);
+          this.applyValue(widget, null, null, valueIndex, obj);
         }
       });
     },
     applyValue: function applyValue(widget, valueFn, values, valueIndex, obj) {
-      var _this4 = this;
-
-      var formatterFn = void 0;
+      let formatterFn;
 
       // Sales dashboard widget is using formatModule, but all of the others are using formatterModule. Accept both so overrides happen correctly.
       if (widget.formatterModule && widget.formatter || widget.formatModule && widget.formatter) {
-        var module = widget.formatterModule || widget.formatModule;
+        const module = widget.formatterModule || widget.formatModule;
         formatterFn = module[widget.formatter];
       }
 
@@ -287,7 +291,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       }
 
       // get the formatter
-      (0, _when2.default)(formatterFn, function (func) {
+      (0, _when2.default)(formatterFn, func => {
         if (typeof func === 'function') {
           widget.formatter = func;
         }
@@ -295,11 +299,11 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
 
       // Apply the value to the widget itself by passing obj.value (from the values array) to the value property of the widget
       if (obj.count) {
-        this._getCountValue(widget, obj).then(function (result) {
+        this._getCountValue(widget, obj).then(result => {
           if (result >= 0) {
             obj.countValue = result;
           }
-          _this4.applyDataToWidget(widget, obj);
+          this.applyDataToWidget(widget, obj);
         });
       } else {
         this.applyDataToWidget(widget, obj);
@@ -310,8 +314,8 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
         if (typeof widget.decorator === 'function') {
           widget.decorator(value, widget);
         } else {
-          var decorators = this.getDecorators();
-          var decorator = decorators[widget.decorator];
+          const decorators = this.getDecorators();
+          const decorator = decorators[widget.decorator];
           if (decorator && decorator.fn) {
             decorator.fn.call(decorator, value, widget);
           }
@@ -354,31 +358,31 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       $(widget.metricDetailNode).replaceWith(widget.itemTemplate.apply({ value: error }, widget));
     },
     _getCountValue: function _getCountValue(widget, obj) {
-      var def = new _Deferred2.default();
-      var queryArg = this.queryArgs && this.queryArgs[obj.queryIndex] ? this.queryArgs[obj.queryIndex] : null;
+      const def = new _Deferred2.default();
+      const queryArg = this.queryArgs && this.queryArgs[obj.queryIndex] ? this.queryArgs[obj.queryIndex] : null;
       if (!queryArg) {
         def.resolved(-1);
         return def.promise;
       }
 
-      var queryOptions = {
+      const queryOptions = {
         count: 1,
         start: 0,
         select: ['$key'],
         where: queryArg[1]._activeFilter
       };
 
-      var store = new _SData2.default({
+      const store = new _SData2.default({
         service: App.services.crm,
         contractName: 'dynamic',
         resourceKind: queryArg[0], // resourcekind;
         scope: this
       });
 
-      var queryResults = store.query(null, queryOptions);
-      (0, _when2.default)(queryResults, function () {
+      const queryResults = store.query(null, queryOptions);
+      (0, _when2.default)(queryResults, () => {
         def.resolve(queryResults.total);
-      }, function (error) {
+      }, error => {
         console.warn(error); //eslint-disable-line
         def.reject(error);
       });
@@ -388,14 +392,14 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       $(widget.metricDetailNode).empty();
       if (!data.error) {
         if (data.count && data.countValue >= 0) {
-          $(widget.metricDetailNode).prepend($('<span class="metric-count">' + _string2.default.substitute(data.countTitle ? _Format2.default.encode(data.countTitle) : _Format2.default.encode(widget.countTitle), [_Format2.default.encode(data.countValue)]) + '</span>'));
+          $(widget.metricDetailNode).prepend($(`<span class="metric-count">${_string2.default.substitute(data.countTitle ? _Format2.default.encode(data.countTitle) : _Format2.default.encode(widget.countTitle), [_Format2.default.encode(data.countValue)])}</span>`));
         }
       }
 
       $(widget.metricDetailNode).prepend(widget.itemTemplate.apply({ value: data.value }, widget));
     },
     navToReportView: function navToReportView() {
-      var view = void 0;
+      let view;
 
       if (this.navTo) {
         view = App.getView(this.navTo);
@@ -412,7 +416,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       }
     },
     changeRange: function changeRange() {
-      var view = this.parent;
+      const view = this.parent;
       view.dayValue = this.value;
       // Change the previously selected range color back to what it was and the new selected range color to selected
       view.selectedRange.style['background-color'] = view.getColor();
@@ -422,15 +426,15 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
     },
     buildView: function buildView() {},
     buildNoDataView: function buildNoDataView(entry) {
-      var frag = document.createDocumentFragment();
-      var node = $(this.nodataTemplate.apply(entry, this));
+      const frag = document.createDocumentFragment();
+      const node = $(this.nodataTemplate.apply(entry, this));
       frag.appendChild(node);
       if (frag.childNodes.length > 0) {
         $(this.metricsNode).append(frag);
       }
     },
     getAbrv: function getAbrv() {
-      var abrv = '';
+      let abrv = '';
       abrv = _Format2.default.formatUserInitial(this.titleText);
       return abrv;
     },
@@ -444,7 +448,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       return this.selectedColor;
     },
     getStore: function getStore() {
-      var store = new _SData2.default({
+      const store = new _SData2.default({
         service: this.service,
         contractName: this.contractName,
         resourceKind: this.resourceKind,
@@ -469,7 +473,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
       return this.queryWhere;
     },
     getQueryStore: function getQueryStore() {
-      var store = [];
+      const store = [];
 
       if (!(this.queryArgs instanceof Array) && this.queryArgs) {
         this.queryArgs = [this.queryArgs];
@@ -499,7 +503,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
     rebuildWidgets: function rebuildWidgets() {},
     rebuildValues: function rebuildValues() {
       // TODO: add in functionality to check if value is dependent on datetime (i.e. rangeValue dependent) and force it to update if necessary
-      for (var z = 0; z < this.values.length; z++) {
+      for (let z = 0; z < this.values.length; z++) {
         this.values[z].value = null;
         if (this.values[z].count >= 0) {
           this.values[z].count = true;
@@ -511,9 +515,9 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
      * @params {string, int, int} Property to be searched for, the days ago from the current, and days up to (from current)
      */
     pastDays: function pastDays(property, from, to) {
-      var now = moment();
-      var pastWeekStart = now.clone().subtract(from, 'days').startOf('day');
-      var today = void 0;
+      const now = moment();
+      const pastWeekStart = now.clone().subtract(from, 'days').startOf('day');
+      let today;
 
       if (!to) {
         today = now.clone().endOf('day');
@@ -521,7 +525,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
         today = now.clone().subtract(to, 'days').endOf('day');
       }
 
-      var query = '((' + property + ' between @' + _Convert2.default.toIsoStringFromDate(pastWeekStart.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(today.toDate()) + '@) or (' + property + ' between @' + pastWeekStart.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + today.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
+      const query = `((${property} between @${_Convert2.default.toIsoStringFromDate(pastWeekStart.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(today.toDate())}@) or (${property} between @${pastWeekStart.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${today.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
       return query;
     },
     /*
@@ -529,10 +533,10 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
      * @params {string} Property to be searched for
      */
     pastDaysLt: function pastDaysLt(property) {
-      var now = moment();
-      var pastDay = now.clone().subtract(this.dayValue, 'days').startOf('day');
+      const now = moment();
+      const pastDay = now.clone().subtract(this.dayValue, 'days').startOf('day');
 
-      var query = '(' + property + ' lt @' + _Convert2.default.toIsoStringFromDate(pastDay.toDate()) + '@ or (' + property + ' lt @' + pastDay.format('YYYY-MM-DDT00:00:00[Z]') + '@))';
+      const query = `(${property} lt @${_Convert2.default.toIsoStringFromDate(pastDay.toDate())}@ or (${property} lt @${pastDay.format('YYYY-MM-DDT00:00:00[Z]')}@))`;
       return query;
     },
     hasValidOptions: function hasValidOptions(options) {
@@ -543,7 +547,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
     },
     destroyWidgets: function destroyWidgets() {
       if (this.metricWidgets) {
-        this.metricWidgets.forEach(function (widget) {
+        this.metricWidgets.forEach(widget => {
           widget.destroy();
         });
       }
@@ -560,7 +564,7 @@ define('crm/Integrations/BOE/_DashboardWidgetBase', ['module', 'exports', 'dojo/
     }
   });
 
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('dashboard_widget_base', __class);
   _lang2.default.setObject('crm.Views._DashboardWidgetBase', __class);
   _lang2.default.setObject('icboe._DashboardWidgetBase', __class);

--- a/src-out/Integrations/Contour/ApplicationModule.js
+++ b/src-out/Integrations/Contour/ApplicationModule.js
@@ -40,17 +40,15 @@ define('crm/Integrations/Contour/ApplicationModule', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('proxAppModule');
+  const resource = (0, _I18n2.default)('proxAppModule');
 
-  var __class = (0, _declare2.default)('crm.Integrations.Contour.ApplicationModule', [_ApplicationModule2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.Contour.ApplicationModule', [_ApplicationModule2.default], {
     // Localization strings
     viewAccountsNearbyText: resource.viewAccountsNearbyText,
     helpTitleText: resource.helpTitleText,
 
     isIntegrationEnabled: function isIntegrationEnabled() {
-      var results = this.application.context.integrations.filter(function (integration) {
-        return integration.Name === 'Contour';
-      })[0];
+      const results = this.application.context.integrations.filter(integration => integration.Name === 'Contour')[0];
       return results && results.Enabled;
     },
     loadViewsDynamic: function loadViews() {
@@ -73,11 +71,11 @@ define('crm/Integrations/Contour/ApplicationModule', ['module', 'exports', 'dojo
 
       // We want to add these views to the default set of home screen views.
       // Save the original getDefaultviews() function.
-      var originalDefViews = _Application2.default.prototype.getDefaultViews;
+      const originalDefViews = _Application2.default.prototype.getDefaultViews;
       _lang2.default.extend(_Application2.default, {
-        getDefaultViews: function getDefaultViews() {
+        getDefaultViews() {
           // Get view array from original function, or default to empty array
-          var views = originalDefViews.apply(this, arguments) || [];
+          const views = originalDefViews.apply(this, arguments) || [];
           // Add custom view(s)
           views.push('pxSearch_Accounts');
           views.push('pxSearch_locations');
@@ -86,9 +84,9 @@ define('crm/Integrations/Contour/ApplicationModule', ['module', 'exports', 'dojo
       });
 
       // Add the new help
-      var onHelpRowCreated = crm.Views.Help.prototype.onHelpRowCreated;
+      const onHelpRowCreated = crm.Views.Help.prototype.onHelpRowCreated;
       this.registerCustomization('detail', 'help', {
-        at: function at(row) {
+        at: row => {
           return row.name === 'HelpSection';
         },
         type: 'insert',
@@ -109,13 +107,12 @@ define('crm/Integrations/Contour/ApplicationModule', ['module', 'exports', 'dojo
 
       this.registerAccountMods();
     },
-    registerAccountMods: function registerAccountMods() {
+    registerAccountMods() {
       // add the view nearby button
       this.registerCustomization('detail', 'account_detail', {
-        at: function at(row) {
+        at(row) {
           return row.name === 'AddNoteAction';
         },
-
         type: 'insert',
         value: {
           name: 'ViewNearbyAction',
@@ -130,13 +127,13 @@ define('crm/Integrations/Contour/ApplicationModule', ['module', 'exports', 'dojo
         addressNotGeocodedErrorText: resource.addressNotGeocodedErrorText,
         accountsNearText: resource.accountsNearText,
         querySelect: crm.Views.Account.Detail.prototype.querySelect.concat(['Address/GeocodeFailed', 'Address/GeocodeLatitude', 'Address/GeocodeLongitude', 'Address/GeocodeProvider']),
-        viewNearby: function viewNearby() {
+        viewNearby() {
           if (this.entry.Address.GeocodeFailed !== null && this.entry.Address.GeocodeFailed === true || this.entry.Address.GeocodeProvider === null || this.entry.Address.GeocodeLatitude === null || this.entry.Address.GeocodeLongitude === null) {
             alert(this.addressNotGeocodedErrorText); // eslint-disable-line
             return;
           }
-          var geocode = this.entry.Address;
-          var view = App.getView('pxSearch_Accounts');
+          const geocode = this.entry.Address;
+          const view = App.getView('pxSearch_Accounts');
           view.refreshRequired = true;
           view.lat = geocode.GeocodeLatitude;
           view.lon = geocode.GeocodeLongitude;

--- a/src-out/Integrations/Contour/Models/Place/Base.js
+++ b/src-out/Integrations/Contour/Models/Place/Base.js
@@ -32,10 +32,10 @@ define('crm/Integrations/Contour/Models/Place/Base', ['module', 'exports', 'dojo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('placeModel'); // eslint-disable-line
-  var addressResource = (0, _I18n2.default)('addressModel');
+  const resource = (0, _I18n2.default)('placeModel'); // eslint-disable-line
+  const addressResource = (0, _I18n2.default)('addressModel');
 
-  var __class = (0, _declare2.default)('crm.Integrations.Contour.Models.Place.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.Contour.Models.Place.Base', [_ModelBase3.default], {
     resourceKind: 'places',
     entityName: 'Place',
     entityDisplayName: resource.entityDisplayName,
@@ -43,7 +43,7 @@ define('crm/Integrations/Contour/Models/Place/Base', ['module', 'exports', 'dojo
     modelName: _Names2.default.PLACE,
     listViewId: 'pxSearch_locations',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Addresses',
         displayName: addressResource.entityDisplayNamePlural,
         type: 'OneToMany',

--- a/src-out/Integrations/Contour/Models/Place/Offline.js
+++ b/src-out/Integrations/Contour/Models/Place/Offline.js
@@ -36,7 +36,7 @@ define('crm/Integrations/Contour/Models/Place/Offline', ['module', 'exports', 'd
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.Contour.Models.Place.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.Contour.Models.Place.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'place_offline_model'
   });
 

--- a/src-out/Integrations/Contour/Models/Place/SData.js
+++ b/src-out/Integrations/Contour/Models/Place/SData.js
@@ -36,13 +36,13 @@ define('crm/Integrations/Contour/Models/Place/SData', ['module', 'exports', 'doj
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Integrations.Contour.Models.Place.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.Contour.Models.Place.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'place_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
         name: 'list',
         queryOrderBy: 'Name',
-        queryWhere: '(ThisUserOnly eq "F" or (ThisUserOnly eq "T" and UserId eq "' + App.context.user.$key + '"))',
+        queryWhere: `(ThisUserOnly eq "F" or (ThisUserOnly eq "T" and UserId eq "${App.context.user.$key}"))`,
         querySelect: ['Name', 'ModifyDate', 'ThisUserOnly', 'Address/Address1', 'Address/Address2', 'Address/City', 'Address/State', 'Address/PostalCode', 'Address/Country', 'Address/CountryCode', 'Address/GeocodeProvider', 'Address/GeocodeLatitude', 'Address/GeocodeLongitude', 'Address/GeocodeFailed']
       }];
     }

--- a/src-out/Integrations/Contour/Views/PxSearch/AccountPxSearch.js
+++ b/src-out/Integrations/Contour/Views/PxSearch/AccountPxSearch.js
@@ -31,22 +31,22 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
     };
   }
 
-  var resource = (0, _I18n2.default)('acctPxSearch'); /* Copyright 2017 Infor
-                                                       *
-                                                       * Licensed under the Apache License, Version 2.0 (the "License");
-                                                       * you may not use this file except in compliance with the License.
-                                                       * You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing, software
-                                                       * distributed under the License is distributed on an "AS IS" BASIS,
-                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                       * See the License for the specific language governing permissions and
-                                                       * limitations under the License.
-                                                       */
+  const resource = (0, _I18n2.default)('acctPxSearch'); /* Copyright 2017 Infor
+                                                         *
+                                                         * Licensed under the Apache License, Version 2.0 (the "License");
+                                                         * you may not use this file except in compliance with the License.
+                                                         * You may obtain a copy of the License at
+                                                         *
+                                                         *    http://www.apache.org/licenses/LICENSE-2.0
+                                                         *
+                                                         * Unless required by applicable law or agreed to in writing, software
+                                                         * distributed under the License is distributed on an "AS IS" BASIS,
+                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                         * See the License for the specific language governing permissions and
+                                                         * limitations under the License.
+                                                         */
 
-  var __class = (0, _declare2.default)('crm.Integrations.Contour.Views.PxSearch.AccountPxSearch', [_List2.default, _LegacySDataListMixin2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.Contour.Views.PxSearch.AccountPxSearch', [_List2.default, _LegacySDataListMixin2.default], {
     // Localization strings
     accountsNearMeText: resource.accountsNearMeText,
     addActivityActionText: resource.addActivityActionText,
@@ -68,17 +68,17 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
     '</p>', '{% } %}']),
     itemRowContentTemplate: new Simplate(['<div id="top_item_indicators" class="list-item-indicator-content"></div>', '<div class="list-item-content">{%! $$.itemTemplate %}</div>']),
 
-    formatDecimal: function formatDecimal(n) {
+    // Functions
+    formatDecimal(n) {
       return _Format2.default.fixedLocale(n, 2);
     },
-    distanceText: function distanceText() {
+    distanceText() {
       return App.isCurrentRegionMetric() ? this.kilometerAbbrevText : this.mileAbbrevText;
     },
-    distanceCalc: function distanceCalc(gLat, gLon) {
-      var conv = App.isCurrentRegionMetric() ? 1.609344 : 1;
+    distanceCalc(gLat, gLon) {
+      const conv = App.isCurrentRegionMetric() ? 1.609344 : 1;
       return conv * Math.sqrt(Math.pow(69.1 * (gLat - this.lat), 2) + Math.pow(53.0 * (gLon - this.lon), 2));
     },
-
     joinFields: function joinFields(sep, fields) {
       return _Utility2.default.joinFields(sep, fields);
     },
@@ -113,9 +113,9 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
     lon: null, // longitude
 
     createRequest: function createRequest() {
-      var request = new Sage.SData.Client.SDataBaseRequest(this.getService());
-      var pageSize = this.pageSize;
-      var startIndex = this.feed && this.feed.$startIndex > 0 && this.feed.$itemsPerPage > 0 ? this.feed.$startIndex + this.feed.$itemsPerPage : 1;
+      const request = new Sage.SData.Client.SDataBaseRequest(this.getService());
+      const pageSize = this.pageSize;
+      const startIndex = this.feed && this.feed.$startIndex > 0 && this.feed.$itemsPerPage > 0 ? this.feed.$startIndex + this.feed.$itemsPerPage : 1;
       request.uri.setPathSegment(0, '$app');
       request.uri.setPathSegment(1, 'mashups');
       request.uri.setPathSegment(2, '-');
@@ -133,17 +133,16 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
       request.uri.setCount(pageSize);
       return request;
     },
-    _requestDistanceCalc: function _requestDistanceCalc() {
-      var conv = App.isCurrentRegionMetric() ? 1.609344 : 1;
-      return '((' + conv + ' mul sqrt((((69.1 mul (Address.GeocodeLatitude-(' + this.lat + ')))) mul (69.1 mul (Address.GeocodeLatitude-(' + this.lat + '))))+((53 mul (Address.GeocodeLongitude-(' + this.lon + '))) mul (53 mul (Address.GeocodeLongitude-(' + this.lon + ')))))) lt ' + this.maxDistance + ')';
+    _requestDistanceCalc() {
+      const conv = App.isCurrentRegionMetric() ? 1.609344 : 1;
+      return `((${conv} mul sqrt((((69.1 mul (Address.GeocodeLatitude-(${this.lat})))) mul (69.1 mul (Address.GeocodeLatitude-(${this.lat}))))+((53 mul (Address.GeocodeLongitude-(${this.lon}))) mul (53 mul (Address.GeocodeLongitude-(${this.lon})))))) lt ${this.maxDistance})`;
     },
-
     requestData: function requestData() {
       this.loadAccountTypes();
       $(this.domNode).addClass('list-loading');
 
       if (this.lat && this.lon) {
-        var request = this.createRequest();
+        const request = this.createRequest();
         request.service.readFeed(request, {
           success: this.onRequestDataSuccess,
           failure: this.onRequestDataFailure,
@@ -162,7 +161,7 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
       $(this.domNode).removeClass('list-loading');
     },
     processFeed: function processFeed(_feed) {
-      var feed = _feed;
+      const feed = _feed;
       if (!this.feed) {
         this.set('listContent', '');
       }
@@ -172,12 +171,12 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
       if (this.feed.$totalResults === 0) {
         this.set('listContent', this.noDataTemplate.apply(this));
       } else if (feed.$resources) {
-        var docfrag = document.createDocumentFragment();
-        for (var i = 0; i < feed.$resources.length; i++) {
-          var entry = feed.$resources[i];
+        const docfrag = document.createDocumentFragment();
+        for (let i = 0; i < feed.$resources.length; i++) {
+          const entry = feed.$resources[i];
           entry.$descriptor = entry.$descriptor || feed.$descriptor;
           this.entries[entry.$key] = entry;
-          var rowNode = $(this.rowTemplate.apply(entry, this)).get(0);
+          const rowNode = $(this.rowTemplate.apply(entry, this)).get(0);
           docfrag.appendChild(rowNode);
           this.onApplyRowTemplate(entry, rowNode);
           if (this.relatedViews.length > 0) {
@@ -191,7 +190,7 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
       }
 
       if (typeof this.feed.$totalResults !== 'undefined') {
-        var remaining = this.feed.$totalResults - (this.feed.$startIndex + this.feed.$itemsPerPage - 1);
+        const remaining = this.feed.$totalResults - (this.feed.$startIndex + this.feed.$itemsPerPage - 1);
         this.set('remainingContent', _string2.default.substitute(this.remainingText, [remaining]));
       }
 
@@ -239,17 +238,16 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
     loadAccountTypes: function loadAccountTypes() {
       this.queryTypeEl = document.getElementById('queryType');
       this.queryTypeEl.onchange = _lang2.default.hitch(this, 'onAccountTypeChange'); // this.;
-      var request = new Sage.SData.Client.SDataResourceCollectionRequest(App.getService()).setResourceKind('picklists').setContractName('system');
-      var uri = request.getUri();
+      const request = new Sage.SData.Client.SDataResourceCollectionRequest(App.getService()).setResourceKind('picklists').setContractName('system');
+      const uri = request.getUri();
       uri.setPathSegment(Sage.SData.Client.SDataUri.ResourcePropertyIndex, 'items');
       uri.setCollectionPredicate('name eq "Account Type"');
       request.allowCacheUse = true;
       request.read({
         success: this.onAccountTypeLoad,
-        failure: function failure() {
+        failure() {
           console.error('failed to load account type'); // eslint-disable-line
         },
-
         scope: this
       });
     },
@@ -263,7 +261,7 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
         return;
       }
 
-      for (var i = 0; i < data.$resources.length; i++) {
+      for (let i = 0; i < data.$resources.length; i++) {
         this.queryTypeEl.options[i] = new Option(data.$resources[i].text, data.$resources[i].code, true, false);
         if (this.queryTypeEl.options[i].value === 'Customer') {
           this.queryTypeEl.options[i].selected = 'True';
@@ -271,7 +269,7 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
       }
     },
     formatSearchQuery: function formatSearchQuery(qry) {
-      return 'AccountName like "' + this.escapeSearchQuery(qry) + '%"';
+      return `AccountName like "${this.escapeSearchQuery(qry)}%"`;
     },
     createActionLayout: function createActionLayout() {
       return this.actions || (this.actions = [{
@@ -298,7 +296,7 @@ define('crm/Integrations/Contour/Views/PxSearch/AccountPxSearch', ['module', 'ex
       }]);
     },
     callMain: function callMain(params) {
-      this.invokeActionItemBy(function (a) {
+      this.invokeActionItemBy(a => {
         return a.id === 'callMain';
       }, params.key);
     }

--- a/src-out/Integrations/Contour/Views/PxSearch/LocationPicker.js
+++ b/src-out/Integrations/Contour/Views/PxSearch/LocationPicker.js
@@ -36,13 +36,15 @@ define('crm/Integrations/Contour/Views/PxSearch/LocationPicker', ['module', 'exp
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('locPicker');
+  const resource = (0, _I18n2.default)('locPicker');
 
-  var __class = (0, _declare2.default)('crm.Integrations.Contour.Views.PxSearch.LocationPicker', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Integrations.Contour.Views.PxSearch.LocationPicker', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Name %}</p>']),
     // overriding the stock rowTemplate with our custom key and descriptor
-    liRowTemplate: new Simplate(['<li data-action="activateEntry" data-key="{%: $.$key %}" data-descriptor="{%: $.$descriptor %}" data-lat="{%: $.Address.GeocodeLatitude %}" data-lon="{%: $.Address.GeocodeLongitude %}">', '<button data-action="selectEntry" class="list-item-selector btn-icon hide-focus">', '<svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n        <use xlink:href="#icon-{%= $$.icon || $$.selectIcon %}" />\n      </svg>', '</button>', '<div class="list-item-content">{%! $$.itemTemplate %}</div>', '</li>']),
+    liRowTemplate: new Simplate(['<li data-action="activateEntry" data-key="{%: $.$key %}" data-descriptor="{%: $.$descriptor %}" data-lat="{%: $.Address.GeocodeLatitude %}" data-lon="{%: $.Address.GeocodeLongitude %}">', '<button data-action="selectEntry" class="list-item-selector btn-icon hide-focus">', `<svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-{%= $$.icon || $$.selectIcon %}" />
+      </svg>`, '</button>', '<div class="list-item-content">{%! $$.itemTemplate %}</div>', '</li>']),
     isCardView: false,
 
     // Localization
@@ -73,27 +75,25 @@ define('crm/Integrations/Contour/Views/PxSearch/LocationPicker', ['module', 'exp
       this.inherited(startup, arguments);
       this._getUserInfoAddresses();
     },
-    _getUserInfoAddresses: function _getUserInfoAddresses() {
-      var _this = this;
-
+    _getUserInfoAddresses() {
       if (App.context.user) {
-        var querySelect = ['UserInfo/Address/GeocodeProvider', 'UserInfo/Address/GeocodeLatitude', 'UserInfo/Address/GeocodeLongitude', 'UserInfo/Address/GeocodeFailed', 'UserInfo/HomeAddress/GeocodeProvider', 'UserInfo/HomeAddress/GeocodeLatitude', 'UserInfo/HomeAddress/GeocodeLongitude', 'UserInfo/HomeAddress/GeocodeFailed'];
-        var request = new Sage.SData.Client.SDataSingleResourceRequest(App.getService()).setResourceKind('users').setResourceSelector('\'' + App.context.user.$key + '\'').setQueryArg('select', querySelect.join(','));
+        const querySelect = ['UserInfo/Address/GeocodeProvider', 'UserInfo/Address/GeocodeLatitude', 'UserInfo/Address/GeocodeLongitude', 'UserInfo/Address/GeocodeFailed', 'UserInfo/HomeAddress/GeocodeProvider', 'UserInfo/HomeAddress/GeocodeLatitude', 'UserInfo/HomeAddress/GeocodeLongitude', 'UserInfo/HomeAddress/GeocodeFailed'];
+        const request = new Sage.SData.Client.SDataSingleResourceRequest(App.getService()).setResourceKind('users').setResourceSelector(`'${App.context.user.$key}'`).setQueryArg('select', querySelect.join(','));
 
         request.read({
-          success: function success(data) {
+          success: data => {
             if (data.UserInfo.Address && data.UserInfo.Address.GeocodeFailed === false) {
-              _this._myWork = _this._createPlaceEntry(_this.myOfficeText, data.UserInfo.Address);
+              this._myWork = this._createPlaceEntry(this.myOfficeText, data.UserInfo.Address);
             }
             if (data.UserInfo.HomeAddress && data.UserInfo.HomeAddress.GeocodeFailed === false) {
-              _this._myHome = _this._createPlaceEntry(_this.myHouseText, data.UserInfo.HomeAddress);
+              this._myHome = this._createPlaceEntry(this.myHouseText, data.UserInfo.HomeAddress);
             }
           }
         });
       }
     },
-    _createPlaceEntry: function _createPlaceEntry(name, address) {
-      var plc = {};
+    _createPlaceEntry(name, address) {
+      const plc = {};
       plc.Address = address;
       plc.$descriptor = plc.Name = name;
       plc.$httpStatus = 200;
@@ -101,7 +101,7 @@ define('crm/Integrations/Contour/Views/PxSearch/LocationPicker', ['module', 'exp
       plc.ThisUserOnly = true;
       return plc;
     },
-    processData: function processData(entries) {
+    processData(entries) {
       // Inject the current user's addresses
       if (this._myHome) {
         entries.unshift(this._myHome);
@@ -114,17 +114,17 @@ define('crm/Integrations/Contour/Views/PxSearch/LocationPicker', ['module', 'exp
         return;
       }
 
-      var count = entries.length;
+      const count = entries.length;
 
       if (count > 0) {
-        var docfrag = document.createDocumentFragment();
-        for (var i = 0; i < count; i++) {
-          var entry = this._processEntry(entries[i]);
+        const docfrag = document.createDocumentFragment();
+        for (let i = 0; i < count; i++) {
+          const entry = this._processEntry(entries[i]);
           // If key comes back with nothing, check that the store is properly
           // setup with an idProperty
           this.entries[this.getIdentity(entry)] = entry;
 
-          var rowNode = this.createItemRowNode(entry);
+          const rowNode = this.createItemRowNode(entry);
 
           docfrag.appendChild(rowNode);
           this.onApplyRowTemplate(entry, rowNode);
@@ -135,8 +135,9 @@ define('crm/Integrations/Contour/Views/PxSearch/LocationPicker', ['module', 'exp
         }
       }
     },
-    activateEntry: function activateEntry(params) {
-      var view = App.getView('pxSearch_Accounts');
+    // custom activateEntry method since we aren't actually opening a detail view
+    activateEntry(params) {
+      const view = App.getView('pxSearch_Accounts');
       if (params.key === 'Me') {
         view.show();
       } else {
@@ -147,10 +148,9 @@ define('crm/Integrations/Contour/Views/PxSearch/LocationPicker', ['module', 'exp
         }, {});
       }
     },
-
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery);
-      return '(ThisUserOnly eq "F" or (ThisUserOnly eq "T" and UserId eq "' + App.context.user.$key + '")) and Name like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery);
+      return `(ThisUserOnly eq "F" or (ThisUserOnly eq "T" and UserId eq "${App.context.user.$key}")) and Name like "%${q}%"`;
     }
   });
 

--- a/src-out/MingleUtility.js
+++ b/src-out/MingleUtility.js
@@ -18,30 +18,28 @@ define('crm/MingleUtility', ['module', 'exports', 'dojo/_base/lang', 'argos/I18n
    * @alias module:crm/MingleUtility
    * @static
    */
-  var __class = _lang2.default.setObject('crm.MingleUtility', /** @lends module:crm/MingleUtility */{
+  const __class = _lang2.default.setObject('crm.MingleUtility', /** @lends module:crm/MingleUtility */{
     accessToken: '',
 
-    refreshAccessToken: function refreshAccessToken(appConfig) {
+    refreshAccessToken(appConfig) {
       if (!App.isOnline()) {
         App.requiresMingleRefresh = true;
         return;
       }
 
-      var hash = 'mingleRefresh'; // location.hash.substring(2);
-      var state = '';
+      const hash = 'mingleRefresh'; // location.hash.substring(2);
+      let state = '';
       if (hash) {
-        state = '/redirectTo/' + hash;
+        state = `/redirectTo/${hash}`;
       }
       this.redirectToMingle(appConfig, state);
     },
-    populateAccessToken: function populateAccessToken(appConfig) {
-      var _this = this;
-
-      var hash = location.hash.substring(1);
-      var result = void 0;
+    populateAccessToken(appConfig) {
+      const hash = location.hash.substring(1);
+      let result;
       if (hash) {
-        result = hash.split('&').reduce(function (values, item) {
-          var parts = item.split('=');
+        result = hash.split('&').reduce((values, item) => {
+          const parts = item.split('=');
           values[parts[0]] = parts[1];
           return values;
         }, {});
@@ -50,11 +48,11 @@ define('crm/MingleUtility', ['module', 'exports', 'dojo/_base/lang', 'argos/I18n
           this.accessToken = result.access_token;
           if (result.expires_in) {
             // result.expires_in = '420'; // Refresh Test
-            setTimeout(function () {
-              var resource = (0, _I18n2.default)('mingle');
+            setTimeout(() => {
+              const resource = (0, _I18n2.default)('mingle');
               App.toast.add({ message: resource.refreshText, title: resource.refreshTitle, toastTime: 300 * 1000, showProgressBar: true });
-              setTimeout(function () {
-                _this.refreshAccessToken(appConfig);
+              setTimeout(() => {
+                this.refreshAccessToken(appConfig);
               }, 300 * 1000);
               // Show message to user before 5 minutes of refresh (300 seconds)
             }, (result.expires_in - 300) * 1000);
@@ -70,12 +68,12 @@ define('crm/MingleUtility', ['module', 'exports', 'dojo/_base/lang', 'argos/I18n
 
       this.redirectToMingle(appConfig, hash);
     },
-    redirectToMingle: function redirectToMingle(appConfig, state) {
-      var authorizationUrl = appConfig.mingleSettings.pu + appConfig.mingleSettings.oa;
-      var redirectURI = appConfig.mingleRedirectUrl;
-      var clientId = appConfig.mingleSettings.ci;
-      var responseType = 'token';
-      var url = authorizationUrl + '?' + ('client_id=' + encodeURI(clientId) + '&') + ('redirect_uri=' + encodeURI(redirectURI) + '&') + ('response_type=' + encodeURI(responseType) + '&') + ('state=' + encodeURI(state) + '&') + 'include_granted_scopes=false';
+    redirectToMingle(appConfig, state) {
+      const authorizationUrl = appConfig.mingleSettings.pu + appConfig.mingleSettings.oa;
+      const redirectURI = appConfig.mingleRedirectUrl;
+      const clientId = appConfig.mingleSettings.ci;
+      const responseType = 'token';
+      const url = `${authorizationUrl}?` + `client_id=${encodeURI(clientId)}&` + `redirect_uri=${encodeURI(redirectURI)}&` + `response_type=${encodeURI(responseType)}&` + `state=${encodeURI(state)}&` + 'include_granted_scopes=false';
       window.location = url;
     }
   }); /* Copyright 2017 Infor

--- a/src-out/Models/Account/Base.js
+++ b/src-out/Models/Account/Base.js
@@ -32,15 +32,15 @@ define('crm/Models/Account/Base', ['module', 'exports', 'dojo/_base/declare', 'a
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('accountModel');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var activityResource = (0, _I18n2.default)('activityModel');
-  var historyResource = (0, _I18n2.default)('historyModel');
-  var oppResource = (0, _I18n2.default)('opportunityModel');
-  var addressResource = (0, _I18n2.default)('addressModel');
-  var ticketResource = (0, _I18n2.default)('ticketModel');
+  const resource = (0, _I18n2.default)('accountModel');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const activityResource = (0, _I18n2.default)('activityModel');
+  const historyResource = (0, _I18n2.default)('historyModel');
+  const oppResource = (0, _I18n2.default)('opportunityModel');
+  const addressResource = (0, _I18n2.default)('addressModel');
+  const ticketResource = (0, _I18n2.default)('ticketModel');
 
-  var __class = (0, _declare2.default)('crm.Models.Account.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Account.Base', [_ModelBase3.default], {
     resourceKind: 'accounts',
     entityName: 'Account',
     entityDisplayName: resource.entityDisplayName,
@@ -63,7 +63,7 @@ define('crm/Models/Account/Base', ['module', 'exports', 'dojo/_base/declare', 'a
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Addresses',
         displayName: addressResource.entityDisplayNamePlural,
         type: 'OneToMany',

--- a/src-out/Models/Account/Offline.js
+++ b/src-out/Models/Account/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/Account/Offline', ['module', 'exports', 'dojo/_base/declare',
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Account.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Account.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'account_offline_model'
   });
 

--- a/src-out/Models/Account/SData.js
+++ b/src-out/Models/Account/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/Account/SData', ['module', 'exports', 'dojo/_base/declare', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Account.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Account.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'account_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -50,10 +50,10 @@ define('crm/Models/Account/SData', ['module', 'exports', 'dojo/_base/declare', '
       }];
     },
     getEntry: function getEntry() /* options */{
-      var results$ = this.inherited(getEntry, arguments);
-      return results$.then(function (entry) {
-        return new Promise(function (resolve) {
-          App.picklistService.requestPicklist('Account ' + entry.Type).then(function () {
+      const results$ = this.inherited(getEntry, arguments);
+      return results$.then(entry => {
+        return new Promise(resolve => {
+          App.picklistService.requestPicklist(`Account ${entry.Type}`).then(() => {
             resolve(entry);
           });
         });

--- a/src-out/Models/Activity/ActivityTypePicklists.js
+++ b/src-out/Models/Activity/ActivityTypePicklists.js
@@ -18,7 +18,7 @@ define('crm/Models/Activity/ActivityTypePicklists', ['exports'], function (expor
    * limitations under the License.
    */
 
-  var ActivityTypePicklists = exports.ActivityTypePicklists = {
+  const ActivityTypePicklists = exports.ActivityTypePicklists = {
     atAppointment: {
       Category: 'Meeting Category Codes',
       Description: 'Meeting Regarding',

--- a/src-out/Models/Activity/ActivityTypeText.js
+++ b/src-out/Models/Activity/ActivityTypeText.js
@@ -11,20 +11,20 @@ define('crm/Models/Activity/ActivityTypeText', ['module', 'exports', 'argos/I18n
     };
   }
 
-  var resource = (0, _I18n2.default)('activityTypeText'); /* Copyright 2017 Infor
-                                                           *
-                                                           * Licensed under the Apache License, Version 2.0 (the "License");
-                                                           * you may not use this file except in compliance with the License.
-                                                           * You may obtain a copy of the License at
-                                                           *
-                                                           *    http://www.apache.org/licenses/LICENSE-2.0
-                                                           *
-                                                           * Unless required by applicable law or agreed to in writing, software
-                                                           * distributed under the License is distributed on an "AS IS" BASIS,
-                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                           * See the License for the specific language governing permissions and
-                                                           * limitations under the License.
-                                                           */
+  const resource = (0, _I18n2.default)('activityTypeText'); /* Copyright 2017 Infor
+                                                             *
+                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                             * you may not use this file except in compliance with the License.
+                                                             * You may obtain a copy of the License at
+                                                             *
+                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                             *
+                                                             * Unless required by applicable law or agreed to in writing, software
+                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                             * See the License for the specific language governing permissions and
+                                                             * limitations under the License.
+                                                             */
 
   exports.default = {
     atToDo: resource.atToDoText,

--- a/src-out/Models/Activity/Base.js
+++ b/src-out/Models/Activity/Base.js
@@ -36,16 +36,16 @@ define('crm/Models/Activity/Base', ['module', 'exports', 'dojo/_base/declare', '
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityModel');
-  var attendeeResource = (0, _I18n2.default)('activityAttendeeModel');
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var oppResource = (0, _I18n2.default)('opportunityModel');
-  var ticketResource = (0, _I18n2.default)('ticketModel');
-  var leadResource = (0, _I18n2.default)('leadModel');
-  var activityTypeResource = (0, _I18n2.default)('activityTypeText');
+  const resource = (0, _I18n2.default)('activityModel');
+  const attendeeResource = (0, _I18n2.default)('activityAttendeeModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const oppResource = (0, _I18n2.default)('opportunityModel');
+  const ticketResource = (0, _I18n2.default)('ticketModel');
+  const leadResource = (0, _I18n2.default)('leadModel');
+  const activityTypeResource = (0, _I18n2.default)('activityTypeText');
 
-  var __class = (0, _declare2.default)('crm.Models.Activity.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Activity.Base', [_ModelBase3.default], {
     modelName: _Names2.default.ACTIVITY,
     entityName: 'Activity',
     entityDisplayName: resource.entityDisplayName,
@@ -73,7 +73,7 @@ define('crm/Models/Activity/Base', ['module', 'exports', 'dojo/_base/declare', '
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayName,
         type: 'ManyToOne',
@@ -113,25 +113,25 @@ define('crm/Models/Activity/Base', ['module', 'exports', 'dojo/_base/declare', '
       return rel;
     },
     getIconClass: function getIconClass(entry) {
-      var cls = this.iconClass;
+      let cls = this.iconClass;
       if (entry && entry.Type) {
         cls = _ActivityTypeIcon2.default[entry.Type];
         if (cls) {
-          cls = '' + cls;
+          cls = `${cls}`;
         }
       }
       return cls;
     },
     getEntityDescription: function getEntityDescription(entry) {
       if (entry) {
-        var type = entry.Type || '';
-        var titleText = this.activityTypeText[type] ? this.activityTypeText[type] + ' - ' + entry.Description : entry.$descriptor;
+        const type = entry.Type || '';
+        const titleText = this.activityTypeText[type] ? `${this.activityTypeText[type]} - ${entry.Description}` : entry.$descriptor;
         return titleText;
       }
       return '';
     },
     getTypeText: function getTypeText(entry) {
-      var name = '';
+      let name = '';
       if (entry && entry.Type) {
         name = _ActivityTypeText2.default[entry.Type];
       }

--- a/src-out/Models/Activity/Offline.js
+++ b/src-out/Models/Activity/Offline.js
@@ -23,18 +23,18 @@ define('crm/Models/Activity/Offline', ['module', 'exports', 'dojo/_base/declare'
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Models.Activity.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Activity.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'activity_offline_model',
     onActivityCompleted: function onActivityCompleted(entry) {
-      var def = new _Deferred2.default();
-      var key = entry.$completedBasedOn ? entry.$completedBasedOn.$key : entry.$key;
+      const def = new _Deferred2.default();
+      const key = entry.$completedBasedOn ? entry.$completedBasedOn.$key : entry.$key;
       this.deleteEntry(key);
       this.removeFromAuxiliaryEntities(key);
       def.resolve();
       return def.promise;
     },
     onEntryUpdated: function onEntryUpdated(entry, orginalEntry) {
-      var def = new _Deferred2.default();
+      const def = new _Deferred2.default();
 
       if (entry && entry.$key && orginalEntry && orginalEntry.$key) {
         if (entry.$key !== orginalEntry.$key) {

--- a/src-out/Models/ActivityAttendee/Base.js
+++ b/src-out/Models/ActivityAttendee/Base.js
@@ -32,9 +32,9 @@ define('crm/Models/ActivityAttendee/Base', ['module', 'exports', 'dojo/_base/dec
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityAttendeeModel');
+  const resource = (0, _I18n2.default)('activityAttendeeModel');
 
-  var __class = (0, _declare2.default)('crm.Models.ActivityAttendee.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.ActivityAttendee.Base', [_ModelBase3.default], {
     resourceKind: 'activityAttendees',
     entityName: 'ActivityAttendee',
     entityDisplayName: resource.entityDisplayName,

--- a/src-out/Models/ActivityAttendee/Offline.js
+++ b/src-out/Models/ActivityAttendee/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/ActivityAttendee/Offline', ['module', 'exports', 'dojo/_base/
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.ActivityAttendee.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.ActivityAttendee.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'activity_attendee_offline_model'
   });
 

--- a/src-out/Models/ActivityAttendee/SData.js
+++ b/src-out/Models/ActivityAttendee/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/ActivityAttendee/SData', ['module', 'exports', 'dojo/_base/de
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.ActivityAttendee.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.ActivityAttendee.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'activity_attendee_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -54,11 +54,9 @@ define('crm/Models/ActivityAttendee/SData', ['module', 'exports', 'dojo/_base/de
       }];
     },
     deleteEntry: function getEntry(entityId) {
-      var _this = this;
+      const request = new Sage.SData.Client.SDataSingleResourceRequest(App.getService()).setContractName('dynamic').setResourceKind(this.resourceKind).setResourceSelector(`"${entityId}"`);
 
-      var request = new Sage.SData.Client.SDataSingleResourceRequest(App.getService()).setContractName('dynamic').setResourceKind(this.resourceKind).setResourceSelector('"' + entityId + '"');
-
-      return new Promise(function (resolve, reject) {
+      return new Promise((resolve, reject) => {
         request.delete({}, {
           success: function success(entry) {
             resolve(entry);
@@ -66,7 +64,7 @@ define('crm/Models/ActivityAttendee/SData', ['module', 'exports', 'dojo/_base/de
           failure: function failure(e) {
             reject(e);
           },
-          scope: _this
+          scope: this
         });
       });
     }

--- a/src-out/Models/Address/Base.js
+++ b/src-out/Models/Address/Base.js
@@ -32,9 +32,9 @@ define('crm/Models/Address/Base', ['module', 'exports', 'dojo/_base/declare', 'a
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('addressModel');
+  const resource = (0, _I18n2.default)('addressModel');
 
-  var __class = (0, _declare2.default)('crm.Models.Address.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Address.Base', [_ModelBase3.default], {
     resourceKind: 'addresses',
     entityName: 'Address',
     entityDisplayName: resource.entityDisplayName,

--- a/src-out/Models/Address/Offline.js
+++ b/src-out/Models/Address/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/Address/Offline', ['module', 'exports', 'dojo/_base/declare',
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Address.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Address.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'address_offline_model'
   });
 

--- a/src-out/Models/Address/SData.js
+++ b/src-out/Models/Address/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/Address/SData', ['module', 'exports', 'dojo/_base/declare', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Address.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Address.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'address_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Models/AreaCategoryIssue/Base.js
+++ b/src-out/Models/AreaCategoryIssue/Base.js
@@ -15,7 +15,7 @@ define('crm/Models/AreaCategoryIssue/Base', ['module', 'exports', 'dojo/_base/de
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Models.AreaCategoryIssue.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.AreaCategoryIssue.Base', [_ModelBase3.default], {
     resourceKind: 'areaCategoryIssues',
     entityName: 'AreaCategoryIssue',
     modelName: _Names2.default.AREACATEGORYISSUE

--- a/src-out/Models/AreaCategoryIssue/SData.js
+++ b/src-out/Models/AreaCategoryIssue/SData.js
@@ -37,9 +37,7 @@ define('crm/Models/AreaCategoryIssue/SData', ['module', 'exports', 'dojo/_base/d
    */
 
   function assignKeyDescriptor(values) {
-    return values.filter(function (v) {
-      return typeof v === 'string' && v.length > 0;
-    }).map(function (v) {
+    return values.filter(v => typeof v === 'string' && v.length > 0).map(v => {
       return {
         $key: v,
         $descriptor: v
@@ -47,74 +45,64 @@ define('crm/Models/AreaCategoryIssue/SData', ['module', 'exports', 'dojo/_base/d
     });
   }
 
-  var __class = (0, _declare2.default)('crm.Models.Integration.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Integration.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'areacategoryissue_sdata_model',
     getDistinctAreas: function getDistinctAreas() {
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('GetDistinctAreas');
-      var entry = {};
-      return new Promise(function (resolve, reject) {
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('GetDistinctAreas');
+      const entry = {};
+      return new Promise((resolve, reject) => {
         request.execute(entry, {
-          success: function success(data) {
-            var Result = data.response.Result;
-
+          success: data => {
+            const { response: { Result } } = data;
             resolve(assignKeyDescriptor(Result));
           },
-          failure: function failure(response) {
+          failure: response => {
             reject(response);
           }
         });
       });
     },
-    getDistinctAreaCategories: function getDistinctAreaCategories() {
-      var area = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('GetDistinctAreaCategories');
-      var entry = {
+    getDistinctAreaCategories: function getDistinctAreaCategories(area = '') {
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('GetDistinctAreaCategories');
+      const entry = {
         request: {
-          area: area
+          area
         }
       };
-      return new Promise(function (resolve, reject) {
+      return new Promise((resolve, reject) => {
         request.execute(entry, {
-          success: function success(data) {
-            var Result = data.response.Result;
-
+          success: data => {
+            const { response: { Result } } = data;
             resolve(assignKeyDescriptor(Result));
           },
-          failure: function failure(response) {
+          failure: response => {
             reject(response);
           }
         });
       });
     },
-    getDistinctAreaCategoryIssues: function getDistinctAreaCategoryIssues() {
-      var area = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-      var category = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
-
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('GetDistinctAreaCategoryIssues');
-      var entry = {
+    getDistinctAreaCategoryIssues: function getDistinctAreaCategoryIssues(area = '', category = '') {
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(App.getService()).setResourceKind(this.resourceKind).setOperationName('GetDistinctAreaCategoryIssues');
+      const entry = {
         request: {
-          area: area,
-          category: category
+          area,
+          category
         }
       };
-      return new Promise(function (resolve, reject) {
+      return new Promise((resolve, reject) => {
         request.execute(entry, {
-          success: function success(data) {
-            var Result = data.response.Result;
-
+          success: data => {
+            const { response: { Result } } = data;
             resolve(assignKeyDescriptor(Result));
           },
-          failure: function failure(response) {
+          failure: response => {
             reject(response);
           }
         });
       });
     },
     getEntries: function getEntries(queryExpression, queryOptions) {
-      var area = queryOptions.area,
-          category = queryOptions.category;
-
+      const { area, category } = queryOptions;
       switch (queryExpression) {
         case 'area':
           return this.getDistinctAreas();

--- a/src-out/Models/Authentication/Offline.js
+++ b/src-out/Models/Authentication/Offline.js
@@ -23,22 +23,22 @@ define('crm/Models/Authentication/Offline', ['module', 'exports', 'dojo/_base/de
     };
   }
 
-  var resource = (0, _I18n2.default)('autenticationModel'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('autenticationModel'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var __class = (0, _declare2.default)('crm.Models.Autentication.Offline', [_OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Autentication.Offline', [_OfflineModelBase3.default], {
     id: 'auth_offline_model',
     entityName: 'Authentication',
     modelName: 'Authentication',
@@ -46,7 +46,7 @@ define('crm/Models/Authentication/Offline', ['module', 'exports', 'dojo/_base/de
     entityDisplayNamePlural: resource.entityDisplayNamePlural,
     isSystem: true,
     createEntry: function createEntity(userId) {
-      var entity = {}; // need to dynamicly create Properties;
+      const entity = {}; // need to dynamicly create Properties;
       entity.$key = 'Auth_00000000000';
       entity.$descriptor = resource.entityDisplayName;
       entity.CreateDate = moment().toDate();
@@ -55,19 +55,17 @@ define('crm/Models/Authentication/Offline', ['module', 'exports', 'dojo/_base/de
       return entity;
     },
     initAuthentication: function initAuthentication(userId) {
-      var _this = this;
-
-      var def = new _Deferred2.default();
-      var result = {
+      const def = new _Deferred2.default();
+      const result = {
         entry: null,
         hasUserChanged: false,
         hasAuthenticatedToday: false
       };
-      this.getEntry('Auth_00000000000').then(function (entry) {
+      this.getEntry('Auth_00000000000').then(entry => {
         if (entry) {
           if (entry.UserId === userId) {
             result.hasUserChanged = false;
-            result.hasAuthenticatedToday = _this._hasAuthenticatedToday(entry);
+            result.hasAuthenticatedToday = this._hasAuthenticatedToday(entry);
           } else {
             result.hasUserChanged = true;
             result.hasAuthenticatedToday = false;
@@ -77,9 +75,9 @@ define('crm/Models/Authentication/Offline', ['module', 'exports', 'dojo/_base/de
           result.entry = entry;
         }
         def.resolve(result);
-      }, function () {
-        var newEntry = _this.createEntry(userId);
-        _this.insertEntry(newEntry);
+      }, () => {
+        const newEntry = this.createEntry(userId);
+        this.insertEntry(newEntry);
         result.hasUserChanged = true;
         result.hasAuthenticatedToday = false;
         result.entry = newEntry;
@@ -89,8 +87,8 @@ define('crm/Models/Authentication/Offline', ['module', 'exports', 'dojo/_base/de
     },
     _hasAuthenticatedToday: function _hasAuthenticatedToday(entry) {
       if (entry.ModifyDate) {
-        var currentDate = moment();
-        var authDate = moment(_Convert2.default.toDateFromString(entry.ModifyDate));
+        const currentDate = moment();
+        const authDate = moment(_Convert2.default.toDateFromString(entry.ModifyDate));
         if (authDate.isAfter(currentDate.startOf('day')) && authDate.isBefore(moment().endOf('day'))) {
           return true;
         }

--- a/src-out/Models/Contact/Base.js
+++ b/src-out/Models/Contact/Base.js
@@ -32,14 +32,14 @@ define('crm/Models/Contact/Base', ['module', 'exports', 'dojo/_base/declare', 'a
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('contactModel');
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var activityResource = (0, _I18n2.default)('activityModel');
-  var historyResource = (0, _I18n2.default)('historyModel');
-  var addressResource = (0, _I18n2.default)('addressModel');
-  var ticketResource = (0, _I18n2.default)('ticketModel');
+  const resource = (0, _I18n2.default)('contactModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const activityResource = (0, _I18n2.default)('activityModel');
+  const historyResource = (0, _I18n2.default)('historyModel');
+  const addressResource = (0, _I18n2.default)('addressModel');
+  const ticketResource = (0, _I18n2.default)('ticketModel');
 
-  var __class = (0, _declare2.default)('crm.Models.Contact.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Contact.Base', [_ModelBase3.default], {
     resourceKind: 'contacts',
     entityName: 'Contact',
     entityDisplayName: resource.entityDisplayName,
@@ -70,7 +70,7 @@ define('crm/Models/Contact/Base', ['module', 'exports', 'dojo/_base/declare', 'a
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Models/Contact/Offline.js
+++ b/src-out/Models/Contact/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/Contact/Offline', ['module', 'exports', 'dojo/_base/declare',
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Contact.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Contact.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'contact_offline_model'
   });
 

--- a/src-out/Models/Contact/SData.js
+++ b/src-out/Models/Contact/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/Contact/SData', ['module', 'exports', 'dojo/_base/declare', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Contact.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Contact.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'contact_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -54,9 +54,9 @@ define('crm/Models/Contact/SData', ['module', 'exports', 'dojo/_base/declare', '
       }];
     },
     getEntry: function getEntry() /* options */{
-      var results$ = this.inherited(getEntry, arguments);
-      return results$.then(function (entry) {
-        return new Promise(function (resolve) {
+      const results$ = this.inherited(getEntry, arguments);
+      return results$.then(entry => {
+        return new Promise(resolve => {
           Promise.all([App.picklistService.requestPicklist('Name Prefix', {
             language: entry.LocationCode && entry.LocationCode.trim() || App.getCurrentLocale(),
             filterByLanguage: true
@@ -66,7 +66,7 @@ define('crm/Models/Contact/SData', ['module', 'exports', 'dojo/_base/declare', '
           }), App.picklistService.requestPicklist('Title', {
             language: entry.LocationCode && entry.LocationCode.trim() || App.getCurrentLocale(),
             filterByLanguage: true
-          })]).then(function () {
+          })]).then(() => {
             resolve(entry);
           });
         });

--- a/src-out/Models/History/Base.js
+++ b/src-out/Models/History/Base.js
@@ -32,9 +32,9 @@ define('crm/Models/History/Base', ['module', 'exports', 'dojo/_base/declare', 'a
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('historyModel');
+  const resource = (0, _I18n2.default)('historyModel');
 
-  var __class = (0, _declare2.default)('crm.Models.History.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.History.Base', [_ModelBase3.default], {
     resourceKind: 'history',
     entityName: 'History',
     entityDisplayName: resource.entityDisplayName,

--- a/src-out/Models/History/Offline.js
+++ b/src-out/Models/History/Offline.js
@@ -36,32 +36,30 @@ define('crm/Models/History/Offline', ['module', 'exports', 'dojo/_base/declare',
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.History.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.History.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'history_offline_model',
     deleteEntry: function deleteEntry(entry) {
-      var _this = this;
-
-      return new Promise(function (resolve, reject) {
-        var store = _this.getStore();
-        store.query(function (doc, emit) {
-          if (doc.entityName === _this.entityName && doc.entity && doc.entity.entityId === null || typeof doc.entity.entityId === 'undefined') {
+      return new Promise((resolve, reject) => {
+        const store = this.getStore();
+        store.query((doc, emit) => {
+          if (doc.entityName === this.entityName && doc.entity && doc.entity.entityId === null || typeof doc.entity.entityId === 'undefined') {
             if (doc.entity.UID === entry.UID) {
               emit(doc);
             }
           }
-        }).then(function (docs) {
+        }).then(docs => {
           if (docs && docs.length === 1) {
-            var doc = docs[0];
-            _this._removeDoc(doc.key).then(function (result) {
-              _this.onEntryDelete(entry);
+            const doc = docs[0];
+            this._removeDoc(doc.key).then(result => {
+              this.onEntryDelete(entry);
               resolve(result);
-            }, function (err) {
+            }, err => {
               reject(err);
             });
           } else {
             reject('No entry to delete.');
           }
-        }, function (err) {
+        }, err => {
           reject(err);
         });
       });

--- a/src-out/Models/History/SData.js
+++ b/src-out/Models/History/SData.js
@@ -40,7 +40,7 @@ define('crm/Models/History/SData', ['module', 'exports', 'dojo/_base/declare', '
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.History.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.History.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'history_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -55,19 +55,19 @@ define('crm/Models/History/SData', ['module', 'exports', 'dojo/_base/declare', '
       }];
     },
     requestCompletedUser: function requestCompletedUser(entry) {
-      var def = new _Deferred2.default();
-      var completedUser = entry.CompletedUser;
+      const def = new _Deferred2.default();
+      const completedUser = entry.CompletedUser;
 
       if (completedUser) {
-        var request = new Sage.SData.Client.SDataSingleResourceRequest(App.getService()).setContractName('dynamic').setResourceKind('users').setResourceSelector('\'' + completedUser + '\'').setQueryArg('select', ['UserInfo/FirstName', 'UserInfo/LastName'].join(','));
+        const request = new Sage.SData.Client.SDataSingleResourceRequest(App.getService()).setContractName('dynamic').setResourceKind('users').setResourceSelector(`'${completedUser}'`).setQueryArg('select', ['UserInfo/FirstName', 'UserInfo/LastName'].join(','));
 
         request.allowCacheUse = true;
 
         request.read({
-          success: function success(data) {
+          success: data => {
             def.resolve(data);
           },
-          failure: function failure(response, o) {
+          failure: (response, o) => {
             _ErrorManager2.default.addError(response, o, {}, 'failure');
             def.reject(response);
           }
@@ -79,11 +79,9 @@ define('crm/Models/History/SData', ['module', 'exports', 'dojo/_base/declare', '
       return def.promise;
     },
     getEntry: function getEntry() {
-      var _this = this;
-
-      var results$ = this.inherited(getEntry, arguments);
-      return results$.then(function (entry) {
-        return _this.requestCompletedUser(entry).then(function (user) {
+      const results$ = this.inherited(getEntry, arguments);
+      return results$.then(entry => {
+        return this.requestCompletedUser(entry).then(user => {
           if (user) {
             entry.CompletedUser = user;
           }

--- a/src-out/Models/HistoryAttendee/Base.js
+++ b/src-out/Models/HistoryAttendee/Base.js
@@ -32,9 +32,9 @@ define('crm/Models/HistoryAttendee/Base', ['module', 'exports', 'dojo/_base/decl
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('historyAttendeeModel');
+  const resource = (0, _I18n2.default)('historyAttendeeModel');
 
-  var __class = (0, _declare2.default)('crm.Models.HistoryAttendee.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.HistoryAttendee.Base', [_ModelBase3.default], {
     resourceKind: 'historyAttendees',
     entityName: 'HistoryAttendee',
     entityDisplayName: resource.entityDisplayName,

--- a/src-out/Models/HistoryAttendee/Offline.js
+++ b/src-out/Models/HistoryAttendee/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/HistoryAttendee/Offline', ['module', 'exports', 'dojo/_base/d
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.HistoryAttendee.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.HistoryAttendee.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'history_attendee_offline_model'
   });
 

--- a/src-out/Models/HistoryAttendee/SData.js
+++ b/src-out/Models/HistoryAttendee/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/HistoryAttendee/SData', ['module', 'exports', 'dojo/_base/dec
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.HistoryAttendee.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.HistoryAttendee.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'history_attendee_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Models/Integration/Base.js
+++ b/src-out/Models/Integration/Base.js
@@ -15,7 +15,7 @@ define('crm/Models/Integration/Base', ['module', 'exports', 'dojo/_base/declare'
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Models.Integration.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Integration.Base', [_ModelBase3.default], {
     resourceKind: 'integrations',
     entityName: 'Integration',
     modelName: _Names2.default.INTEGRATION

--- a/src-out/Models/Integration/SData.js
+++ b/src-out/Models/Integration/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/Integration/SData', ['module', 'exports', 'dojo/_base/declare
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Integration.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Integration.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'integration_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Models/Lead/Base.js
+++ b/src-out/Models/Lead/Base.js
@@ -32,12 +32,12 @@ define('crm/Models/Lead/Base', ['module', 'exports', 'dojo/_base/declare', 'argo
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('leadModel');
-  var activityResource = (0, _I18n2.default)('activityModel');
-  var historyResource = (0, _I18n2.default)('historyModel');
-  var addressResource = (0, _I18n2.default)('addressModel');
+  const resource = (0, _I18n2.default)('leadModel');
+  const activityResource = (0, _I18n2.default)('activityModel');
+  const historyResource = (0, _I18n2.default)('historyModel');
+  const addressResource = (0, _I18n2.default)('addressModel');
 
-  var __class = (0, _declare2.default)('crm.Models.Lead.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Lead.Base', [_ModelBase3.default], {
     resourceKind: 'leads',
     entityName: 'Lead',
     entityDisplayName: resource.entityDisplayName,
@@ -74,7 +74,7 @@ define('crm/Models/Lead/Base', ['module', 'exports', 'dojo/_base/declare', 'argo
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Addresses',
         displayName: addressResource.entityDisplayNamePlural,
         propertyName: 'Addresses',

--- a/src-out/Models/Lead/Offline.js
+++ b/src-out/Models/Lead/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/Lead/Offline', ['module', 'exports', 'dojo/_base/declare', '.
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Lead.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Lead.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'lead_offline_model'
   });
 

--- a/src-out/Models/Lead/SData.js
+++ b/src-out/Models/Lead/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/Lead/SData', ['module', 'exports', 'dojo/_base/declare', './B
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Lead.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Lead.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'lead_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -50,16 +50,16 @@ define('crm/Models/Lead/SData', ['module', 'exports', 'dojo/_base/declare', './B
       }];
     },
     getEntry: function getEntry() /* options */{
-      var results$ = this.inherited(getEntry, arguments);
-      return results$.then(function (entry) {
-        return new Promise(function (resolve) {
+      const results$ = this.inherited(getEntry, arguments);
+      return results$.then(entry => {
+        return new Promise(resolve => {
           Promise.all([App.picklistService.requestPicklist('Name Prefix', {
             language: ' '
           }), App.picklistService.requestPicklist('Name Suffix', {
             language: ' '
           }), App.picklistService.requestPicklist('Title', {
             language: ' '
-          })]).then(function () {
+          })]).then(() => {
             resolve(entry);
           });
         });

--- a/src-out/Models/LeadAddress/Base.js
+++ b/src-out/Models/LeadAddress/Base.js
@@ -32,9 +32,9 @@ define('crm/Models/LeadAddress/Base', ['module', 'exports', 'dojo/_base/declare'
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('leadAddressModel');
+  const resource = (0, _I18n2.default)('leadAddressModel');
 
-  var __class = (0, _declare2.default)('crm.Models.LeadAddress.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.LeadAddress.Base', [_ModelBase3.default], {
     resourceKind: 'leadAddresses',
     entityName: 'LeadAddress',
     listViewId: 'address_related',

--- a/src-out/Models/LeadAddress/Offline.js
+++ b/src-out/Models/LeadAddress/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/LeadAddress/Offline', ['module', 'exports', 'dojo/_base/decla
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.LeadAddress.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.LeadAddress.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'leadaddress_offline_model'
   });
 

--- a/src-out/Models/LeadAddress/SData.js
+++ b/src-out/Models/LeadAddress/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/LeadAddress/SData', ['module', 'exports', 'dojo/_base/declare
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.LeadAddress.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.LeadAddress.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'leadaddress_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Models/Opportunity/Base.js
+++ b/src-out/Models/Opportunity/Base.js
@@ -32,12 +32,12 @@ define('crm/Models/Opportunity/Base', ['module', 'exports', 'dojo/_base/declare'
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('opportunityModel');
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var activityResource = (0, _I18n2.default)('activityModel');
-  var historyResource = (0, _I18n2.default)('historyModel');
+  const resource = (0, _I18n2.default)('opportunityModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const activityResource = (0, _I18n2.default)('activityModel');
+  const historyResource = (0, _I18n2.default)('historyModel');
 
-  var __class = (0, _declare2.default)('crm.Models.Opportunity.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Opportunity.Base', [_ModelBase3.default], {
     entityName: 'Opportunity',
     entityDisplayName: resource.entityDisplayName,
     entityDisplayNamePlural: resource.entityDisplayNamePlural,
@@ -59,7 +59,7 @@ define('crm/Models/Opportunity/Base', ['module', 'exports', 'dojo/_base/declare'
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Models/Opportunity/Offline.js
+++ b/src-out/Models/Opportunity/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/Opportunity/Offline', ['module', 'exports', 'dojo/_base/decla
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Opportunity.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Opportunity.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'opportunity_offline_model'
   });
 

--- a/src-out/Models/Opportunity/SData.js
+++ b/src-out/Models/Opportunity/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/Opportunity/SData', ['module', 'exports', 'dojo/_base/declare
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Opportunity.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Opportunity.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'opportunity_sdata_model',
     querySelect: ['Account/AccountName', 'Account/WebAddress', 'Account/MainPhone', 'Account/Fax', 'Account/Address/*', 'AccountManager/UserInfo/FirstName', 'AccountManager/UserInfo/LastName', 'CloseProbability', 'Description', 'EstimatedClose', 'ExchangeRate', 'ExchangeRateCode', 'ExchangeRateDate', 'ExchangeRateLocked', 'LeadSource/Description', 'Owner/OwnerDescription', 'Reseller/AccountName', 'SalesPotential', 'Stage', 'Status', 'Type', 'Weighted'],
     createQueryModels: function createQueryModels() {

--- a/src-out/Models/OpportunityContact/Base.js
+++ b/src-out/Models/OpportunityContact/Base.js
@@ -32,11 +32,11 @@ define('crm/Models/OpportunityContact/Base', ['module', 'exports', 'dojo/_base/d
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('opportunityContactModel');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var opportunityResource = (0, _I18n2.default)('opportunityModel');
+  const resource = (0, _I18n2.default)('opportunityContactModel');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const opportunityResource = (0, _I18n2.default)('opportunityModel');
 
-  var __class = (0, _declare2.default)('crm.Models.OpportunityContact.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.OpportunityContact.Base', [_ModelBase3.default], {
     entityName: 'OpportunityContact',
     entityDisplayName: resource.entityDisplayName,
     entityDisplayNamePlural: resource.entityDisplayNamePlural,
@@ -55,7 +55,7 @@ define('crm/Models/OpportunityContact/Base', ['module', 'exports', 'dojo/_base/d
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Contact',
         displayName: contactResource.entityDisplayName,
         type: 'OneToOne',

--- a/src-out/Models/OpportunityContact/Offline.js
+++ b/src-out/Models/OpportunityContact/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/OpportunityContact/Offline', ['module', 'exports', 'dojo/_bas
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.OpportunityContact.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.OpportunityContact.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'opportunity_contact_offline_model'
   });
 

--- a/src-out/Models/OpportunityContact/SData.js
+++ b/src-out/Models/OpportunityContact/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/OpportunityContact/SData', ['module', 'exports', 'dojo/_base/
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.OpportunityContact.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.OpportunityContact.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'opportunity_contact_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Models/Ticket/Base.js
+++ b/src-out/Models/Ticket/Base.js
@@ -32,13 +32,13 @@ define('crm/Models/Ticket/Base', ['module', 'exports', 'dojo/_base/declare', 'ar
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('ticketModel');
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var activityResource = (0, _I18n2.default)('activityModel');
-  var historyResource = (0, _I18n2.default)('historyModel');
+  const resource = (0, _I18n2.default)('ticketModel');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const activityResource = (0, _I18n2.default)('activityModel');
+  const historyResource = (0, _I18n2.default)('historyModel');
 
-  var __class = (0, _declare2.default)('crm.Models.Ticket.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Ticket.Base', [_ModelBase3.default], {
     entityName: 'Ticket',
     entityDisplayName: resource.entityDisplayName,
     entityDisplayNamePlural: resource.entityDisplayNamePlural,
@@ -57,7 +57,7 @@ define('crm/Models/Ticket/Base', ['module', 'exports', 'dojo/_base/declare', 'ar
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = [{
+      const rel = this.relationships || (this.relationships = [{
         name: 'Account',
         displayName: accountResource.entityDisplayName,
         type: 'ManyToOne',

--- a/src-out/Models/Ticket/Offline.js
+++ b/src-out/Models/Ticket/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/Ticket/Offline', ['module', 'exports', 'dojo/_base/declare', 
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Ticket.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Ticket.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'ticket_offline_model'
   });
 

--- a/src-out/Models/Ticket/SData.js
+++ b/src-out/Models/Ticket/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/Ticket/SData', ['module', 'exports', 'dojo/_base/declare', '.
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.Ticket.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.Ticket.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'ticket_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Models/TicketActivity/Base.js
+++ b/src-out/Models/TicketActivity/Base.js
@@ -32,9 +32,9 @@ define('crm/Models/TicketActivity/Base', ['module', 'exports', 'dojo/_base/decla
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('ticketActivityModel');
+  const resource = (0, _I18n2.default)('ticketActivityModel');
 
-  var __class = (0, _declare2.default)('crm.Models.TicketActivity.Base', [_ModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.TicketActivity.Base', [_ModelBase3.default], {
     entityName: 'TicketActivity',
     entityDisplayName: resource.entityDisplayName,
     entityDisplayNamePlural: resource.entityDisplayNamePlural,
@@ -53,7 +53,7 @@ define('crm/Models/TicketActivity/Base', ['module', 'exports', 'dojo/_base/decla
       }]);
     },
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
 

--- a/src-out/Models/TicketActivity/Offline.js
+++ b/src-out/Models/TicketActivity/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/TicketActivity/Offline', ['module', 'exports', 'dojo/_base/de
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.TicketActivity.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.TicketActivity.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'ticket_activity_offline_model'
   });
 

--- a/src-out/Models/TicketActivity/SData.js
+++ b/src-out/Models/TicketActivity/SData.js
@@ -36,7 +36,7 @@ define('crm/Models/TicketActivity/SData', ['module', 'exports', 'dojo/_base/decl
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.TicketActivity.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.TicketActivity.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'ticket_activity_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{

--- a/src-out/Models/UserActivity/Base.js
+++ b/src-out/Models/UserActivity/Base.js
@@ -32,9 +32,9 @@ define('crm/Models/UserActivity/Base', ['module', 'exports', 'dojo/_base/declare
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('userActivityModel');
+  const resource = (0, _I18n2.default)('userActivityModel');
 
-  var __class = (0, _declare2.default)('crm.Models.UserActivity.Base', [_Base2.default], {
+  const __class = (0, _declare2.default)('crm.Models.UserActivity.Base', [_Base2.default], {
     modelName: _Names2.default.USERACTIVITY,
     entityName: 'UserActivity',
     entityDisplayName: resource.entityDisplayName,
@@ -43,7 +43,7 @@ define('crm/Models/UserActivity/Base', ['module', 'exports', 'dojo/_base/declare
     resourceKind: 'userActivities',
     contractName: 'system',
     createRelationships: function createRelationships() {
-      var rel = this.relationships || (this.relationships = []);
+      const rel = this.relationships || (this.relationships = []);
       return rel;
     }
   });

--- a/src-out/Models/UserActivity/Offline.js
+++ b/src-out/Models/UserActivity/Offline.js
@@ -36,7 +36,7 @@ define('crm/Models/UserActivity/Offline', ['module', 'exports', 'dojo/_base/decl
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Models.UserActivity.Offline', [_Base2.default, _OfflineModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.UserActivity.Offline', [_Base2.default, _OfflineModelBase3.default], {
     id: 'useractivity_offline_model'
   });
 

--- a/src-out/Models/UserActivity/SData.js
+++ b/src-out/Models/UserActivity/SData.js
@@ -23,7 +23,7 @@ define('crm/Models/UserActivity/SData', ['module', 'exports', 'dojo/_base/declar
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Models.UserActivity.SData', [_Base2.default, _SDataModelBase3.default], {
+  const __class = (0, _declare2.default)('crm.Models.UserActivity.SData', [_Base2.default, _SDataModelBase3.default], {
     id: 'useractivity_sdata_model',
     createQueryModels: function createQueryModels() {
       return [{
@@ -34,12 +34,12 @@ define('crm/Models/UserActivity/SData', ['module', 'exports', 'dojo/_base/declar
       }, {
         name: 'myday',
         queryWhere: function queryWhere() {
-          var now = moment();
-          var todayStart = now.clone().startOf('day');
-          var todayEnd = todayStart.clone().endOf('day');
+          const now = moment();
+          const todayStart = now.clone().startOf('day');
+          const todayEnd = todayStart.clone().endOf('day');
 
-          var theQuery = '((Activity.Timeless eq false and Activity.StartDate between @' + _Convert2.default.toIsoStringFromDate(todayStart.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(todayEnd.toDate()) + '@) or (Activity.Timeless eq true and Activity.StartDate between @' + todayStart.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + todayEnd.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
-          var userQuery = '(User.Id eq "' + App.context.user.$key + '" and Status ne "asDeclned" and Activity.Type ne "atLiterature")';
+          const theQuery = `((Activity.Timeless eq false and Activity.StartDate between @${_Convert2.default.toIsoStringFromDate(todayStart.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(todayEnd.toDate())}@) or (Activity.Timeless eq true and Activity.StartDate between @${todayStart.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${todayEnd.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
+          const userQuery = `(User.Id eq "${App.context.user.$key}" and Status ne "asDeclned" and Activity.Type ne "atLiterature")`;
 
           return [userQuery, theQuery].join(' and ');
         },
@@ -49,7 +49,7 @@ define('crm/Models/UserActivity/SData', ['module', 'exports', 'dojo/_base/declar
       }];
     },
     getMyDayQuery: function getMyDayQuery() {
-      var queryModel = this._getQueryModelByName('myday');
+      const queryModel = this._getQueryModelByName('myday');
       return queryModel && queryModel.queryWhere();
     }
   }); /* Copyright 2017 Infor

--- a/src-out/PicklistService.js
+++ b/src-out/PicklistService.js
@@ -15,33 +15,33 @@ define('crm/PicklistService', ['module', 'exports', 'dojo/_base/lang', 'argos/Er
     };
   }
 
-  var PickListService = ICRMServicesSDK.PickListService; /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const PickListService = ICRMServicesSDK.PickListService; /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
   /**
    * @module crm/PicklistService
    */
 
-  var picklistFormat = ICRMCommonSDK.format.picklist;
+  const picklistFormat = ICRMCommonSDK.format.picklist;
 
   /**
    * @class
    * @alias module:crm/PicklistService
    * @static
    */
-  var __class = _lang2.default.setObject('crm.PicklistService', /** @lends module:crm/PicklistService */{
+  const __class = _lang2.default.setObject('crm.PicklistService', /** @lends module:crm/PicklistService */{
     _picklists: {},
     _currentRequests: new Map(),
 
@@ -55,28 +55,26 @@ define('crm/PicklistService', ['module', 'exports', 'dojo/_base/lang', 'argos/Er
     orderBy: 'name',
     where: '',
 
-    init: function init(service, storage) {
+    init(service, storage) {
       this.service = new PickListService(storage, service);
     },
-    getPicklistByKey: function getPicklistByKey(key) {
+    getPicklistByKey(key) {
       return this.getPicklistByName(key);
     },
-    getPicklistByName: function getPicklistByName(name, languageCode) {
+    getPicklistByName(name, languageCode) {
       if (languageCode) {
-        var picklist = this._picklists[name + '_' + languageCode];
+        const picklist = this._picklists[`${name}_${languageCode}`];
         if (picklist) {
           return picklist;
         }
       }
       return this._picklists[name] || false;
     },
-    getPicklistItemByKey: function getPicklistItemByKey(picklistName, key) {
-      var languageCode = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : App.getCurrentLocale();
-
-      var picklist = this.getPicklistByName(picklistName, languageCode);
+    getPicklistItemByKey(picklistName, key, languageCode = App.getCurrentLocale()) {
+      const picklist = this.getPicklistByName(picklistName, languageCode);
 
       if (picklist) {
-        for (var i = 0; i < picklist.items.length; i++) {
+        for (let i = 0; i < picklist.items.length; i++) {
           if (picklist.items[i].$key === key) {
             return picklist.items[i];
           }
@@ -84,13 +82,11 @@ define('crm/PicklistService', ['module', 'exports', 'dojo/_base/lang', 'argos/Er
       }
       return false;
     },
-    getPicklistItemByCode: function getPicklistItemByCode(picklistName, itemCode) {
-      var languageCode = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : App.getCurrentLocale();
-
-      var picklist = this.getPicklistByName(picklistName, languageCode);
+    getPicklistItemByCode(picklistName, itemCode, languageCode = App.getCurrentLocale()) {
+      const picklist = this.getPicklistByName(picklistName, languageCode);
 
       if (picklist) {
-        for (var i = 0; i < picklist.items.length; i++) {
+        for (let i = 0; i < picklist.items.length; i++) {
           if (picklist.items[i].code === itemCode) {
             return picklist.items[i];
           }
@@ -98,11 +94,11 @@ define('crm/PicklistService', ['module', 'exports', 'dojo/_base/lang', 'argos/Er
       }
       return false;
     },
-    getPicklistItemByText: function getPicklistItemByText(picklistName, text) {
-      var picklist = this.getPicklistByName(picklistName, '');
+    getPicklistItemByText(picklistName, text) {
+      const picklist = this.getPicklistByName(picklistName, '');
 
       if (picklist) {
-        for (var i = 0; i < picklist.items.length; i++) {
+        for (let i = 0; i < picklist.items.length; i++) {
           if (picklist.items[i].text === text) {
             return picklist.items[i];
           }
@@ -110,109 +106,89 @@ define('crm/PicklistService', ['module', 'exports', 'dojo/_base/lang', 'argos/Er
       }
       return false;
     },
-    getPicklistItemTextByCode: function getPicklistItemTextByCode(picklistName, itemCode) {
-      var languageCode = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : App.getCurrentLocale();
-
-      var picklistItem = this.getPicklistItemByCode(picklistName, itemCode, languageCode);
+    getPicklistItemTextByCode(picklistName, itemCode, languageCode = App.getCurrentLocale()) {
+      const picklistItem = this.getPicklistItemByCode(picklistName, itemCode, languageCode);
       if (itemCode && picklistItem) {
         return picklistItem.text;
       }
       return null;
     },
-    getPicklistItemTextByKey: function getPicklistItemTextByKey(picklistName, key) {
-      var languageCode = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : App.getCurrentLocale();
-
-      var picklistItem = this.getPicklistItemByKey(picklistName, key, languageCode);
+    getPicklistItemTextByKey(picklistName, key, languageCode = App.getCurrentLocale()) {
+      const picklistItem = this.getPicklistItemByKey(picklistName, key, languageCode);
       if (key && picklistItem) {
         return picklistItem.text;
       }
       return null;
     },
-    format: function format(picklistCode /* , storageMode */) {
-      var picklist = this.getPicklistByName(picklistCode);
+    format(picklistCode /* , storageMode */) {
+      const picklist = this.getPicklistByName(picklistCode);
       return picklistFormat(picklist);
     },
-    registerPicklist: function registerPicklist(code, picklist) {
+    registerPicklist(code, picklist) {
       if (!this._picklists[code]) {
         this._picklists[code] = picklist;
       }
     },
-    requestPicklistsFromArray: function requestPicklistsFromArray(picklists) {
-      var _this = this;
-
-      var promise = new Promise(function (resolve, reject) {
-        var promises = [];
-        for (var i = 0; i < picklists.length; i++) {
-          promises.push(_this.requestPicklist(picklists[i].name, picklists[i].options));
+    requestPicklistsFromArray(picklists) {
+      const promise = new Promise((resolve, reject) => {
+        const promises = [];
+        for (let i = 0; i < picklists.length; i++) {
+          promises.push(this.requestPicklist(picklists[i].name, picklists[i].options));
         }
-        Promise.all(promises).then(function () {
+        Promise.all(promises).then(() => {
           resolve(true);
-        }, function (response) {
+        }, response => {
           reject(response);
         });
       });
       return promise;
     },
-    onPicklistSuccess: function onPicklistSuccess(resolve, languageCode) {
-      var _this2 = this;
-
-      return function (result) {
-        var picklist = null;
+    onPicklistSuccess(resolve, languageCode) {
+      return result => {
+        let picklist = null;
         if (result && result.items) {
           picklist = result;
-          picklist.items = picklist.items.$resources.map(function (item) {
-            return Object.assign({}, item, { id: item.$key });
-          });
+          picklist.items = picklist.items.$resources.map(item => Object.assign({}, item, { id: item.$key }));
           if (languageCode) {
-            _this2._picklists[picklist.name + '_' + languageCode] = picklist;
+            this._picklists[`${picklist.name}_${languageCode}`] = picklist;
           } else {
-            _this2._picklists[picklist.name] = picklist;
+            this._picklists[picklist.name] = picklist;
           }
         }
-        _this2.removeRequest(picklist.name);
+        this.removeRequest(picklist.name);
         resolve(picklist);
       };
     },
-    onPicklistError: function onPicklistError(reject, name) {
-      var _this3 = this;
-
-      return function (response, o) {
-        _this3.removeRequest(name);
+    onPicklistError(reject, name) {
+      return (response, o) => {
+        this.removeRequest(name);
         _ErrorManager2.default.addError(response, o, null, 'failure');
         reject(response);
       };
     },
-    requestPicklist: function requestPicklist(name) {
-      var _this4 = this;
-
-      var queryOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
+    requestPicklist(name, queryOptions = {}) {
       // Avoid duplicating model requests
       if (this.hasRequest(name)) {
-        return new Promise(function (resolve) {
-          return resolve();
-        });
+        return new Promise(resolve => resolve());
       }
 
-      var pickListServiceOptions = Object.assign({}, {
+      const pickListServiceOptions = Object.assign({}, {
         storageMode: 'code'
       }, queryOptions);
-      var language = this.determineLanguage(pickListServiceOptions, queryOptions);
-      var useCache = typeof queryOptions.useCache === 'boolean' ? queryOptions.useCache : true;
+      const language = this.determineLanguage(pickListServiceOptions, queryOptions);
+      const useCache = typeof queryOptions.useCache === 'boolean' ? queryOptions.useCache : true;
 
-      return new Promise(function (resolve, reject) {
-        _this4.addRequest(name);
-        var first = _this4.service.getFirstByName(name, _this4.onPicklistSuccess(resolve, language), _this4.onPicklistError(reject, name), { pickListServiceOptions: pickListServiceOptions, language: language, useCache: useCache });
+      return new Promise((resolve, reject) => {
+        this.addRequest(name);
+        const first = this.service.getFirstByName(name, this.onPicklistSuccess(resolve, language), this.onPicklistError(reject, name), { pickListServiceOptions, language, useCache });
 
         if (first && first.options) {
-          var request = _this4.service.setUpRequest(new Sage.SData.Client.SDataResourceCollectionRequest(App.getService(false)).setContractName(_this4.contractName), first.options);
+          const request = this.service.setUpRequest(new Sage.SData.Client.SDataResourceCollectionRequest(App.getService(false)).setContractName(this.contractName), first.options);
           request.read(first.handlers);
         }
-      }).catch(function (err) {
-        return console.error(err);
-      }); // eslint-disable-line
+      }).catch(err => console.error(err)); // eslint-disable-line
     },
-    determineLanguage: function determineLanguage(serviceOptions, queryOptions) {
+    determineLanguage(serviceOptions, queryOptions) {
       if (serviceOptions.filterByLanguage) {
         return queryOptions.language && queryOptions.language.trim() || App.getCurrentLocale();
       }
@@ -223,23 +199,26 @@ define('crm/PicklistService', ['module', 'exports', 'dojo/_base/lang', 'argos/Er
       }
       return queryOptions.language && queryOptions.language.trim() || App.getCurrentLocale();
     },
-    addRequest: function addRequest(name) {
+
+    /**
+     * Simple requestMap to optimize requests to avoid overlap from model requests
+     */
+    addRequest(name) {
       return this._currentRequests.set(name, true);
     },
-    removeRequest: function removeRequest(name) {
+    removeRequest(name) {
       return this._currentRequests.delete(name);
     },
-    hasRequest: function hasRequest(name) {
+    hasRequest(name) {
       return this._currentRequests.has(name);
     },
 
-
     // Previous functions
     getViewPicklists: function getViewPicklists(viewId) {
-      var picklistIds = this._viewMapping[viewId];
-      var picklists = [];
+      const picklistIds = this._viewMapping[viewId];
+      const picklists = [];
       if (picklistIds && picklistIds.length) {
-        for (var i = 0; i < picklistIds.length; i++) {
+        for (let i = 0; i < picklistIds.length; i++) {
           if (this._picklists[picklistIds[i]]) {
             picklists.push(this._picklists[picklistIds[i]]);
           } else {
@@ -263,13 +242,13 @@ define('crm/PicklistService', ['module', 'exports', 'dojo/_base/lang', 'argos/Er
     },
     getStore: function getStore() {
       if (!this._store) {
-        var options = this.getStoreOptions();
+        const options = this.getStoreOptions();
         this._store = new _SData2.default(options);
       }
       return this._store;
     },
     getStoreOptions: function getStoreOptions() {
-      var options = {
+      const options = {
         service: App.getService(false),
         contractName: this.contractName,
         resourceKind: this.resourceKind,

--- a/src-out/Recurrence.js
+++ b/src-out/Recurrence.js
@@ -15,33 +15,33 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
     };
   }
 
-  var resource = (0, _I18n2.default)('recurrence'); /* Copyright 2017 Infor
-                                                     *
-                                                     * Licensed under the Apache License, Version 2.0 (the "License");
-                                                     * you may not use this file except in compliance with the License.
-                                                     * You may obtain a copy of the License at
-                                                     *
-                                                     *    http://www.apache.org/licenses/LICENSE-2.0
-                                                     *
-                                                     * Unless required by applicable law or agreed to in writing, software
-                                                     * distributed under the License is distributed on an "AS IS" BASIS,
-                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                     * See the License for the specific language governing permissions and
-                                                     * limitations under the License.
-                                                     */
+  const resource = (0, _I18n2.default)('recurrence'); /* Copyright 2017 Infor
+                                                       *
+                                                       * Licensed under the Apache License, Version 2.0 (the "License");
+                                                       * you may not use this file except in compliance with the License.
+                                                       * You may obtain a copy of the License at
+                                                       *
+                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                       *
+                                                       * Unless required by applicable law or agreed to in writing, software
+                                                       * distributed under the License is distributed on an "AS IS" BASIS,
+                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                       * See the License for the specific language governing permissions and
+                                                       * limitations under the License.
+                                                       */
 
   /**
    * @module crm/Recurrence
    */
 
-  var dtFormatResource = (0, _I18n2.default)('recurrenceDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('recurrenceDateTimeFormat');
 
   /**
    * @class
    * @alias module:crm/Recurrence
    * @static
    */
-  var __class = _lang2.default.setObject('crm.Recurrence', /** @lends module:crm/Recurrence */{
+  const __class = _lang2.default.setObject('crm.Recurrence', /** @lends module:crm/Recurrence */{
     // Localization
     neverText: resource.neverText,
     dailyText: resource.dailyText,
@@ -142,15 +142,15 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
     createSimplifiedOptions: function createSimplifiedOptions(startDate) {
       this.recalculateSimplifiedPeriodSpec(startDate);
 
-      var list = [];
-      var currentDate = startDate || new Date();
-      var wrapped = moment(currentDate);
-      var day = currentDate.getDate();
-      var ord = this.ordText[parseInt(((day - 1) / 7).toString(), 10) + 1];
-      var textOptions = [null, // scale, replaced in loop
+      const list = [];
+      const currentDate = startDate || new Date();
+      const wrapped = moment(currentDate);
+      const day = currentDate.getDate();
+      const ord = this.ordText[parseInt(((day - 1) / 7).toString(), 10) + 1];
+      const textOptions = [null, // scale, replaced in loop
       day, wrapped.format(this.dayFormatText), wrapped.localeData().weekdays(wrapped), wrapped.localeData().monthsShort(wrapped), ord];
 
-      for (var recurOption in this.simplifiedOptions) {
+      for (const recurOption in this.simplifiedOptions) {
         if (this.simplifiedOptions.hasOwnProperty(recurOption)) {
           textOptions[0] = this.getPanel(this.simplifiedOptions[recurOption].RecurPeriod);
           this.simplifiedOptions[recurOption].RecurIterations = this.defaultIterations[this.simplifiedOptions[recurOption].RecurPeriod] || 0;
@@ -193,17 +193,17 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
       return '1369'.indexOf(panel) >= 0;
     },
     recalculateSimplifiedPeriodSpec: function recalculateSimplifiedPeriodSpec(startDate) {
-      for (var recurOption in this.simplifiedOptions) {
+      for (const recurOption in this.simplifiedOptions) {
         if (this.simplifiedOptions.hasOwnProperty(recurOption)) {
-          var opt = this.simplifiedOptions[recurOption];
+          const opt = this.simplifiedOptions[recurOption];
           this.simplifiedOptions[recurOption].RecurPeriodSpec = this.getRecurPeriodSpec(opt.RecurPeriod, startDate, opt.weekdays);
         }
       }
     },
     getWeekdays: function getWeekdays(rps, names) {
       // pass a RecurPeriodSpec (as long as RecurPeriod corresponds to a Spec with weekdays)
-      var weekdays = [];
-      for (var i = 0; i < this._weekDayValues.length; i++) {
+      const weekdays = [];
+      for (let i = 0; i < this._weekDayValues.length; i++) {
         if (names) {
           if (rps & this._weekDayValues[i]) {
             weekdays.push(this.weekDaysText[i]);
@@ -216,11 +216,11 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
       return weekdays;
     },
     getOrd: function getOrd(entry) {
-      var nthWeek = 0;
-      var weekday = entry.StartDate.getDay();
-      var monthNum = entry.StartDate.getMonth() + 1;
-      var ordBits = entry.RecurPeriodSpec % 524288;
-      var monthBits = entry.RecurPeriodSpec % 4194304 - ordBits;
+      let nthWeek = 0;
+      let weekday = entry.StartDate.getDay();
+      let monthNum = entry.StartDate.getMonth() + 1;
+      const ordBits = entry.RecurPeriodSpec % 524288;
+      const monthBits = entry.RecurPeriodSpec % 4194304 - ordBits;
 
       if (entry && (entry.RecurPeriod === 5 || entry.RecurPeriod === 8)) {
         nthWeek = parseInt((ordBits / 65536).toString(), 10) + 1;
@@ -230,16 +230,16 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
 
       return {
         week: nthWeek,
-        weekday: weekday,
+        weekday,
         month: monthNum
       };
     },
     getRecurPeriodSpec: function getRecurPeriodSpec(recurPeriod, startDate, weekdays, inter) {
-      var spec = 0;
-      var interval = inter || this.interval;
-      var weekDay = void 0;
-      var nthWeek = void 0;
-      var monthNum = void 0;
+      let spec = 0;
+      let interval = inter || this.interval;
+      let weekDay;
+      let nthWeek;
+      let monthNum;
 
       if (!startDate) {
         return null;
@@ -255,7 +255,7 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
           break;
         case 2:
           // weekly
-          for (var i = 0; i < weekdays.length; i++) {
+          for (let i = 0; i < weekdays.length; i++) {
             spec += weekdays[i] ? this._weekDayValues[i] : 0;
           }
           if (spec === 0) {
@@ -305,24 +305,24 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
       return spec + interval; // + every interval days/weeks/months/years
     },
     createTextOptions: function createTextOptions(entry) {
-      var weekdaysString = '';
-      var recurPeriodSpec = parseInt(entry.RecurPeriodSpec, 10);
-      var interval = recurPeriodSpec % 65536;
-      var momentCurrentDate = moment(entry.StartDate);
-      var currentDate = momentCurrentDate.toDate();
-      var day = currentDate.getDate();
-      var weekday = momentCurrentDate.format(this.weekdayFormatText);
-      var weekdays = this.getWeekdays(recurPeriodSpec, true);
-      var month = momentCurrentDate.localeData().months(momentCurrentDate);
+      let weekdaysString = '';
+      const recurPeriodSpec = parseInt(entry.RecurPeriodSpec, 10);
+      const interval = recurPeriodSpec % 65536;
+      const momentCurrentDate = moment(entry.StartDate);
+      const currentDate = momentCurrentDate.toDate();
+      const day = currentDate.getDate();
+      const weekday = momentCurrentDate.format(this.weekdayFormatText);
+      const weekdays = this.getWeekdays(recurPeriodSpec, true);
+      const month = momentCurrentDate.localeData().months(momentCurrentDate);
 
-      var timeFormatted = momentCurrentDate.format(this.timeFormatText);
+      let timeFormatted = momentCurrentDate.format(this.timeFormatText);
 
       if (App && App.is24HourClock()) {
         timeFormatted = momentCurrentDate.format(this.timeFormatText24);
       }
 
       // eslint-disable-next-line guard-for-in
-      for (var key in weekdays) {
+      for (const key in weekdays) {
         if (weekdays[key] && parseInt(key, 10) < weekdays.length - 1) {
           weekdays[key] = _string2.default.substitute(this.daySeparator, [weekdays[key]]);
         }
@@ -332,7 +332,7 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
       return [interval, timeFormatted, momentCurrentDate.format(this.dateFormatText), this.calcEndDate(currentDate, entry).format(this.endDateFormatText), weekdaysString, month, _string2.default.substitute(this.ordText[parseInt((day - 1) / 7, 10) + 1], [weekday]), day];
     },
     buildSummaryText: function buildSummaryText(entry, textOptions) {
-      var rp = parseInt(entry.RecurPeriod, 10);
+      const rp = parseInt(entry.RecurPeriod, 10);
       switch (rp) {
         case -1:
           // occurs only once
@@ -378,14 +378,14 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
         }
         return '';
       }
-      var textOptions = this.createTextOptions(entry);
+      const textOptions = this.createTextOptions(entry);
       return this.buildSummaryText(entry, textOptions);
     },
     calcEndDate: function calcEndDate(date, entry) {
-      var interval = entry.RecurPeriodSpec % 65536;
-      var weekDay = void 0;
-      var nthWeek = void 0;
-      var tempDate = moment.isMoment(date) ? date.clone() : new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds());
+      const interval = entry.RecurPeriodSpec % 65536;
+      let weekDay;
+      let nthWeek;
+      let tempDate = moment.isMoment(date) ? date.clone() : new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds());
 
       tempDate = moment(tempDate);
       switch (parseInt(entry.RecurPeriod, 10)) {
@@ -421,13 +421,13 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
     },
     calcDateOfNthWeekday: function calcDateOfNthWeekday(date, weekDay, nthWeek) {
       // calculate date of #nthWeek #weekDay  e.g. First Friday
-      var tempDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+      let tempDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
       tempDate = moment(tempDate);
 
       if (nthWeek === 5) {
         // "last" - count backwards...
         tempDate.endOf('month');
-        for (var i = 0; i < 7; i++) {
+        for (let i = 0; i < 7; i++) {
           if (tempDate.day() === weekDay) {
             break;
           }
@@ -437,7 +437,7 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
         // count from the beginning...
         tempDate.startOf('month');
         // get to the first day that matches...
-        for (var _i = 0; _i < 7; _i++) {
+        for (let i = 0; i < 7; i++) {
           if (tempDate.day() === weekDay) {
             break;
           }
@@ -450,9 +450,9 @@ define('crm/Recurrence', ['module', 'exports', 'dojo/_base/lang', 'dojo/string',
     },
     calcRecurIterations: function calcRecurIterations(endDate, startDate, interval, recurPeriod) {
       // calculate number of occurances based on start and end dates
-      var days = (endDate - startDate) / (1000 * 60 * 60 * 24);
-      var years = endDate.getFullYear() - startDate.getFullYear();
-      var result = void 0;
+      const days = (endDate - startDate) / (1000 * 60 * 60 * 24);
+      const years = endDate.getFullYear() - startDate.getFullYear();
+      let result;
 
       switch (parseInt(recurPeriod, 10)) {
         case 8:

--- a/src-out/SalesProcessUtility.js
+++ b/src-out/SalesProcessUtility.js
@@ -40,7 +40,7 @@ define('crm/SalesProcessUtility', ['module', 'exports', 'dojo/_base/lang', 'dojo
   /**
    * @module crm/SalesProcessUtility
    */
-  var __class = _lang2.default.setObject('crm.SalesProcessUtility', /** @lends module:crm/SalesProcessUtility */{
+  const __class = _lang2.default.setObject('crm.SalesProcessUtility', /** @lends module:crm/SalesProcessUtility */{
     store: null,
     service: null,
     contractName: 'dynamic',
@@ -58,12 +58,12 @@ define('crm/SalesProcessUtility', ['module', 'exports', 'dojo/_base/lang', 'dojo
       return this.store;
     },
     createStore: function createStore() {
-      var options = this.getStoreOptions();
-      var store = new _SData2.default(options);
+      const options = this.getStoreOptions();
+      const store = new _SData2.default(options);
       return store;
     },
     getStoreOptions: function getStoreOptions() {
-      var options = {
+      const options = {
         service: App.getService(false),
         contractName: this.contractName,
         resourceKind: this.resourceKind,
@@ -84,19 +84,19 @@ define('crm/SalesProcessUtility', ['module', 'exports', 'dojo/_base/lang', 'dojo
      *
      */
     getSalesProcessByEntityId: function getSalesProcessByEntityId(entityId) {
-      var deferred = new _Deferred2.default();
-      var store = this.getStore();
-      var options = {
-        where: 'EntityId eq "' + entityId + '"'
+      const deferred = new _Deferred2.default();
+      const store = this.getStore();
+      const options = {
+        where: `EntityId eq "${entityId}"`
       };
-      var queryResults = store.query(null, options);
-      (0, _when2.default)(queryResults, function (feed) {
-        var salesProcess = null;
+      const queryResults = store.query(null, options);
+      (0, _when2.default)(queryResults, feed => {
+        let salesProcess = null;
         if (feed && feed.length > 0) {
           salesProcess = feed[0];
         }
         deferred.resolve(salesProcess);
-      }, function (err) {
+      }, err => {
         deferred.reject(err);
       });
       return deferred.promise;

--- a/src-out/SpeedSearchWidget.js
+++ b/src-out/SpeedSearchWidget.js
@@ -15,22 +15,22 @@ define('crm/SpeedSearchWidget', ['module', 'exports', 'dojo/_base/declare', 'arg
     };
   }
 
-  var resource = (0, _I18n2.default)('speedSearchWidget'); /* Copyright 2017 Infor
-                                                            *
-                                                            * Licensed under the Apache License, Version 2.0 (the "License");
-                                                            * you may not use this file except in compliance with the License.
-                                                            * You may obtain a copy of the License at
-                                                            *
-                                                            *    http://www.apache.org/licenses/LICENSE-2.0
-                                                            *
-                                                            * Unless required by applicable law or agreed to in writing, software
-                                                            * distributed under the License is distributed on an "AS IS" BASIS,
-                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                            * See the License for the specific language governing permissions and
-                                                            * limitations under the License.
-                                                            */
+  const resource = (0, _I18n2.default)('speedSearchWidget'); /* Copyright 2017 Infor
+                                                              *
+                                                              * Licensed under the Apache License, Version 2.0 (the "License");
+                                                              * you may not use this file except in compliance with the License.
+                                                              * You may obtain a copy of the License at
+                                                              *
+                                                              *    http://www.apache.org/licenses/LICENSE-2.0
+                                                              *
+                                                              * Unless required by applicable law or agreed to in writing, software
+                                                              * distributed under the License is distributed on an "AS IS" BASIS,
+                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                              * See the License for the specific language governing permissions and
+                                                              * limitations under the License.
+                                                              */
 
-  var __class = (0, _declare2.default)('crm.SpeedSearchWidget', [_SearchWidget2.default], {
+  const __class = (0, _declare2.default)('crm.SpeedSearchWidget', [_SearchWidget2.default], {
     /*
      * The placeholder text for the input.
      */

--- a/src-out/Template.js
+++ b/src-out/Template.js
@@ -35,7 +35,7 @@ define('crm/Template', ['module', 'exports', 'dojo/_base/lang', 'argos/Format'],
   /**
    * @module crm/Template
    */
-  var __class = _lang2.default.setObject('crm.Template', /** @lends module:crm/Template */{
+  const __class = _lang2.default.setObject('crm.Template', /** @lends module:crm/Template */{
     /**
      * @property {Simplate} nameLF
      * Template for lastname, firstname

--- a/src-out/Utility.js
+++ b/src-out/Utility.js
@@ -31,7 +31,7 @@ define('crm/Utility', ['module', 'exports', 'dojo/_base/lang', 'argos/Utility'],
   /**
    * @module crm/Utility
    */
-  var commonutil = ICRMCommonSDK.utility;
+  const commonutil = ICRMCommonSDK.utility;
   /**
    * @class
    * @alias module:crm/Utility
@@ -39,7 +39,7 @@ define('crm/Utility', ['module', 'exports', 'dojo/_base/lang', 'argos/Utility'],
    * @static
    *
    */
-  var __class = _lang2.default.setObject('crm.Utility', _lang2.default.mixin({}, _Utility2.default, /** @lends module:crm/Utility */{
+  const __class = _lang2.default.setObject('crm.Utility', _lang2.default.mixin({}, _Utility2.default, /** @lends module:crm/Utility */{
     base64ArrayBuffer: commonutil.base64ArrayBuffer,
 
     /** Gets the extension for a file.
@@ -77,12 +77,12 @@ define('crm/Utility', ['module', 'exports', 'dojo/_base/lang', 'argos/Utility'],
         return activityId;
       }
 
-      var epochTicks = 621355968e9; // Number of ticks from 0001 to Unix Epoch that JS uses
-      var ticksPerMillisecond = 10000;
-      var ticksPerSecond = 10000000;
-      var ticks = epochTicks + occurrenceStart.getTime() * ticksPerMillisecond;
-      var serverTicks = ticks / ticksPerSecond;
-      return activityId + ';' + serverTicks;
+      const epochTicks = 621355968e9; // Number of ticks from 0001 to Unix Epoch that JS uses
+      const ticksPerMillisecond = 10000;
+      const ticksPerSecond = 10000000;
+      const ticks = epochTicks + occurrenceStart.getTime() * ticksPerMillisecond;
+      const serverTicks = ticks / ticksPerSecond;
+      return `${activityId};${serverTicks}`;
     }
   }));
 

--- a/src-out/Validator.js
+++ b/src-out/Validator.js
@@ -31,7 +31,7 @@ define('crm/Validator', ['module', 'exports', 'dojo/_base/lang', 'argos/I18n'], 
   /**
    * @module crm/Validator
    */
-  var resource = (0, _I18n2.default)('validators');
+  const resource = (0, _I18n2.default)('validators');
 
   /**
    * @class
@@ -58,7 +58,7 @@ define('crm/Validator', ['module', 'exports', 'dojo/_base/lang', 'argos/I18n'], 
    *       }
    * @static
    */
-  var __class = _lang2.default.setObject('crm.Validator', /** @lends module:crm/Validator */{
+  const __class = _lang2.default.setObject('crm.Validator', /** @lends module:crm/Validator */{
     /**
      * @property {Object} exists
      * Validator that ensures the field contains a value.
@@ -182,8 +182,8 @@ define('crm/Validator', ['module', 'exports', 'dojo/_base/lang', 'argos/I18n'], 
      */
     isDateInRange: {
       fn: function isDateInRange(value, field) {
-        var minValue = field.minValue;
-        var maxValue = field.maxValue;
+        const minValue = field.minValue;
+        const maxValue = field.maxValue;
 
         // if value is empty or not a date, ignore comparison
         if (!value || !(value instanceof Date)) {
@@ -213,7 +213,7 @@ define('crm/Validator', ['module', 'exports', 'dojo/_base/lang', 'argos/I18n'], 
      */
     isGreaterThan: {
       fn: function isGreaterThan(value, field) {
-        var comp = field.greaterThan;
+        const comp = field.greaterThan;
 
         if (typeof comp !== 'number' || Number.isNaN(comp)) {
           return false;
@@ -236,7 +236,7 @@ define('crm/Validator', ['module', 'exports', 'dojo/_base/lang', 'argos/I18n'], 
      */
     isLessThan: {
       fn: function isLessThan(value, field) {
-        var comp = field.lessThan;
+        const comp = field.lessThan;
 
         if (typeof comp !== 'number' || Number.isNaN(comp)) {
           return false;

--- a/src-out/Views/Account/Detail.js
+++ b/src-out/Views/Account/Detail.js
@@ -40,9 +40,9 @@ define('crm/Views/Account/Detail', ['module', 'exports', 'dojo/_base/declare', '
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('accountDetail');
+  const resource = (0, _I18n2.default)('accountDetail');
 
-  var __class = (0, _declare2.default)('crm.Views.Account.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Account.Detail', [_Detail2.default], {
     // Localization
     accountText: resource.accountText,
     acctMgrText: resource.acctMgrText,
@@ -91,7 +91,7 @@ define('crm/Views/Account/Detail', ['module', 'exports', 'dojo/_base/declare', '
       _Action2.default.navigateToHistoryInsert(entry);
     },
     recordCallToHistory: function recordCallToHistory(phoneNumber) {
-      var entry = {
+      const entry = {
         Type: 'atPhoneCall',
         AccountId: this.entry.$key,
         AccountName: this.entry.AccountName,
@@ -112,7 +112,7 @@ define('crm/Views/Account/Detail', ['module', 'exports', 'dojo/_base/declare', '
       App.navigateToActivityInsertView();
     },
     addNote: function addNote() {
-      var view = App.getView(this.noteEditView);
+      const view = App.getView(this.noteEditView);
       if (view) {
         view.show({
           template: {},
@@ -121,7 +121,7 @@ define('crm/Views/Account/Detail', ['module', 'exports', 'dojo/_base/declare', '
       }
     },
     addTicket: function addNote() {
-      var view = App.getView('ticket_edit');
+      const view = App.getView('ticket_edit');
       if (view) {
         view.show({
           template: {},
@@ -204,7 +204,7 @@ define('crm/Views/Account/Detail', ['module', 'exports', 'dojo/_base/declare', '
           name: 'SubType',
           property: 'SubType',
           label: this.subTypeText,
-          renderer: _Format2.default.picklist(this.app.picklistService, null, null, 'Account ' + this.entry.Type)
+          renderer: _Format2.default.picklist(this.app.picklistService, null, null, `Account ${this.entry.Type}`)
         }, {
           name: 'Industry',
           property: 'Industry',

--- a/src-out/Views/Account/Edit.js
+++ b/src-out/Views/Account/Edit.js
@@ -23,22 +23,22 @@ define('crm/Views/Account/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
     };
   }
 
-  var resource = (0, _I18n2.default)('accountEdit'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('accountEdit'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
-  var __class = (0, _declare2.default)('crm.Views.Account.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Account.Edit', [_Edit2.default], {
     // Localization
     accountStatusTitleText: resource.accountStatusTitleText,
     accountSubTypeTitleText: resource.accountSubTypeTitleText,

--- a/src-out/Views/Account/List.js
+++ b/src-out/Views/Account/List.js
@@ -44,9 +44,9 @@ define('crm/Views/Account/List', ['module', 'exports', 'dojo/_base/declare', '..
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('accountList');
+  const resource = (0, _I18n2.default)('accountList');
 
-  var __class = (0, _declare2.default)('crm.Views.Account.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Account.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">{%: $.Industry %}</p>', '<p class="micro-text">', '{%: $$.joinFields(" | ", [$.Type, $.SubType]) %}', '</p>', '<p class="micro-text">{%: $.AccountManager && $.AccountManager.UserInfo ? $.AccountManager.UserInfo.UserName : "" %}', '{% if ($.Owner && $.Owner.OwnerDescription) { %} | {%: $.Owner.OwnerDescription %}{% } %}</p>', '<p class="micro-text">{%: $.WebAddress %}</p>', '{% if ($.MainPhone) { %}', '<p class="micro-text">', '{%: $$.phoneAbbreviationText %} <span class="hyperlink" data-action="callMain" data-key="{%: $.$key %}">{%: argos.Format.phone($.MainPhone) %}</span>', // TODO: Avoid global
     '</p>', '{% } %}', '{% if ($.Fax) { %}', '<p class="micro-text">', '{%: $$.faxAbbreviationText + argos.Format.phone($.Fax) %}', // TODO: Avoid global
@@ -88,7 +88,7 @@ define('crm/Views/Account/List', ['module', 'exports', 'dojo/_base/declare', '..
     modelName: _Names2.default.ACCOUNT,
 
     callMain: function callMain(params) {
-      this.invokeActionItemBy(function (a) {
+      this.invokeActionItemBy(a => {
         return a.id === 'callMain';
       }, params.key);
     },
@@ -127,8 +127,8 @@ define('crm/Views/Account/List', ['module', 'exports', 'dojo/_base/declare', '..
       }]);
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'AccountNameUpper like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `AccountNameUpper like "${q}%"`;
     }
   });
 

--- a/src-out/Views/Activity/Complete.js
+++ b/src-out/Views/Activity/Complete.js
@@ -29,24 +29,24 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
     };
   }
 
-  var resource = (0, _I18n2.default)('activityComplete'); /* Copyright 2017 Infor
-                                                           *
-                                                           * Licensed under the Apache License, Version 2.0 (the "License");
-                                                           * you may not use this file except in compliance with the License.
-                                                           * You may obtain a copy of the License at
-                                                           *
-                                                           *    http://www.apache.org/licenses/LICENSE-2.0
-                                                           *
-                                                           * Unless required by applicable law or agreed to in writing, software
-                                                           * distributed under the License is distributed on an "AS IS" BASIS,
-                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                           * See the License for the specific language governing permissions and
-                                                           * limitations under the License.
-                                                           */
+  const resource = (0, _I18n2.default)('activityComplete'); /* Copyright 2017 Infor
+                                                             *
+                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                             * you may not use this file except in compliance with the License.
+                                                             * You may obtain a copy of the License at
+                                                             *
+                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                             *
+                                                             * Unless required by applicable law or agreed to in writing, software
+                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                             * See the License for the specific language governing permissions and
+                                                             * limitations under the License.
+                                                             */
 
-  var dtFormatResource = (0, _I18n2.default)('activityCompleteDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('activityCompleteDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.Complete', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.Complete', [_Edit2.default], {
     // Localization
     activityInfoText: resource.activityInfoText,
     accountText: resource.accountText,
@@ -196,16 +196,16 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     isInLeadContext: function isInLeadContext() {
-      var insert = this.options && this.options.insert;
-      var entry = this.options && this.options.entry;
-      var context = this._getNavContext();
-      var isLeadContext = false;
+      const insert = this.options && this.options.insert;
+      const entry = this.options && this.options.entry;
+      const context = this._getNavContext();
+      let isLeadContext = false;
 
       if (context.resourceKind === 'leads') {
         isLeadContext = true;
       }
 
-      var lead = insert && isLeadContext || this.isActivityForLead(entry);
+      const lead = insert && isLeadContext || this.isActivityForLead(entry);
 
       return !!lead;
     },
@@ -226,40 +226,36 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     showFieldsForLead: function showFieldsForLead() {
-      var _this = this;
-
-      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(function (item) {
-        if (_this.fields[item]) {
-          _this.fields[item].hide();
+      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].hide();
         }
       }, this);
 
-      this.fieldsForLeads.forEach(function (item) {
-        if (_this.fields[item]) {
-          _this.fields[item].show();
+      this.fieldsForLeads.forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].show();
         }
       }, this);
     },
     showFieldsForStandard: function showFieldsForStandard() {
-      var _this2 = this;
-
-      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(function (item) {
-        if (_this2.fields[item]) {
-          _this2.fields[item].hide();
+      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].hide();
         }
       }, this);
 
-      this.fieldsForStandard.forEach(function (item) {
-        if (_this2.fields[item]) {
-          _this2.fields[item].show();
+      this.fieldsForStandard.forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].show();
         }
       }, this);
     },
     onTimelessChange: function onTimelessChange(value) {
       this.toggleSelectField(this.fields.Duration, value);
 
-      var startDateField = this.fields.StartDate;
-      var startDate = startDateField.getValue();
+      const startDateField = this.fields.StartDate;
+      let startDate = startDateField.getValue();
 
       if (value) {
         startDateField.dateFormatText = this.startingTimelessFormatText;
@@ -304,9 +300,9 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
     },
     onAsScheduledChange: function onAsScheduledChange(scheduled) {
       if (scheduled) {
-        var duration = this.fields.Duration.getValue();
-        var startDate = moment(this.fields.StartDate.getValue());
-        var completedDate = startDate.add({
+        const duration = this.fields.Duration.getValue();
+        const startDate = moment(this.fields.StartDate.getValue());
+        const completedDate = startDate.add({
           minutes: duration
         }).toDate();
 
@@ -318,19 +314,19 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     onFollowupChange: function onFollowupChange(value) {
-      var disable = value === 'none' || value && value.key === 'none';
+      const disable = value === 'none' || value && value.key === 'none';
       this.toggleSelectField(this.fields.CarryOverNotes, disable);
     },
     onLeadChange: function onLeadChange(value, field) {
-      var selection = field.getSelection();
+      const selection = field.getSelection();
 
       if (selection && this.insert) {
         this.fields.AccountName.setValue(_Utility2.default.getValue(selection, 'Company'));
       }
 
-      var entry = field.currentSelection;
+      const entry = field.currentSelection;
       if (entry.WorkPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.WorkPhone);
       }
     },
@@ -348,7 +344,7 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       this.toggleSelectField(this.fields.CarryOverNotes, true);
       this.toggleSelectField(this.fields.CompletedDate, false);
       if (this.isInLeadContext()) {
-        var isLeadField = this.fields.IsLead;
+        const isLeadField = this.fields.IsLead;
         if (isLeadField) {
           isLeadField.setValue(true);
           this.onIsLeadChange(isLeadField.getValue(), isLeadField);
@@ -359,10 +355,10 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     onLeaderChange: function onLeaderChange(value, field) {
-      var user = field.getValue();
-      var resourceId = '';
+      const user = field.getValue();
+      let resourceId = '';
 
-      var key = user.$key;
+      let key = user.$key;
 
       // The key is a composite key on activityresourceviews endpoint.
       // The format is 'ResourceId-AccessId'.
@@ -383,7 +379,7 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     convertEntry: function convertEntry() {
-      var entry = this.inherited(convertEntry, arguments);
+      const entry = this.inherited(convertEntry, arguments);
       if (!this.options.entry) {
         if (entry && entry.Leader.$key) {
           this.requestLeader(entry.Leader.$key);
@@ -393,7 +389,7 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       return entry;
     },
     requestLeader: function requestLeader(userId) {
-      var request = new Sage.SData.Client.SDataSingleResourceRequest(this.getConnection()).setResourceKind('users').setResourceSelector('\'' + userId + '\'').setQueryArg('select', ['UserInfo/FirstName', 'UserInfo/LastName'].join(','));
+      const request = new Sage.SData.Client.SDataSingleResourceRequest(this.getConnection()).setResourceKind('users').setResourceSelector(`'${userId}'`).setQueryArg('select', ['UserInfo/FirstName', 'UserInfo/LastName'].join(','));
 
       request.read({
         success: this.processLeader,
@@ -412,8 +408,8 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       return this.followupValueText[key] || text;
     },
     createDurationData: function createDurationData() {
-      var list = [];
-      for (var duration in this.durationValueText) {
+      const list = [];
+      for (const duration in this.durationValueText) {
         if (this.durationValueText.hasOwnProperty(duration)) {
           list.push({
             $key: duration,
@@ -427,9 +423,9 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       };
     },
     createFollowupData: function createFollowupData() {
-      var list = [];
+      const list = [];
 
-      for (var followup in this.followupValueText) {
+      for (const followup in this.followupValueText) {
         if (this.followupValueText.hasOwnProperty(followup)) {
           list.push({
             $key: followup,
@@ -443,8 +439,8 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       };
     },
     navigateToFollowUpView: function navigateToFollowUpView(entry) {
-      var view = App.getView(this.followupView);
-      var followupEntry = {
+      const view = App.getView(this.followupView);
+      const followupEntry = {
         Type: this.fields.Followup.getValue(),
         Description: entry.Description,
         AccountId: entry.AccountId,
@@ -472,28 +468,28 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
     },
     applyContext: function applyContext() {
       this.inherited(applyContext, arguments);
-      var startDate = this._getCalculatedStartTime(moment());
-      var activityType = this.options && this.options.activityType;
-      var activityGroup = this.groupOptionsByType[activityType] || '';
-      var activityDuration = App.context.userOptions && App.context.userOptions[activityGroup + ':Duration'] || 15;
+      const startDate = this._getCalculatedStartTime(moment());
+      const activityType = this.options && this.options.activityType;
+      const activityGroup = this.groupOptionsByType[activityType] || '';
+      const activityDuration = App.context.userOptions && App.context.userOptions[`${activityGroup}:Duration`] || 15;
       this.fields.StartDate.setValue(startDate.toDate());
       this.fields.Type.setValue(activityType);
       this.fields.Duration.setValue(activityDuration);
-      var user = App.context.user;
+      const user = App.context.user;
       if (user) {
         this.fields.UserId.setValue(user.$key);
 
-        var leaderField = this.fields.Leader;
+        const leaderField = this.fields.Leader;
         leaderField.setValue(user);
         this.onLeaderChange(user, leaderField);
       }
 
-      var found = this._getNavContext();
-      var accountField = this.fields.Account;
+      const found = this._getNavContext();
+      const accountField = this.fields.Account;
       this.onAccountChange(accountField.getValue(), accountField);
 
-      var context = found && found.options && found.options.source || found;
-      var lookup = {
+      const context = found && found.options && found.options.source || found;
+      const lookup = {
         accounts: this.applyAccountContext,
         contacts: this.applyContactContext,
         opportunities: this.applyOpportunityContext,
@@ -506,8 +502,8 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     _getCalculatedStartTime: function _getCalculatedStartTime(selectedDate) {
-      var now = moment();
-      var thisSelectedDate = selectedDate;
+      const now = moment();
+      let thisSelectedDate = selectedDate;
 
       if (!moment.isMoment(selectedDate)) {
         thisSelectedDate = moment(selectedDate);
@@ -519,21 +515,21 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       // 11:24 -> 11:30
       // 11:12 -> 11:15
       // 11:31 -> 11:45
-      var startDate = thisSelectedDate.clone().startOf('day').hours(now.hours()).add({
+      const startDate = thisSelectedDate.clone().startOf('day').hours(now.hours()).add({
         minutes: Math.floor(now.minutes() / this.ROUND_MINUTES) * this.ROUND_MINUTES + this.ROUND_MINUTES
       });
 
       return startDate;
     },
     applyAccountContext: function applyAccountContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setSelection(entry);
       accountField.setValue({
         AccountId: entry.$key,
@@ -542,14 +538,14 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       this.onAccountChange(accountField.getValue(), accountField);
     },
     applyContactContext: function applyContactContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var contactField = this.fields.Contact;
+      const contactField = this.fields.Contact;
 
       contactField.setSelection(entry);
       contactField.setValue({
@@ -559,26 +555,26 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
 
       this.onAccountDependentChange(contactField.getValue(), contactField);
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setValue({
         AccountId: _Utility2.default.getValue(entry, 'Account.$key'),
         AccountName: _Utility2.default.getValue(entry, 'Account.AccountName')
       });
 
       if (entry.WorkPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.WorkPhone);
       }
     },
     applyTicketContext: function applyTicketContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var ticketField = this.fields.Ticket;
+      const ticketField = this.fields.Ticket;
       ticketField.setSelection(entry);
       ticketField.setValue({
         TicketId: entry.$key,
@@ -586,34 +582,34 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       });
       this.onAccountDependentChange(ticketField.getValue(), ticketField);
 
-      var contactField = this.fields.Contact;
+      const contactField = this.fields.Contact;
       contactField.setValue({
         ContactId: _Utility2.default.getValue(entry, 'Contact.$key'),
         ContactName: _Utility2.default.getValue(entry, 'Contact.NameLF')
       });
       this.onAccountDependentChange(contactField.getValue(), contactField);
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setValue({
         AccountId: _Utility2.default.getValue(entry, 'Account.$key'),
         AccountName: _Utility2.default.getValue(entry, 'Account.AccountName')
       });
 
-      var phone = entry && entry.Contact && entry.Contact.WorkPhone || entry && entry.Account && entry.Account.MainPhone;
+      const phone = entry && entry.Contact && entry.Contact.WorkPhone || entry && entry.Account && entry.Account.MainPhone;
       if (phone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(phone);
       }
     },
     applyOpportunityContext: function applyOpportunityContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var opportunityField = this.fields.Opportunity;
+      const opportunityField = this.fields.Opportunity;
       opportunityField.setSelection(entry);
       opportunityField.setValue({
         OpportunityId: entry.$key,
@@ -622,26 +618,26 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
 
       this.onAccountDependentChange(opportunityField.getValue(), opportunityField);
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setValue({
         AccountId: _Utility2.default.getValue(entry, 'Account.$key'),
         AccountName: _Utility2.default.getValue(entry, 'Account.AccountName')
       });
 
       if (entry.Account && entry.Account.MainPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.Account.MainPhone);
       }
     },
     applyLeadContext: function applyLeadContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var leadField = this.fields.Lead;
+      const leadField = this.fields.Lead;
       leadField.setSelection(entry);
       leadField.setValue({
         LeadId: entry.$key,
@@ -651,23 +647,23 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
 
       this.fields.AccountName.setValue(entry.Company);
 
-      var isLeadField = this.fields.IsLead;
+      const isLeadField = this.fields.IsLead;
       if (isLeadField) {
         isLeadField.setValue(context.resourceKind === 'leads');
         this.onIsLeadChange(isLeadField.getValue(), isLeadField);
       }
 
       if (entry.WorkPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.WorkPhone);
       }
     },
     onAccountChange: function onAccountChange(value, field) {
-      var fields = this.fields;
-      ['Contact', 'Opportunity', 'Ticket'].forEach(function (f) {
+      const fields = this.fields;
+      ['Contact', 'Opportunity', 'Ticket'].forEach(f => {
         if (value) {
           fields[f].dependsOn = 'Account';
-          fields[f].where = 'Account.Id eq "' + (value.AccountId || value.key) + '"';
+          fields[f].where = `Account.Id eq "${value.AccountId || value.key}"`;
 
           if (fields[f].currentSelection && fields[f].currentSelection.Account.$key !== (value.AccountId || value.key)) {
             fields[f].setValue(false);
@@ -687,42 +683,42 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
         return;
       }
 
-      var entry = field.currentSelection;
+      const entry = field.currentSelection;
       if (entry && entry.MainPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.MainPhone);
       }
     },
     onContactChange: function onContactChange(value, field) {
       this.onAccountDependentChange(value, field);
-      var entry = field.currentSelection;
+      const entry = field.currentSelection;
 
       if (entry && entry.WorkPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.WorkPhone);
       }
     },
     onOpportunityChange: function onOpportunityChange(value, field) {
       this.onAccountDependentChange(value, field);
-      var entry = field.currentSelection;
+      const entry = field.currentSelection;
 
       if (entry && entry.Account && entry.Account.MainPhone) {
-        var phoneField = this.fieldsPhoneNumber;
+        const phoneField = this.fieldsPhoneNumber;
         phoneField.setValue(entry.Account.MainPhone);
       }
     },
     onTicketChange: function onTicketChange(value, field) {
       this.onAccountDependentChange(value, field);
-      var entry = field.currentSelection;
-      var phone = entry && entry.Contact && entry.Contact.WorkPhone || entry && entry.Account && entry.Account.MainPhone;
+      const entry = field.currentSelection;
+      const phone = entry && entry.Contact && entry.Contact.WorkPhone || entry && entry.Account && entry.Account.MainPhone;
       if (phone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(phone);
       }
     },
     onAccountDependentChange: function onAccountDependentChange(value, field) {
       if (value && !field.dependsOn && field.currentSelection && field.currentSelection.Account) {
-        var accountField = this.fields.Account;
+        const accountField = this.fields.Account;
         accountField.setValue({
           AccountId: field.currentSelection.Account.$key,
           AccountName: field.currentSelection.Account.AccountName
@@ -731,13 +727,13 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     completeActivity: function completeActivity(entry, callback) {
-      var activityModel = App.ModelManager.getModel(_Names2.default.ACTIVITY, _Types2.default.SDATA);
+      const activityModel = App.ModelManager.getModel(_Names2.default.ACTIVITY, _Types2.default.SDATA);
       entry.Leader = this.fields.Leader.getValue();
       entry.Result = this.fields.Result.getValue();
       entry.ResultCode = this.fields.ResultCode.getValue();
       entry.CompletedDate = this.fields.CompletedDate.getValue();
 
-      var success = function refreshStale(scope, theCallback, theEntry) {
+      const success = function refreshStale(scope, theCallback, theEntry) {
         return function refreshStaleViews() {
           _Environment2.default.refreshStaleDetailViews();
           _connect2.default.publish('/app/refresh', [{
@@ -768,18 +764,18 @@ define('crm/Views/Activity/Complete', ['module', 'exports', 'dojo/_base/declare'
         return;
       }
 
-      var followup = this.fields.Followup.getValue() === 'none' ? this.getInherited(onUpdateCompleted, arguments) : this.navigateToFollowUpView;
+      const followup = this.fields.Followup.getValue() === 'none' ? this.getInherited(onUpdateCompleted, arguments) : this.navigateToFollowUpView;
       entry.$completedBasedOn = this._completedBasedOn;
       this.completeActivity(entry, followup);
     },
     formatDependentQuery: function formatDependentQuery(dependentValue, format, property) {
-      var theProperty = property || '$key';
+      const theProperty = property || '$key';
 
       return _string2.default.substitute(format, [_Utility2.default.getValue(dependentValue, theProperty)]);
     },
     _getNavContext: function _getNavContext() {
-      var navContext = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      const navContext = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
 
         if (/^(accounts|contacts|opportunities|tickets|leads)$/.test(context.resourceKind) && context.key) {
           return true;

--- a/src-out/Views/Activity/Detail.js
+++ b/src-out/Views/Activity/Detail.js
@@ -50,10 +50,10 @@ define('crm/Views/Activity/Detail', ['module', 'exports', 'dojo/_base/declare', 
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityDetail');
-  var dtFormatResource = (0, _I18n2.default)('activityDetailDateTimeFormat');
+  const resource = (0, _I18n2.default)('activityDetail');
+  const dtFormatResource = (0, _I18n2.default)('activityDetailDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.Detail', [_Detail2.default], {
     // Localization
     actionsText: resource.actionsText,
     completeActivityText: resource.completeActivityText,
@@ -116,8 +116,6 @@ define('crm/Views/Activity/Detail', ['module', 'exports', 'dojo/_base/declare', 
       return this.activityTypeText[val] || val;
     },
     navigateToEditView: function navigateToEditView() {
-      var _this = this;
-
       if (!this.isActivityRecurringSeries(this.entry)) {
         // normal activity
         this.onEditActivity(this.entry);
@@ -133,12 +131,12 @@ define('crm/Views/Activity/Detail', ['module', 'exports', 'dojo/_base/declare', 
             this.onEditActivity(this.entry);
           } else {
             // we need to resolve occurance
-            this.getOccurance(this.entry).then(function (occurance) {
+            this.getOccurance(this.entry).then(occurance => {
               if (occurance) {
-                if (_this.entry.Leader) {
-                  occurance.Leader = _this.entry.Leader;
+                if (this.entry.Leader) {
+                  occurance.Leader = this.entry.Leader;
                 }
-                _this.onEditActivity(occurance);
+                this.onEditActivity(occurance);
               }
             });
           }
@@ -146,12 +144,12 @@ define('crm/Views/Activity/Detail', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     getOccurance: function getOccurance(entry) {
-      var def = new _Deferred2.default();
-      var key = entry.$key;
+      const def = new _Deferred2.default();
+      const key = entry.$key;
       // Check to ensure we have a composite key (meaning we have the occurance, not the master)
       if (this.isActivityRecurring(entry) && key.split(this.recurringActivityIdSeparator).length !== 2) {
         // Fetch the occurance, and continue on to the complete screen
-        var request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setResourceKind('activities').setContractName('system').setQueryArg('where', 'id eq \'' + key + '\'').setCount(1);
+        const request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setResourceKind('activities').setContractName('system').setQueryArg('where', `id eq '${key}'`).setCount(1);
 
         request.read({
           success: function success(feed) {
@@ -168,19 +166,19 @@ define('crm/Views/Activity/Detail', ['module', 'exports', 'dojo/_base/declare', 
       return def.promise;
     },
     onEditActivity: function onEditActivity(entry) {
-      var view = App.getView(this.editView);
+      const view = App.getView(this.editView);
       if (view) {
         view.show({
-          entry: entry
+          entry
         });
       }
     },
     navigateToCompleteView: function navigateToCompleteView(completionTitle, isSeries) {
-      var view = App.getView(this.completeView);
+      const view = App.getView(this.completeView);
 
       if (view) {
         _Environment2.default.refreshActivityLists();
-        var options = {
+        const options = {
           title: completionTitle,
           template: {}
         };
@@ -201,13 +199,13 @@ define('crm/Views/Activity/Detail', ['module', 'exports', 'dojo/_base/declare', 
       this.navigateToCompleteView(this.completeActivityText);
     },
     completeOccurrence: function completeOccurrence() {
-      var entry = this.entry;
-      var key = entry.$key;
+      const entry = this.entry;
+      const key = entry.$key;
 
       // Check to ensure we have a composite key (meaning we have the occurance, not the master)
       if (this.isActivityRecurring(entry) && key.split(this.recurringActivityIdSeparator).length !== 2) {
         // Fetch the occurance, and continue on to the complete screen
-        var request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setResourceKind('activities').setContractName('system').setQueryArg('where', 'id eq \'' + key + '\'').setCount(1);
+        const request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setResourceKind('activities').setContractName('system').setQueryArg('where', `id eq '${key}'`).setCount(1);
 
         request.read({
           success: this.processOccurance,
@@ -251,11 +249,11 @@ define('crm/Views/Activity/Detail', ['module', 'exports', 'dojo/_base/declare', 
       return _Format2.default.picklist(this.app.picklistService, this._model, property);
     },
     formatRelatedQuery: function formatRelatedQuery(entry, fmt, property) {
-      var toReturn = void 0;
+      let toReturn;
       if (property === 'activityId') {
         toReturn = _string2.default.substitute(fmt, [_Utility4.default.getRealActivityId(entry.$key)]);
       } else {
-        var theProperty = property || '$key';
+        const theProperty = property || '$key';
         toReturn = _string2.default.substitute(fmt, [_Utility2.default.getValue(entry, theProperty, '')]);
       }
       return toReturn;
@@ -466,7 +464,7 @@ define('crm/Views/Activity/Detail', ['module', 'exports', 'dojo/_base/declare', 
       }]);
     },
     getOfflineIcon: function getOfflineIcon() {
-      var model = this.getModel();
+      const model = this.getModel();
       return model.getIconClass(this.entry);
     }
   });

--- a/src-out/Views/Activity/Edit.js
+++ b/src-out/Views/Activity/Edit.js
@@ -46,10 +46,10 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityEdit');
-  var dtFormatResource = (0, _I18n2.default)('activityEditDateTimeFormat');
+  const resource = (0, _I18n2.default)('activityEdit');
+  const dtFormatResource = (0, _I18n2.default)('activityEditDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.Edit', [_Edit2.default], {
     // Localization
     activityCategoryTitleText: resource.activityCategoryTitleText,
     activityDescriptionTitleText: resource.activityDescriptionTitleText,
@@ -192,8 +192,8 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       this.inherited(onAddComplete, arguments);
     },
     onPutComplete: function onPutComplete(entry, updatedEntry) {
-      var view = App.getView(this.detailView);
-      var originalKey = this.options.entry && this.options.entry.$key || updatedEntry.$key;
+      const view = App.getView(this.detailView);
+      const originalKey = this.options.entry && this.options.entry.$key || updatedEntry.$key;
 
       this.enable();
 
@@ -216,7 +216,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       }
     },
     convertEntry: function convertEntry() {
-      var entry = this.inherited(convertEntry, arguments);
+      const entry = this.inherited(convertEntry, arguments);
       if (!this.options.entry) {
         if (entry && entry.Leader.$key) {
           this.requestLeader(entry.Leader.$key);
@@ -226,7 +226,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       return entry;
     },
     requestLeader: function requestLeader(userId) {
-      var request = new Sage.SData.Client.SDataSingleResourceRequest(this.getConnection()).setResourceKind('users').setResourceSelector('\'' + userId + '\'').setQueryArg('select', ['UserInfo/FirstName', 'UserInfo/LastName'].join(','));
+      const request = new Sage.SData.Client.SDataSingleResourceRequest(this.getConnection()).setResourceKind('users').setResourceSelector(`'${userId}'`).setQueryArg('select', ['UserInfo/FirstName', 'UserInfo/LastName'].join(','));
 
       request.read({
         success: this.processLeader,
@@ -255,16 +255,16 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       );
     },
     isInLeadContext: function isInLeadContext() {
-      var insert = this.options && this.options.insert;
-      var entry = this.options && this.options.entry;
-      var context = this._getNavContext();
-      var isLeadContext = false;
+      const insert = this.options && this.options.insert;
+      const entry = this.options && this.options.entry;
+      const context = this._getNavContext();
+      let isLeadContext = false;
 
       if (context.resourceKind === 'leads') {
         isLeadContext = true;
       }
 
-      var lead = insert && isLeadContext || this.isActivityForLead(entry);
+      const lead = insert && isLeadContext || this.isActivityForLead(entry);
 
       return !!lead;
     },
@@ -286,14 +286,14 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       }
     },
     disableFields: function disableFields(predicate) {
-      for (var name in this.fields) {
+      for (const name in this.fields) {
         if (!predicate || predicate(this.fields[name])) {
           this.fields[name].disable();
         }
       }
     },
     enableFields: function enableFields(predicate) {
-      for (var name in this.fields) {
+      for (const name in this.fields) {
         if (!predicate || predicate(this.fields[name])) {
           this.fields[name].enable();
         }
@@ -309,32 +309,28 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       }
     },
     showFieldsForLead: function showFieldsForLead() {
-      var _this = this;
-
-      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(function (item) {
-        if (_this.fields[item]) {
-          _this.fields[item].hide();
+      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].hide();
         }
       }, this);
 
-      this.fieldsForLeads.forEach(function (item) {
-        if (_this.fields[item]) {
-          _this.fields[item].show();
+      this.fieldsForLeads.forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].show();
         }
       }, this);
     },
     showFieldsForStandard: function showFieldsForStandard() {
-      var _this2 = this;
-
-      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(function (item) {
-        if (_this2.fields[item]) {
-          _this2.fields[item].hide();
+      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].hide();
         }
       }, this);
 
-      this.fieldsForStandard.forEach(function (item) {
-        if (_this2.fields[item]) {
-          _this2.fields[item].show();
+      this.fieldsForStandard.forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].show();
         }
       }, this);
     },
@@ -347,7 +343,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
     },
     onTimelessChange: function onTimelessChange(value) {
       this.toggleSelectField(this.fields.Duration, value);
-      var startDateField = this.fields.StartDate;
+      const startDateField = this.fields.StartDate;
 
       if (value) {
         // StartDate timeless
@@ -355,7 +351,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
         startDateField.dateFormatText = this.startingTimelessFormatText;
         startDateField.showTimePicker = false;
         startDateField.timeless = true;
-        var startDate = this._getNewStartDate(startDateField.getValue(), true);
+        const startDate = this._getNewStartDate(startDateField.getValue(), true);
 
         if (startDate) {
           startDateField.setValue(startDate);
@@ -367,10 +363,10 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
         startDateField.dateFormatText = App.is24HourClock() ? this.startingFormatText24 : this.startingFormatText;
         startDateField.showTimePicker = true;
         startDateField.timeless = false;
-        var _startDate = this._getNewStartDate(startDateField.getValue(), false);
+        const startDate = this._getNewStartDate(startDateField.getValue(), false);
 
-        if (_startDate) {
-          startDateField.setValue(_startDate);
+        if (startDate) {
+          startDateField.setValue(startDate);
         }
       }
     },
@@ -382,23 +378,23 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       }
     },
     onLeadChange: function onLeadChange(value, field) {
-      var selection = field.getSelection();
+      const selection = field.getSelection();
 
       if (selection && this.options && this.options.insert) {
         this.fields.AccountName.setValue(_Utility2.default.getValue(selection, 'Company'));
       }
 
-      var entry = field.currentSelection;
+      const entry = field.currentSelection;
       if (entry.WorkPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.WorkPhone);
       }
     },
     onLeaderChange: function onLeaderChange(value, field) {
-      var user = field.getValue();
-      var resourceId = '';
+      const user = field.getValue();
+      let resourceId = '';
 
-      var key = user.$key;
+      let key = user.$key;
 
       // The key is a composite key on activityresourceviews endpoint.
       // The format is 'ResourceId-AccessId'.
@@ -419,11 +415,11 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       }
     },
     onAccountChange: function onAccountChange(value, field) {
-      var fields = this.fields;
-      ['Contact', 'Opportunity', 'Ticket'].forEach(function (f) {
+      const fields = this.fields;
+      ['Contact', 'Opportunity', 'Ticket'].forEach(f => {
         if (value) {
           fields[f].dependsOn = 'Account';
-          fields[f].where = 'Account.Id eq "' + (value.AccountId || value.key) + '"';
+          fields[f].where = `Account.Id eq "${value.AccountId || value.key}"`;
 
           if (fields[f].currentSelection && fields[f].currentSelection.Account && fields[f].currentSelection.Account.$key !== (value.AccountId || value.key)) {
             fields[f].setValue(false);
@@ -443,42 +439,42 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
         return;
       }
 
-      var entry = field.currentSelection;
+      const entry = field.currentSelection;
       if (entry && entry.MainPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.MainPhone);
       }
     },
     onContactChange: function onContactChange(value, field) {
       this.onAccountDependentChange(value, field);
-      var entry = field.currentSelection;
+      const entry = field.currentSelection;
 
       if (entry && entry.WorkPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.WorkPhone);
       }
     },
     onOpportunityChange: function onOpportunityChange(value, field) {
       this.onAccountDependentChange(value, field);
-      var entry = field.currentSelection;
+      const entry = field.currentSelection;
 
       if (entry && entry.Account && entry.Account.MainPhone) {
-        var phoneField = this.fieldsPhoneNumber;
+        const phoneField = this.fieldsPhoneNumber;
         phoneField.setValue(entry.Account.MainPhone);
       }
     },
     onTicketChange: function onTicketChange(value, field) {
       this.onAccountDependentChange(value, field);
-      var entry = field.currentSelection;
-      var phone = entry && entry.Contact && entry.Contact.WorkPhone || entry && entry.Account && entry.Account.MainPhone;
+      const entry = field.currentSelection;
+      const phone = entry && entry.Contact && entry.Contact.WorkPhone || entry && entry.Account && entry.Account.MainPhone;
       if (phone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(phone);
       }
     },
     onAccountDependentChange: function onAccountDependentChange(value, field) {
       if (value && !field.dependsOn && field.currentSelection && field.currentSelection.Account) {
-        var accountField = this.fields.Account;
+        const accountField = this.fields.Account;
         accountField.setValue({
           AccountId: field.currentSelection.Account.$key,
           AccountName: field.currentSelection.Account.AccountName
@@ -496,12 +492,12 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
 
       _Recurrence2.default.createSimplifiedOptions(value);
 
-      var repeats = this.recurrence.RecurrenceState === 'rstMaster';
+      const repeats = this.recurrence.RecurrenceState === 'rstMaster';
       this.fields.RecurrenceUI.setValue(_Recurrence2.default.getPanel(repeats && this.recurrence.RecurPeriod));
     },
     onRecurrenceUIChange: function onRecurrenceUIChange(value, field) {
-      var key = field.currentValue && field.currentValue.key;
-      var opt = _Recurrence2.default.simplifiedOptions[key];
+      const key = field.currentValue && field.currentValue.key;
+      const opt = _Recurrence2.default.simplifiedOptions[key];
       // preserve #iterations (and EndDate) if matching recurrence
       if (this._previousRecurrence === key) {
         opt.RecurIterations = this.recurrence.RecurIterations;
@@ -512,8 +508,8 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
     },
     onRecurrenceChange: function onRecurrenceChange(value) {
       // did the StartDate change on the recurrence_edit screen?
-      var startDate = argos.Convert.toDateFromString(value.StartDate); // TODO: Avoid global
-      var currentDate = this.fields.StartDate.getValue();
+      const startDate = argos.Convert.toDateFromString(value.StartDate); // TODO: Avoid global
+      const currentDate = this.fields.StartDate.getValue();
 
       if (startDate.getDate() !== currentDate.getDate() || startDate.getMonth() !== currentDate.getMonth()) {
         this.fields.StartDate.setValue(startDate);
@@ -574,8 +570,8 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       return _Recurrence2.default.toString(recurrence, true);
     },
     _getCalculatedStartTime: function _getCalculatedStartTime(selectedDate) {
-      var now = moment();
-      var thisSelectedDate = selectedDate;
+      const now = moment();
+      let thisSelectedDate = selectedDate;
 
       if (!moment.isMoment(selectedDate)) {
         thisSelectedDate = moment(selectedDate);
@@ -587,7 +583,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       // 11:24 -> 11:30
       // 11:12 -> 11:15
       // 11:31 -> 11:45
-      var startDate = thisSelectedDate.clone().startOf('day').hours(now.hours()).add({
+      const startDate = thisSelectedDate.clone().startOf('day').hours(now.hours()).add({
         minutes: Math.floor(now.minutes() / this.ROUND_MINUTES) * this.ROUND_MINUTES + this.ROUND_MINUTES
       });
 
@@ -599,12 +595,12 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
     applyContext: function applyContext() {
       this.inherited(applyContext, arguments);
 
-      var startDate = this._getCalculatedStartTime(moment());
-      var activityType = this.options && this.options.activityType;
-      var activityGroup = this.groupOptionsByType[activityType] || '';
-      var activityDuration = App.context.userOptions && App.context.userOptions[activityGroup + ':Duration'] || 15;
-      var alarmEnabled = App.context.userOptions && App.context.userOptions[activityGroup + ':AlarmEnabled'] || true;
-      var alarmDuration = App.context.userOptions && App.context.userOptions[activityGroup + ':AlarmLead'] || 15;
+      let startDate = this._getCalculatedStartTime(moment());
+      const activityType = this.options && this.options.activityType;
+      const activityGroup = this.groupOptionsByType[activityType] || '';
+      const activityDuration = App.context.userOptions && App.context.userOptions[`${activityGroup}:Duration`] || 15;
+      const alarmEnabled = App.context.userOptions && App.context.userOptions[`${activityGroup}:AlarmEnabled`] || true;
+      const alarmDuration = App.context.userOptions && App.context.userOptions[`${activityGroup}:AlarmLead`] || 15;
 
       if (this.options && this.options.currentDate) {
         startDate = this.applyUserActivityContext(moment(this.options.currentDate));
@@ -616,22 +612,22 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       this.fields.Alarm.setValue(alarmEnabled);
       this.fields.Reminder.setValue(alarmDuration);
 
-      var user = App.context.user;
+      const user = App.context.user;
       if (user) {
         this.fields.UserId.setValue(user.$key);
 
-        var leaderField = this.fields.Leader;
+        const leaderField = this.fields.Leader;
         leaderField.setValue(user);
         this.onLeaderChange(user, leaderField);
       }
 
-      var found = this._getNavContext();
+      const found = this._getNavContext();
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       this.onAccountChange(accountField.getValue(), accountField);
 
-      var context = found && found.options && found.options.source || found;
-      var lookup = {
+      const context = found && found.options && found.options.source || found;
+      const lookup = {
         accounts: this.applyAccountContext,
         contacts: this.applyContactContext,
         opportunities: this.applyOpportunityContext,
@@ -644,8 +640,8 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       }
     },
     _getNavContext: function _getNavContext() {
-      var navContext = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      const navContext = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
 
         if (/^(accounts|contacts|opportunities|tickets|leads)$/.test(context.resourceKind) && context.key) {
           return true;
@@ -656,14 +652,14 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       return navContext;
     },
     applyAccountContext: function applyAccountContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setSelection(entry);
       accountField.setValue({
         AccountId: entry.$key,
@@ -672,14 +668,14 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       this.onAccountChange(accountField.getValue(), accountField);
     },
     applyContactContext: function applyContactContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry || context;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry || context;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var contactField = this.fields.Contact;
+      const contactField = this.fields.Contact;
 
       contactField.setSelection(entry);
       contactField.setValue({
@@ -689,26 +685,26 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
 
       this.onAccountDependentChange(contactField.getValue(), contactField);
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setValue({
         AccountId: _Utility2.default.getValue(entry, 'Account.$key'),
         AccountName: _Utility2.default.getValue(entry, 'Account.AccountName')
       });
 
       if (entry.WorkPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.WorkPhone);
       }
     },
     applyTicketContext: function applyTicketContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var ticketField = this.fields.Ticket;
+      const ticketField = this.fields.Ticket;
       ticketField.setSelection(entry);
       ticketField.setValue({
         TicketId: entry.$key,
@@ -716,34 +712,34 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       });
       this.onAccountDependentChange(ticketField.getValue(), ticketField);
 
-      var contactField = this.fields.Contact;
+      const contactField = this.fields.Contact;
       contactField.setValue({
         ContactId: _Utility2.default.getValue(entry, 'Contact.$key'),
         ContactName: _Utility2.default.getValue(entry, 'Contact.NameLF')
       });
       this.onAccountDependentChange(contactField.getValue(), contactField);
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setValue({
         AccountId: _Utility2.default.getValue(entry, 'Account.$key'),
         AccountName: _Utility2.default.getValue(entry, 'Account.AccountName')
       });
 
-      var phone = entry && entry.Contact && entry.Contact.WorkPhone || entry && entry.Account && entry.Account.MainPhone;
+      const phone = entry && entry.Contact && entry.Contact.WorkPhone || entry && entry.Account && entry.Account.MainPhone;
       if (phone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(phone);
       }
     },
     applyOpportunityContext: function applyOpportunityContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var opportunityField = this.fields.Opportunity;
+      const opportunityField = this.fields.Opportunity;
       opportunityField.setSelection(entry);
       opportunityField.setValue({
         OpportunityId: entry.$key,
@@ -752,26 +748,26 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
 
       this.onAccountDependentChange(opportunityField.getValue(), opportunityField);
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setValue({
         AccountId: _Utility2.default.getValue(entry, 'Account.$key'),
         AccountName: _Utility2.default.getValue(entry, 'Account.AccountName')
       });
 
       if (entry.Account && entry.Account.MainPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.Account.MainPhone);
       }
     },
     applyLeadContext: function applyLeadContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var leadField = this.fields.Lead;
+      const leadField = this.fields.Lead;
       leadField.setSelection(entry);
       leadField.setValue({
         LeadId: entry.$key,
@@ -781,25 +777,25 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
 
       this.fields.AccountName.setValue(entry.Company);
 
-      var isLeadField = this.fields.IsLead;
+      const isLeadField = this.fields.IsLead;
       if (isLeadField) {
         isLeadField.setValue(context.resourceKind === 'leads');
         this.onIsLeadChange(isLeadField.getValue(), isLeadField);
       }
 
       if (entry.WorkPhone) {
-        var phoneField = this.fields.PhoneNumber;
+        const phoneField = this.fields.PhoneNumber;
         phoneField.setValue(entry.WorkPhone);
       }
     },
     setValues: function setValues(values) {
       if (values.StartDate && values.AlarmTime) {
-        var startTime = this.isDateTimeless(values.StartDate) ? moment(values.StartDate).add({
+        const startTime = this.isDateTimeless(values.StartDate) ? moment(values.StartDate).add({
           minutes: values.StartDate.getTimezoneOffset()
         }).toDate().getTime() : values.StartDate.getTime();
 
-        var span = startTime - values.AlarmTime.getTime(); // ms
-        var reminder = span / (1000 * 60);
+        const span = startTime - values.AlarmTime.getTime(); // ms
+        const reminder = span / (1000 * 60);
 
         values.Reminder = _Format2.default.fixed(reminder, 0);
       }
@@ -823,7 +819,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       }
 
       if (this.isInLeadContext()) {
-        var isLeadField = this.fields.IsLead;
+        const isLeadField = this.fields.IsLead;
         if (isLeadField) {
           isLeadField.setValue(true);
           this.onIsLeadChange(isLeadField.getValue(), isLeadField);
@@ -833,16 +829,16 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
         this.fields.AccountName.setValue(values.AccountName);
       }
 
-      var entry = this.options.entry || this.entry;
-      var denyEdit = !this.options.insert && !this.currentUserCanEdit(entry);
-      var allowSetAlarm = !denyEdit || this.currentUserCanSetAlarm(entry);
+      const entry = this.options.entry || this.entry;
+      const denyEdit = !this.options.insert && !this.currentUserCanEdit(entry);
+      const allowSetAlarm = !denyEdit || this.currentUserCanSetAlarm(entry);
 
       if (denyEdit) {
         this.disableFields();
       }
 
       if (allowSetAlarm) {
-        this.enableFields(function (f) {
+        this.enableFields(f => {
           if (values.Alarm) {
             return (/^Alarm|Reminder$/.test(f.name)
             );
@@ -898,12 +894,12 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       return true;
     },
     getValues: function getValues() {
-      var isStartDateDirty = this.fields.StartDate.isDirty();
-      var isReminderDirty = this.fields.Reminder.isDirty();
-      var reminderIn = this.fields.Reminder.getValue();
-      var timeless = this.fields.Timeless.getValue();
-      var startDate = this.fields.StartDate.getValue();
-      var values = this.inherited(getValues, arguments);
+      const isStartDateDirty = this.fields.StartDate.isDirty();
+      const isReminderDirty = this.fields.Reminder.isDirty();
+      const reminderIn = this.fields.Reminder.getValue();
+      const timeless = this.fields.Timeless.getValue();
+      let startDate = this.fields.StartDate.getValue();
+      let values = this.inherited(getValues, arguments);
 
       // Fix timeless if necessary (The date picker won't add 5 seconds)
       if (timeless) {
@@ -913,7 +909,7 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       // if StartDate is dirty, always update AlarmTime
       if (startDate && (isStartDateDirty || isReminderDirty)) {
         values = values || {};
-        var alarmTime = this._getNewAlarmTime(startDate, timeless, reminderIn);
+        const alarmTime = this._getNewAlarmTime(startDate, timeless, reminderIn);
         values.AlarmTime = alarmTime;
       }
 
@@ -925,9 +921,9 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       return values;
     },
     createReminderData: function createReminderData() {
-      var list = [];
+      const list = [];
 
-      for (var duration in this.reminderValueText) {
+      for (const duration in this.reminderValueText) {
         if (this.reminderValueText.hasOwnProperty(duration)) {
           list.push({
             $key: duration,
@@ -941,9 +937,9 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
       };
     },
     createDurationData: function createDurationData() {
-      var list = [];
+      const list = [];
 
-      for (var duration in this.durationValueText) {
+      for (const duration in this.durationValueText) {
         if (this.durationValueText.hasOwnProperty(duration)) {
           list.push({
             $key: duration,
@@ -967,40 +963,40 @@ define('crm/Views/Activity/Edit', ['module', 'exports', 'dojo/_base/declare', 'd
         return null;
       }
 
-      var startDate = orginalStartDate;
-      var isTimeLessDate = this.isDateTimeless(startDate) || this.isDateTimelessLocal(startDate);
+      let startDate = orginalStartDate;
+      const isTimeLessDate = this.isDateTimeless(startDate) || this.isDateTimelessLocal(startDate);
 
       if (timeless) {
         if (!isTimeLessDate) {
-          var wrapped = moment(startDate);
+          let wrapped = moment(startDate);
           wrapped = moment.utc(wrapped.format('YYYY-MM-DD'), 'YYYY-MM-DD');
           wrapped.add('seconds', 5);
           startDate = wrapped.toDate();
         }
       } else {
         if (isTimeLessDate) {
-          var currentTime = moment();
-          var _wrapped = moment(startDate);
-          _wrapped.subtract({
-            minutes: _wrapped.utcOffset()
+          const currentTime = moment();
+          const wrapped = moment(startDate);
+          wrapped.subtract({
+            minutes: wrapped.utcOffset()
           });
-          _wrapped.hours(currentTime.hours());
-          _wrapped.minutes(currentTime.minutes());
-          _wrapped.seconds(0);
-          startDate = _wrapped.toDate();
+          wrapped.hours(currentTime.hours());
+          wrapped.minutes(currentTime.minutes());
+          wrapped.seconds(0);
+          startDate = wrapped.toDate();
         }
       }
 
       return startDate;
     },
     _getNewAlarmTime: function _getNewAlarmTime(startDate, timeless, reminderIn) {
-      var alarmTime = void 0;
+      let alarmTime;
       if (!startDate) {
         return null;
       }
 
       if (timeless) {
-        var wrapped = moment(startDate);
+        const wrapped = moment(startDate);
         wrapped.subtract({
           minutes: wrapped.utcOffset()
         });

--- a/src-out/Views/Activity/List.js
+++ b/src-out/Views/Activity/List.js
@@ -56,48 +56,25 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
     };
   }
 
-  var _slicedToArray = function () {
-    function sliceIterator(arr, i) {
-      var _arr = [];
-      var _n = true;
-      var _d = false;
-      var _e = undefined;
+  /* Copyright 2017 Infor
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
 
-      try {
-        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-          _arr.push(_s.value);
+  const resource = (0, _I18n2.default)('activityList');
+  const hashTagResource = (0, _I18n2.default)('activityListHashTags');
 
-          if (i && _arr.length === i) break;
-        }
-      } catch (err) {
-        _d = true;
-        _e = err;
-      } finally {
-        try {
-          if (!_n && _i["return"]) _i["return"]();
-        } finally {
-          if (_d) throw _e;
-        }
-      }
-
-      return _arr;
-    }
-
-    return function (arr, i) {
-      if (Array.isArray(arr)) {
-        return arr;
-      } else if (Symbol.iterator in Object(arr)) {
-        return sliceIterator(arr, i);
-      } else {
-        throw new TypeError("Invalid attempt to destructure non-iterable instance");
-      }
-    };
-  }();
-
-  var resource = (0, _I18n2.default)('activityList');
-  var hashTagResource = (0, _I18n2.default)('activityListHashTags');
-
-  var __class = (0, _declare2.default)('crm.Views.Activity.List', [_List2.default, _RightDrawerListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.List', [_List2.default, _RightDrawerListMixin3.default], {
     // Localization
     allDayText: resource.allDayText,
     completeActivityText: resource.completeActivityText,
@@ -130,7 +107,23 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
 
     // Templates
     // Card View
-    rowTemplate: new Simplate(['<div as data-action="activateEntry" data-key="{%= $$.getItemActionKey($) %}" data-descriptor="{%: $$.getItemDescriptor($) %}" data-activity-type="{%: $.Type %}">\n      <div class="widget">\n        <div class="widget-header">\n          {%! $$.itemIconTemplate %}<h2 class="widget-title">{%: $$.getTitle($) %}</h2>\n          <button class="btn-actions" type="button" data-action="selectEntry" data-key="{%= $$.getItemActionKey($) %}">\n            <span class="audible">Actions</span>\n            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n              <use xlink:href="#icon-more"></use>\n            </svg>\n          </button>\n          {%! $$.listActionTemplate %}\n        </div>\n        <div class="card-content">\n          {%! $$.itemRowContentTemplate %}\n        </div>\n      </div>\n    </div>']),
+    rowTemplate: new Simplate([`<div as data-action="activateEntry" data-key="{%= $$.getItemActionKey($) %}" data-descriptor="{%: $$.getItemDescriptor($) %}" data-activity-type="{%: $.Type %}">
+      <div class="widget">
+        <div class="widget-header">
+          {%! $$.itemIconTemplate %}<h2 class="widget-title">{%: $$.getTitle($) %}</h2>
+          <button class="btn-actions" type="button" data-action="selectEntry" data-key="{%= $$.getItemActionKey($) %}">
+            <span class="audible">Actions</span>
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-more"></use>
+            </svg>
+          </button>
+          {%! $$.listActionTemplate %}
+        </div>
+        <div class="card-content">
+          {%! $$.itemRowContentTemplate %}
+        </div>
+      </div>
+    </div>`]),
     activityTimeTemplate: new Simplate(['{% if ($$.isTimelessToday($)) { %}', '{%: $$.allDayText %}', '{% } else { %}', '{%: $$.format.relativeDate($.StartDate, argos.Convert.toBoolean($.Timeless)) %}', // TODO: Avoid global
     '{% } %}']),
     itemTemplate: new Simplate(['<p class="listview-heading">', '<span class="p-description">{%: $$.format.picklist($$.app.picklistService, null, null, $$.getPicklistByActivityType($.Type, "Description"))($.Description) %}</span>', '</p>', '<p class="micro-text">', '{%! $$.activityTimeTemplate %}', '</p>', '<p class="micro-text">{%! $$.nameTemplate %}</p>']),
@@ -153,44 +146,44 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
       recurring: 'Recurring eq true',
       timeless: 'Timeless eq true',
       yesterday: function computeYesterday() {
-        var now = moment();
-        var yesterdayStart = now.clone().subtract(1, 'days').startOf('day');
-        var yesterdayEnd = yesterdayStart.clone().endOf('day');
+        const now = moment();
+        const yesterdayStart = now.clone().subtract(1, 'days').startOf('day');
+        const yesterdayEnd = yesterdayStart.clone().endOf('day');
 
-        var query = '((Timeless eq false and StartDate between @' + _Convert2.default.toIsoStringFromDate(yesterdayStart.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(yesterdayEnd.toDate()) + '@) or (Timeless eq true and StartDate between @' + yesterdayStart.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + yesterdayEnd.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
+        const query = `((Timeless eq false and StartDate between @${_Convert2.default.toIsoStringFromDate(yesterdayStart.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(yesterdayEnd.toDate())}@) or (Timeless eq true and StartDate between @${yesterdayStart.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${yesterdayEnd.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
         return query;
       },
       today: function computeToday() {
-        var now = moment();
-        var todayStart = now.clone().startOf('day');
-        var todayEnd = todayStart.clone().endOf('day');
+        const now = moment();
+        const todayStart = now.clone().startOf('day');
+        const todayEnd = todayStart.clone().endOf('day');
 
-        var query = '((Timeless eq false and StartDate between @' + _Convert2.default.toIsoStringFromDate(todayStart.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(todayEnd.toDate()) + '@) or (Timeless eq true and StartDate between @' + todayStart.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + todayEnd.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
+        const query = `((Timeless eq false and StartDate between @${_Convert2.default.toIsoStringFromDate(todayStart.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(todayEnd.toDate())}@) or (Timeless eq true and StartDate between @${todayStart.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${todayEnd.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
         return query;
       },
       'this-week': function computeThisWeek() {
-        var now = moment();
-        var weekStartDate = now.clone().startOf('week');
-        var weekEndDate = weekStartDate.clone().endOf('week');
+        const now = moment();
+        const weekStartDate = now.clone().startOf('week');
+        const weekEndDate = weekStartDate.clone().endOf('week');
 
-        var query = '((Timeless eq false and StartDate between @' + _Convert2.default.toIsoStringFromDate(weekStartDate.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(weekEndDate.toDate()) + '@) or (Timeless eq true and StartDate between @' + weekStartDate.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + weekEndDate.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
+        const query = `((Timeless eq false and StartDate between @${_Convert2.default.toIsoStringFromDate(weekStartDate.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(weekEndDate.toDate())}@) or (Timeless eq true and StartDate between @${weekStartDate.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${weekEndDate.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
         return query;
       }
     },
     defaultSearchTerm: function defaultSearchTerm() {
       if (App.enableHashTags) {
-        var hashtag = this.hashTagQueriesText['this-week'];
+        const hashtag = this.hashTagQueriesText['this-week'];
         if (typeof hashtag === 'string' && hashtag.startsWith('#')) {
           return hashtag;
         }
 
-        return '#' + hashtag;
+        return `#${hashtag}`;
       }
 
       return '';
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(Description) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(Description) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     },
     formatDateTime: function formatDateTime() {
       return 'StartTime';
@@ -223,7 +216,7 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
       return this.tools;
     },
     navigateToNewUnscheduled: function navigateToNewUnscheduled() {
-      var additionalOptions = {
+      const additionalOptions = {
         unscheduled: true
       };
 
@@ -269,9 +262,9 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
     },
     hasBeenTouched: function hasBeenTouched(entry) {
       if (entry.ModifyDate) {
-        var modifiedDate = moment(_Convert2.default.toDateFromString(entry.ModifyDate));
-        var currentDate = moment().endOf('day');
-        var weekAgo = moment().subtract(1, 'weeks');
+        const modifiedDate = moment(_Convert2.default.toDateFromString(entry.ModifyDate));
+        const currentDate = moment().endOf('day');
+        const weekAgo = moment().subtract(1, 'weeks');
 
         return modifiedDate.isAfter(weekAgo) && modifiedDate.isBefore(currentDate);
       }
@@ -282,10 +275,10 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
     },
     isOverdue: function isOverdue(entry) {
       if (entry.StartDate) {
-        var startDate = _Convert2.default.toDateFromString(entry.StartDate);
-        var currentDate = new Date();
-        var seconds = Math.round((currentDate - startDate) / 1000);
-        var mins = seconds / 60;
+        const startDate = _Convert2.default.toDateFromString(entry.StartDate);
+        const currentDate = new Date();
+        const seconds = Math.round((currentDate - startDate) / 1000);
+        const mins = seconds / 60;
         if (mins >= 1) {
           return true;
         }
@@ -297,7 +290,7 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
         return false;
       }
 
-      var start = moment(entry.StartDate);
+      const start = moment(entry.StartDate);
       return this._isTimelessToday(start);
     },
     _isTimelessToday: function _isTimelessToday(start) {
@@ -322,7 +315,7 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
       return false;
     },
     getItemIconClass: function getItemIconClass(entry) {
-      var type = entry && entry.Type;
+      const type = entry && entry.Type;
       return this._getItemIconClass(type);
     },
     _getItemIconClass: function _getItemIconClass(type) {
@@ -334,7 +327,7 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
         cls: 'checkbox',
         label: this.completeActivityText,
         enabled: function enabled(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           if (!entry) {
             return false;
           }
@@ -342,7 +335,7 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
           return entry.Leader.$key === App.context.user.$key;
         },
         fn: function fn(theAction, selection) {
-          var entry = selection && selection.data && selection.data;
+          const entry = selection && selection.data && selection.data;
 
           entry.CompletedDate = new Date();
           entry.Result = 'Complete';
@@ -355,12 +348,12 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
         cls: 'phone',
         label: this.callText,
         enabled: function enabled(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           return entry && entry.PhoneNumber;
         },
         fn: function fn(theAction, selection) {
-          var entry = selection && selection.data;
-          var phone = entry && entry.PhoneNumber;
+          const entry = selection && selection.data;
+          const phone = entry && entry.PhoneNumber;
           if (phone) {
             this.recordCallToHistory(function initiateCall() {
               App.initiateCall(phone);
@@ -375,7 +368,7 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
       }]);
     },
     recordCallToHistory: function recordCallToHistory(complete, entry) {
-      var tempEntry = {
+      const tempEntry = {
         $name: 'History',
         Type: 'atPhoneCall',
         ContactName: entry.ContactName,
@@ -395,70 +388,65 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
       _Action2.default.navigateToHistoryInsert(entry, complete);
     },
     completeActivity: function completeActivity(entry) {
-      var _this = this;
-
-      var activityModel = App.ModelManager.getModel(_Names2.default.ACTIVITY, _Types2.default.SDATA);
+      const activityModel = App.ModelManager.getModel(_Names2.default.ACTIVITY, _Types2.default.SDATA);
       if (!activityModel) {
         return;
       }
 
-      var completeAction = function completeAction() {
-        activityModel.completeActivity(entry).then(function () {
+      const completeAction = () => {
+        activityModel.completeActivity(entry).then(() => {
           _connect2.default.publish('/app/refresh', [{
             resourceKind: 'history'
           }]);
-          _this.clear();
-          _this.refresh();
-        }, function (err) {
-          _ErrorManager2.default.addError(err, _this, {}, 'failure');
+          this.clear();
+          this.refresh();
+        }, err => {
+          _ErrorManager2.default.addError(err, this, {}, 'failure');
         });
       };
 
       if (entry.Recurring || entry.$key.indexOf(';') > -1) {
-        var completeOccurrence = false;
+        let completeOccurrence = false;
 
-        var dialog = {
+        const dialog = {
           title: this.completeActivityText,
           content: this.completeRecurringPrompt
         };
 
-        var toolbar = [{
+        const toolbar = [{
           className: 'button--flat button--flat--split',
           text: this.completeOccurrenceText,
-          action: function action() {
+          action: () => {
             completeOccurrence = true;
             App.modal.resolveDeferred();
           }
         }, {
           className: 'button--flat button--flat--split',
           text: this.completeSeriesText,
-          action: function action() {
+          action: () => {
             completeOccurrence = false;
             App.modal.resolveDeferred();
           }
         }, {
           className: 'button--flat button--flat button--flat--full',
           text: this.cancelText,
-          action: function action() {
+          action: () => {
             App.modal.hide();
           }
         }];
 
-        App.modal.add(dialog, toolbar).then(function () {
+        App.modal.add(dialog, toolbar).then(() => {
           // Completing an occurrence, ensure we have a compose key
           if (completeOccurrence && entry.$key && entry.$key.indexOf(';') === -1) {
-            var startDate = _Convert2.default.toDateFromString(entry.StartDate);
-            var key = _Utility2.default.buildActivityCompositeKey(entry.$key, startDate);
+            const startDate = _Convert2.default.toDateFromString(entry.StartDate);
+            const key = _Utility2.default.buildActivityCompositeKey(entry.$key, startDate);
             entry.$key = key; // mutating the entry, but we will refresh anyways
           }
 
           // Completing the series, but we have a composite key, drop it
           if (!completeOccurrence && entry.$key && entry.$key.indexOf(';') > -1) {
-            var _entry$$key$split = entry.$key.split(';'),
-                _entry$$key$split2 = _slicedToArray(_entry$$key$split, 1),
-                _key = _entry$$key$split2[0];
-
-            entry.$key = _key; // mutating the entry, but we will refresh anyways
+            const [key] = entry.$key.split(';');
+            entry.$key = key; // mutating the entry, but we will refresh anyways
           }
 
           completeAction();
@@ -471,9 +459,9 @@ define('crm/Views/Activity/List', ['module', 'exports', 'dojo/_base/declare', 'd
       _ErrorManager2.default.addError(response, o, {}, 'failure');
     },
     activateEntry: function activateEntry(params) {
-      var entry = this.entries[params.key];
+      const entry = this.entries[params.key];
       if (entry) {
-        var activityParams = params;
+        const activityParams = params;
         activityParams.descriptor = this._model.getEntityDescription(entry);
         this.inherited(activateEntry, arguments, [activityParams]);
       } else {

--- a/src-out/Views/Activity/MyDay.js
+++ b/src-out/Views/Activity/MyDay.js
@@ -23,22 +23,22 @@ define('crm/Views/Activity/MyDay', ['module', 'exports', 'dojo/_base/declare', '
     };
   }
 
-  var resource = (0, _I18n2.default)('activityMyDay'); /* Copyright 2017 Infor
-                                                        *
-                                                        * Licensed under the Apache License, Version 2.0 (the "License");
-                                                        * you may not use this file except in compliance with the License.
-                                                        * You may obtain a copy of the License at
-                                                        *
-                                                        *    http://www.apache.org/licenses/LICENSE-2.0
-                                                        *
-                                                        * Unless required by applicable law or agreed to in writing, software
-                                                        * distributed under the License is distributed on an "AS IS" BASIS,
-                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                        * See the License for the specific language governing permissions and
-                                                        * limitations under the License.
-                                                        */
+  const resource = (0, _I18n2.default)('activityMyDay'); /* Copyright 2017 Infor
+                                                          *
+                                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                                          * you may not use this file except in compliance with the License.
+                                                          * You may obtain a copy of the License at
+                                                          *
+                                                          *    http://www.apache.org/licenses/LICENSE-2.0
+                                                          *
+                                                          * Unless required by applicable law or agreed to in writing, software
+                                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                          * See the License for the specific language governing permissions and
+                                                          * limitations under the License.
+                                                          */
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.MyDay', [_MyList2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.MyDay', [_MyList2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
 
     // Localization
     titleText: resource.titleText,
@@ -67,7 +67,7 @@ define('crm/Views/Activity/MyDay', ['module', 'exports', 'dojo/_base/declare', '
       this.inherited(show, arguments);
     },
     _showOfflineView: function _showOfflineView(options) {
-      var view = App.getView('myday_offline_list');
+      let view = App.getView('myday_offline_list');
       if (!view) {
         view = new _MyDayOffline2.default();
         App.registerView(view);
@@ -103,9 +103,9 @@ define('crm/Views/Activity/MyDay', ['module', 'exports', 'dojo/_base/declare', '
     },
     onRefreshClicked: function onRefreshClicked() {},
     _getCurrentQuery: function _getCurrentQuery(options) {
-      var myDayQuery = this._model.getMyDayQuery();
-      var optionsQuery = options && options.queryArgs && options.queryArgs.activeFilter;
-      return [myDayQuery, optionsQuery].filter(function (item) {
+      const myDayQuery = this._model.getMyDayQuery();
+      const optionsQuery = options && options.queryArgs && options.queryArgs.activeFilter;
+      return [myDayQuery, optionsQuery].filter(item => {
         return !!item;
       }).join(' and ');
     },

--- a/src-out/Views/Activity/MyDayMetricListMixin.js
+++ b/src-out/Views/Activity/MyDayMetricListMixin.js
@@ -32,22 +32,22 @@ define('crm/Views/Activity/MyDayMetricListMixin', ['module', 'exports', 'dojo/_b
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.MyDayMetricListMixin', [_MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.MyDayMetricListMixin', [_MetricListMixin3.default], {
 
     metricWidgetCtor: _MyDayMetricWidget2.default,
     _applyStateToWidgetOptions: function _applyStateToWidgetOptions(widgetOptions) {
-      var options = widgetOptions;
+      const options = widgetOptions;
       options.parent = this;
       return options;
     },
     createMetricWidgetsLayout: function createMetricWidgetsLayout() {
-      var metrics = [];
-      var filtered = [];
+      let metrics = [];
+      let filtered = [];
 
       metrics = App.getMetricsByResourceKind('userActivities');
 
       if (metrics.length > 0) {
-        filtered = metrics.filter(function (item) {
+        filtered = metrics.filter(item => {
           return item.enabled;
         });
       }

--- a/src-out/Views/Activity/MyDayMetricWidget.js
+++ b/src-out/Views/Activity/MyDayMetricWidget.js
@@ -27,15 +27,15 @@ define('crm/Views/Activity/MyDayMetricWidget', ['module', 'exports', '../MetricW
     navToReportView: function navToReportView() {},
     activityType: '',
     _buildQueryOptions: function _buildQueryOptions() {
-      var self = this;
+      const self = this;
       return {
         returnQueryResults: true,
-        filter: function filter(entity) {
+        filter: entity => {
           if (entity.Type === self.activityType) {
             if (self.parent) {
-              var filter = self.parent.getCurrentFilter();
+              const filter = self.parent.getCurrentFilter();
               if (filter && filter.fn) {
-                var result = filter.fn.apply(self.parent, [entity]);
+                const result = filter.fn.apply(self.parent, [entity]);
                 if (result) {
                   return true;
                 }
@@ -50,18 +50,16 @@ define('crm/Views/Activity/MyDayMetricWidget', ['module', 'exports', '../MetricW
       };
     },
     _getData: function _getData() {
-      var queryOptions = this._buildQueryOptions();
-      var model = App.ModelManager.getModel('Activity', _Types2.default.OFFLINE);
-      var queryResults = model.getEntries(null, queryOptions);
+      const queryOptions = this._buildQueryOptions();
+      const model = App.ModelManager.getModel('Activity', _Types2.default.OFFLINE);
+      const queryResults = model.getEntries(null, queryOptions);
       (0, _when2.default)(queryResults, _lang2.default.hitch(this, this._onQuerySuccessCount, queryResults), _lang2.default.hitch(this, this._onQueryError));
     },
     _onQuerySuccessCount: function _onQuerySuccessCount(results) {
-      var _this = this;
-
-      var def = new _Deferred2.default();
-      (0, _when2.default)(results.total, function (total) {
-        var metricResults = [{
-          name: _this.activityType,
+      const def = new _Deferred2.default();
+      (0, _when2.default)(results.total, total => {
+        const metricResults = [{
+          name: this.activityType,
           value: total
         }];
         def.resolve(metricResults);

--- a/src-out/Views/Activity/MyDayOffline.js
+++ b/src-out/Views/Activity/MyDayOffline.js
@@ -40,7 +40,7 @@ define('crm/Views/Activity/MyDayOffline', ['module', 'exports', 'dojo/_base/decl
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityMyDayOffline');
+  const resource = (0, _I18n2.default)('activityMyDayOffline');
 
   exports.default = (0, _declare2.default)('crm.Views.Activity.MyDayOffline', [_List2.default, _MyDayMetricListMixin2.default, _MyDayRightDrawerListMixin2.default], {
     id: 'myday_offline_list',
@@ -80,18 +80,18 @@ define('crm/Views/Activity/MyDayOffline', ['module', 'exports', 'dojo/_base/decl
     },
 
     getCurrentFilter: function getCurrentFilter() {
-      var filters = this.getFilters();
+      const filters = this.getFilters();
       return filters[this._currentFilterName];
     },
     setCurrentFilter: function setCurrentFilter(name) {
       this._currentFilterName = name;
     },
     _applyStateToQueryOptions: function _applyStateToQueryOptions(queryOptions) {
-      var self = this;
-      queryOptions.filter = function (entity) {
-        var filter = self.getCurrentFilter();
+      const self = this;
+      queryOptions.filter = entity => {
+        const filter = self.getCurrentFilter();
         if (filter && filter.fn) {
-          var result = filter.fn.apply(self, [entity]);
+          const result = filter.fn.apply(self, [entity]);
           if (result) {
             return true;
           }
@@ -104,8 +104,8 @@ define('crm/Views/Activity/MyDayOffline', ['module', 'exports', 'dojo/_base/decl
     },
     isToday: function isToday(entry) {
       if (entry.StartDate) {
-        var currentDate = moment();
-        var startDate = moment(_Convert2.default.toDateFromString(entry.StartDate));
+        const currentDate = moment();
+        let startDate = moment(_Convert2.default.toDateFromString(entry.StartDate));
         if (entry.Timeless) {
           startDate = startDate.subtract({
             minutes: startDate.utcOffset()
@@ -119,10 +119,10 @@ define('crm/Views/Activity/MyDayOffline', ['module', 'exports', 'dojo/_base/decl
     },
     isThisWeek: function isThisWeek(entry) {
       if (entry.StartDate) {
-        var now = moment();
-        var weekStartDate = now.clone().startOf('week');
-        var weekEndDate = weekStartDate.clone().endOf('week');
-        var startDate = moment(_Convert2.default.toDateFromString(entry.StartDate));
+        const now = moment();
+        const weekStartDate = now.clone().startOf('week');
+        const weekEndDate = weekStartDate.clone().endOf('week');
+        let startDate = moment(_Convert2.default.toDateFromString(entry.StartDate));
         if (entry.Timeless) {
           startDate = startDate.subtract({
             minutes: startDate.utcOffset()
@@ -136,9 +136,9 @@ define('crm/Views/Activity/MyDayOffline', ['module', 'exports', 'dojo/_base/decl
     },
     isYesterday: function isYesterDay(entry) {
       if (entry.StartDate) {
-        var now = moment();
-        var yesterday = now.clone().subtract(1, 'days');
-        var startDate = moment(_Convert2.default.toDateFromString(entry.StartDate));
+        const now = moment();
+        const yesterday = now.clone().subtract(1, 'days');
+        let startDate = moment(_Convert2.default.toDateFromString(entry.StartDate));
         if (entry.Timeless) {
           startDate = startDate.subtract({
             minutes: startDate.utcOffset()

--- a/src-out/Views/Activity/MyDayRightDrawerListMixin.js
+++ b/src-out/Views/Activity/MyDayRightDrawerListMixin.js
@@ -32,9 +32,9 @@ define('crm/Views/Activity/MyDayRightDrawerListMixin', ['module', 'exports', 'do
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityMyDayRightDrawerList');
+  const resource = (0, _I18n2.default)('activityMyDayRightDrawerList');
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.MyDayRightDrawerListMixin', [_RightDrawerBaseMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.MyDayRightDrawerListMixin', [_RightDrawerBaseMixin3.default], {
     // Localization
     kpiSectionText: resource.kpiSectionText,
     filterSectionText: resource.filterSectionText,
@@ -51,29 +51,27 @@ define('crm/Views/Activity/MyDayRightDrawerListMixin', ['module', 'exports', 'do
     },
     setDefaultFilterPreferences: function setDefaultFilterPreferences() {
       if (!App.preferences.myDayFilters) {
-        var defaults = this.getDefaultFilterPreferences();
+        const defaults = this.getDefaultFilterPreferences();
         App.preferences.myDayFilters = defaults;
         App.persistPreferences();
       }
     },
     getDefaultFilterPreferences: function getDefaultFilterPreferences() {
-      var _this = this;
-
-      var filters = this.getFilters();
-      var filterPrefs = Object.keys(filters).map(function (name) {
-        var enabled = false;
-        if (_this._currentFilterName === name) {
+      const filters = this.getFilters();
+      const filterPrefs = Object.keys(filters).map(name => {
+        let enabled = false;
+        if (this._currentFilterName === name) {
           enabled = false;
         }
         return {
-          name: name,
-          enabled: enabled
+          name,
+          enabled
         };
       });
       return filterPrefs;
     },
     setupRightDrawer: function setupRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         _lang2.default.mixin(drawer, this._createActions());
         drawer.setLayout(this.createRightDrawerLayout());
@@ -85,7 +83,7 @@ define('crm/Views/Activity/MyDayRightDrawerListMixin', ['module', 'exports', 'do
       }
     },
     refreshRightDrawer: function refreshRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.clear();
         drawer.layout = null;
@@ -109,7 +107,7 @@ define('crm/Views/Activity/MyDayRightDrawerListMixin', ['module', 'exports', 'do
       }
     },
     unloadRightDrawer: function unloadRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.setLayout([]);
         drawer.getGroupForEntry = function snapperOff() {};
@@ -122,19 +120,19 @@ define('crm/Views/Activity/MyDayRightDrawerListMixin', ['module', 'exports', 'do
     },
     _createActions: function _createActions() {
       // These actions will get mixed into the right drawer view.
-      var actions = {
+      const actions = {
         filterClicked: function onFilterClicked(params) {
-          var prefs = App.preferences && App.preferences.myDayFilters;
-          var filterPref = [];
+          const prefs = App.preferences && App.preferences.myDayFilters;
+          let filterPref = [];
           if (prefs.length) {
-            filterPref = prefs.filter(function (pref) {
+            filterPref = prefs.filter(pref => {
               return pref.name === params.filtername;
             });
           }
           if (filterPref.length > 0) {
-            var enabled = !!filterPref[0].enabled;
+            const enabled = !!filterPref[0].enabled;
             filterPref[0].enabled = !enabled;
-            prefs.forEach(function (pref) {
+            prefs.forEach(pref => {
               if (pref.name !== filterPref[0].name) {
                 pref.enabled = false;
               }
@@ -153,17 +151,17 @@ define('crm/Views/Activity/MyDayRightDrawerListMixin', ['module', 'exports', 'do
           }
         }.bind(this),
         kpiClicked: function kpiClicked(params) {
-          var metrics = this.getMetrics();
-          var results = void 0;
+          const metrics = this.getMetrics();
+          let results;
 
           if (metrics.length > 0) {
-            results = metrics.filter(function (metric) {
+            results = metrics.filter(metric => {
               return metric.title === params.title;
             });
           }
 
           if (results.length > 0) {
-            var enabled = !!results[0].enabled;
+            const enabled = !!results[0].enabled;
             results[0].enabled = !enabled;
             App.persistPreferences();
             this._hasChangedKPIPrefs = true;
@@ -191,18 +189,19 @@ define('crm/Views/Activity/MyDayRightDrawerListMixin', ['module', 'exports', 'do
       };
     },
     createRightDrawerLayout: function createRightDrawerLayout() {
-      var layout = [];
-      var metrics = this.getMetrics();
-      var filters = this.getFilters();
-      var filterSection = {
+      const layout = [];
+      const metrics = this.getMetrics();
+      const filters = this.getFilters();
+      const filterSection = {
         id: 'actions',
-        children: Object.keys(filters).map(function (filterName) {
-          var prefs = App.preferences && App.preferences.myDayFilters;
-          var filterPref = prefs.filter(function (pref) {
+        children: Object.keys(filters).map(filterName => {
+          const prefs = App.preferences && App.preferences.myDayFilters;
+          const filterPref = prefs.filter(pref => {
             return pref.name === filterName;
           });
-          var enabled = filterPref[0].enabled;
-
+          const {
+            enabled
+          } = filterPref[0];
           return {
             name: filterName,
             action: 'filterClicked',
@@ -215,13 +214,11 @@ define('crm/Views/Activity/MyDayRightDrawerListMixin', ['module', 'exports', 'do
         })
       };
       layout.push(filterSection);
-      var kpiSection = {
+      const kpiSection = {
         id: 'kpi',
-        children: metrics.filter(function (m) {
-          return m.title;
-        }).map(function (metric, i) {
+        children: metrics.filter(m => m.title).map((metric, i) => {
           return {
-            name: 'KPI' + i,
+            name: `KPI${i}`,
             action: 'kpiClicked',
             title: metric.title,
             dataProps: {

--- a/src-out/Views/Activity/MyList.js
+++ b/src-out/Views/Activity/MyList.js
@@ -48,14 +48,32 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityMyList');
-  var hashTagResource = (0, _I18n2.default)('activityMyListHashTags');
+  const resource = (0, _I18n2.default)('activityMyList');
+  const hashTagResource = (0, _I18n2.default)('activityMyListHashTags');
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.MyList', [_List2.default, _ListOfflineMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.MyList', [_List2.default, _ListOfflineMixin3.default], {
     format: _Format2.default,
     // Templates
     // Card View
-    rowTemplate: new Simplate(['<div data-action="activateEntry" data-my-activity-key="{%= $.$key %}" data-key="{%= $$.getItemActionKey($) %}" data-descriptor="{%: $$.getItemDescriptor($) %}" data-activity-type="{%: $.Activity.Type %}">\n      <div class="widget">\n        <div class="widget-header">\n          {%! $$.itemIconTemplate %}<h2 class="widget-title">{%: $$.getTitle($) %}</h2>\n          {% if($$.visibleActions.length > 0 && $$.enableActions) { %}\n            <button class="btn-actions" type="button" data-action="selectEntry" data-key="{%= $$.getItemActionKey($) %}">\n              <span class="audible">Actions</span>\n              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n                <use xlink:href="#icon-more"></use>\n              </svg>\n            </button>\n            {%! $$.listActionTemplate %}\n          {% } %}\n        </div>\n        <div class="card-content">\n          {%! $$.itemRowContentTemplate %}\n        </div>\n      </div>\n    </div>']),
+    rowTemplate: new Simplate([`<div data-action="activateEntry" data-my-activity-key="{%= $.$key %}" data-key="{%= $$.getItemActionKey($) %}" data-descriptor="{%: $$.getItemDescriptor($) %}" data-activity-type="{%: $.Activity.Type %}">
+      <div class="widget">
+        <div class="widget-header">
+          {%! $$.itemIconTemplate %}<h2 class="widget-title">{%: $$.getTitle($) %}</h2>
+          {% if($$.visibleActions.length > 0 && $$.enableActions) { %}
+            <button class="btn-actions" type="button" data-action="selectEntry" data-key="{%= $$.getItemActionKey($) %}">
+              <span class="audible">Actions</span>
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-more"></use>
+              </svg>
+            </button>
+            {%! $$.listActionTemplate %}
+          {% } %}
+        </div>
+        <div class="card-content">
+          {%! $$.itemRowContentTemplate %}
+        </div>
+      </div>
+    </div>`]),
     activityTimeTemplate: new Simplate(['{% if ($$.isTimelessToday($)) { %}', '{%: $$.allDayText %}', '{% } else { %}', '{%: $$.format.relativeDate($.Activity.StartDate, argos.Convert.toBoolean($.Activity.Timeless)) %}', // TODO: Avoid global
     '{% } %}']),
     itemTemplate: new Simplate(['<p class="listview-heading">', '<span class="p-description">{%: $$.format.picklist($$.app.picklistService, null, null, $$.getPicklistByActivityType($.Activity.Type, "Description"))($.Activity.Description) %}{% if ($.Status === "asUnconfirmed") { %} ({%: $$.format.userActivityStatus($.Status) %}) {% } %}</span>', '</p>', '<p class="micro-text">', '{%! $$.activityTimeTemplate %}', '</p>', '<p class="micro-text">{%! $$.nameTemplate %}</p>', '<p class="micro-text">', '{% if ($.Activity.PhoneNumber) { %}', '<span class="hyperlink" data-action="_callPhone" data-key="{%: $.$key %}">{%: argos.Format.phone($.Activity.PhoneNumber) %}</span>', // TODO: Avoid global
@@ -82,7 +100,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
     historyEditView: 'history_edit',
     existsRE: /^[\w]{12}$/,
     queryWhere: function queryWhere() {
-      return 'User.Id eq "' + App.context.user.$key + '" and Status ne "asDeclned" and Activity.Type ne "atLiterature"';
+      return `User.Id eq "${App.context.user.$key}" and Status ne "asDeclned" and Activity.Type ne "atLiterature"`;
     },
     queryOrderBy: 'Activity.StartDate desc',
     querySelect: ['Alarm', 'AlarmTime', 'Status', 'Activity/Description', 'Activity/StartDate', 'Activity/EndDate', 'Activity/Type', 'Activity/AccountName', 'Activity/AccountId', 'Activity/ContactId', 'Activity/ContactName', 'Activity/Leader', 'Activity/LeadName', 'Activity/LeadId', 'Activity/OpportunityId', 'Activity/TicketId', 'Activity/UserId', 'Activity/Timeless', 'Activity/PhoneNumber', 'Activity/Recurring', 'Activity/Alarm', 'Activity/ModifyDate', 'Activity/Priority'],
@@ -97,27 +115,27 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
       recurring: 'Activity.Recurring eq true',
       timeless: 'Activity.Timeless eq true',
       yesterday: function yesterday() {
-        var now = moment();
-        var yesterdayStart = now.clone().subtract(1, 'days').startOf('day');
-        var yesterdayEnd = yesterdayStart.clone().endOf('day');
+        const now = moment();
+        const yesterdayStart = now.clone().subtract(1, 'days').startOf('day');
+        const yesterdayEnd = yesterdayStart.clone().endOf('day');
 
-        var theQuery = '((Activity.Timeless eq false and Activity.StartDate between @' + _Convert2.default.toIsoStringFromDate(yesterdayStart.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(yesterdayEnd.toDate()) + '@) or (Activity.Timeless eq true and Activity.StartDate between @' + yesterdayStart.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + yesterdayEnd.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
+        const theQuery = `((Activity.Timeless eq false and Activity.StartDate between @${_Convert2.default.toIsoStringFromDate(yesterdayStart.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(yesterdayEnd.toDate())}@) or (Activity.Timeless eq true and Activity.StartDate between @${yesterdayStart.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${yesterdayEnd.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
         return theQuery;
       },
       today: function today() {
-        var now = moment();
-        var todayStart = now.clone().startOf('day');
-        var todayEnd = todayStart.clone().endOf('day');
+        const now = moment();
+        const todayStart = now.clone().startOf('day');
+        const todayEnd = todayStart.clone().endOf('day');
 
-        var theQuery = '((Activity.Timeless eq false and Activity.StartDate between @' + _Convert2.default.toIsoStringFromDate(todayStart.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(todayEnd.toDate()) + '@) or (Activity.Timeless eq true and Activity.StartDate between @' + todayStart.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + todayEnd.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
+        const theQuery = `((Activity.Timeless eq false and Activity.StartDate between @${_Convert2.default.toIsoStringFromDate(todayStart.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(todayEnd.toDate())}@) or (Activity.Timeless eq true and Activity.StartDate between @${todayStart.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${todayEnd.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
         return theQuery;
       },
       'this-week': function thisWeek() {
-        var now = moment();
-        var weekStartDate = now.clone().startOf('week');
-        var weekEndDate = weekStartDate.clone().endOf('week');
+        const now = moment();
+        const weekStartDate = now.clone().startOf('week');
+        const weekEndDate = weekStartDate.clone().endOf('week');
 
-        var theQuery = '((Activity.Timeless eq false and Activity.StartDate between @' + _Convert2.default.toIsoStringFromDate(weekStartDate.toDate()) + '@ and @' + _Convert2.default.toIsoStringFromDate(weekEndDate.toDate()) + '@) or (Activity.Timeless eq true and Activity.StartDate between @' + weekStartDate.format('YYYY-MM-DDT00:00:00[Z]') + '@ and @' + weekEndDate.format('YYYY-MM-DDT23:59:59[Z]') + '@))';
+        const theQuery = `((Activity.Timeless eq false and Activity.StartDate between @${_Convert2.default.toIsoStringFromDate(weekStartDate.toDate())}@ and @${_Convert2.default.toIsoStringFromDate(weekEndDate.toDate())}@) or (Activity.Timeless eq true and Activity.StartDate between @${weekStartDate.format('YYYY-MM-DDT00:00:00[Z]')}@ and @${weekEndDate.format('YYYY-MM-DDT23:59:59[Z]')}@))`;
         return theQuery;
       }
     },
@@ -157,18 +175,18 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
     },
     onRefreshClicked: function onRefreshClicked() {},
     _callPhone: function _callPhone(params) {
-      this.invokeActionItemBy(function (theAction) {
+      this.invokeActionItemBy(theAction => {
         return theAction.id === 'call';
       }, params.key);
     },
     defaultSearchTerm: function defaultSearchTerm() {
       if (App.enableHashTags) {
-        var hashtag = this.hashTagQueriesText['this-week'];
+        const hashtag = this.hashTagQueriesText['this-week'];
         if (typeof hashtag === 'string' && hashtag.startsWith('#')) {
           return hashtag;
         }
 
-        return '#' + hashtag;
+        return `#${hashtag}`;
       }
 
       return '';
@@ -178,7 +196,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         id: 'viewAccount',
         label: this.viewAccountActionText,
         enabled: function enabled(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           if (!entry) {
             return false;
           }
@@ -188,13 +206,13 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
           return false;
         },
         fn: function fn(theAction, selection) {
-          var viewId = 'account_detail';
-          var options = {
+          const viewId = 'account_detail';
+          const options = {
             key: selection.data.Activity.AccountId,
             descriptor: selection.data.Activity.AccountName
           };
 
-          var view = App.getView(viewId);
+          const view = App.getView(viewId);
           if (view && options) {
             view.show(options);
           }
@@ -203,7 +221,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         id: 'viewOpportunity',
         label: this.viewOpportunityActionText,
         enabled: function enabled(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           if (!entry) {
             return false;
           }
@@ -213,12 +231,12 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
           return false;
         },
         fn: function fn(theAction, selection) {
-          var viewId = 'opportunity_detail';
-          var options = {
+          const viewId = 'opportunity_detail';
+          const options = {
             key: selection.data.Activity.OpportunityId,
             descriptor: selection.data.Activity.OpportunityName
           };
-          var view = App.getView(viewId);
+          const view = App.getView(viewId);
           if (view && options) {
             view.show(options);
           }
@@ -233,7 +251,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         cls: 'fa fa-check-square fa-2x',
         label: this.completeActivityText,
         enabled: function enabled(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           if (!entry) {
             return false;
           }
@@ -241,7 +259,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
           return entry.Activity.Leader.$key === App.context.user.$key;
         },
         fn: function fn(theAction, selection) {
-          var entry = selection && selection.data && selection.data.Activity;
+          const entry = selection && selection.data && selection.data.Activity;
 
           entry.CompletedDate = new Date();
           entry.Result = 'Complete';
@@ -254,7 +272,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         cls: 'fa fa-check fa-2x',
         label: this.acceptActivityText,
         enabled: function enabled(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           if (!entry) {
             return false;
           }
@@ -262,7 +280,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
           return entry.Status === 'asUnconfirmed';
         },
         fn: function fn(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           _Environment2.default.refreshActivityLists();
           this.confirmActivityFor(entry.Activity.$key, App.context.user.$key);
         }.bindDelegate(this)
@@ -271,7 +289,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         cls: 'fa fa-ban fa-2x',
         label: this.declineActivityText,
         enabled: function enabled(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           if (!entry) {
             return false;
           }
@@ -279,7 +297,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
           return entry.Status === 'asUnconfirmed';
         },
         fn: function fn(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
 
           _Environment2.default.refreshActivityLists();
           this.declineActivityFor(entry.Activity.$key, App.context.user.$key);
@@ -289,12 +307,12 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         cls: 'phone',
         label: this.callText,
         enabled: function enabled(theAction, selection) {
-          var entry = selection && selection.data;
+          const entry = selection && selection.data;
           return entry && entry.Activity && entry.Activity.PhoneNumber;
         },
         fn: function fn(theAction, selection) {
-          var entry = selection && selection.data;
-          var phone = entry && entry.Activity && entry.Activity.PhoneNumber;
+          const entry = selection && selection.data;
+          const phone = entry && entry.Activity && entry.Activity.PhoneNumber;
           if (phone) {
             this.recordCallToHistory(function initiateCall() {
               App.initiateCall(phone);
@@ -313,8 +331,8 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
        * Grabbing a different key here, since we use entry.Activity.$key as the main data-key.
        * TODO: Make [data-key] overrideable in the base class.
        */
-      var row = $('[data-key=\'' + params.key + '\']', this.contentNode).first();
-      var key = row ? row.attr('data-my-activity-key') : false;
+      const row = $(`[data-key='${params.key}']`, this.contentNode).first();
+      const key = row ? row.attr('data-my-activity-key') : false;
 
       if (this._selectionModel && key) {
         this._selectionModel.select(key, this.entries[key], row.get(0));
@@ -325,7 +343,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(Activity.Description) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(Activity.Description) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     },
     declineActivityFor: function declineActivityFor(activityId, userId) {
       this._getUserNotifications(activityId, userId, false);
@@ -334,15 +352,15 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
       this._getUserNotifications(activityId, userId, true);
     },
     _getUserNotifications: function _getUserNotifications(activityId, userId, accept) {
-      var id = activityId;
+      let id = activityId;
       if (activityId) {
         id = activityId.substring(0, 12);
       }
 
-      var req = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService());
+      const req = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService());
       req.setResourceKind('userNotifications');
       req.setContractName('dynamic');
-      req.setQueryArg('where', 'ActivityId eq \'' + id + '\' and ToUser.Id eq \'' + userId + '\'');
+      req.setQueryArg('where', `ActivityId eq '${id}' and ToUser.Id eq '${userId}'`);
       req.setQueryArg('precedence', '0');
       req.read({
         success: function success(userNotifications) {
@@ -372,7 +390,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
        * To get the payload template:
        * http://localhost:6666/SlxClient/slxdata.ashx/slx/dynamic/-/userNotifications/$service/accept/$template?format=json
        */
-      var payload = {
+      const payload = {
         $name: operation,
         request: {
           entity: notification,
@@ -380,7 +398,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         }
       };
 
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setContractName('dynamic').setResourceKind('usernotifications').setOperationName(operation.toLowerCase());
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setContractName('dynamic').setResourceKind('usernotifications').setOperationName(operation.toLowerCase());
       request.execute(payload, {
         success: function success() {
           this.clear();
@@ -402,9 +420,9 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
     },
     hasBeenTouched: function hasBeenTouched(entry) {
       if (entry.Activity.ModifyDate) {
-        var modifiedDate = moment(_Convert2.default.toDateFromString(entry.Activity.ModifyDate));
-        var currentDate = moment().endOf('day');
-        var weekAgo = moment().subtract(1, 'weeks');
+        const modifiedDate = moment(_Convert2.default.toDateFromString(entry.Activity.ModifyDate));
+        const currentDate = moment().endOf('day');
+        const weekAgo = moment().subtract(1, 'weeks');
 
         return modifiedDate.isAfter(weekAgo) && modifiedDate.isBefore(currentDate);
       }
@@ -416,10 +434,10 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
     },
     isOverdue: function isOverdue(entry) {
       if (entry.Activity.StartDate) {
-        var startDate = _Convert2.default.toDateFromString(entry.Activity.StartDate);
-        var currentDate = new Date();
-        var seconds = Math.round((currentDate - startDate) / 1000);
-        var mins = seconds / 60;
+        const startDate = _Convert2.default.toDateFromString(entry.Activity.StartDate);
+        const currentDate = new Date();
+        const seconds = Math.round((currentDate - startDate) / 1000);
+        const mins = seconds / 60;
         if (mins >= 1) {
           return true;
         }
@@ -431,7 +449,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         return false;
       }
 
-      var start = moment(entry.Activity.StartDate);
+      const start = moment(entry.Activity.StartDate);
       return this._isTimelessToday(start);
     },
     isRecurring: function isRecurring(entry) {
@@ -442,7 +460,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
       return false;
     },
     getItemIconClass: function getItemIconClass(entry) {
-      var type = entry && entry.Activity && entry.Activity.Type;
+      const type = entry && entry.Activity && entry.Activity.Type;
       return this._getItemIconClass(type);
     },
     getItemActionKey: function getItemActionKey(entry) {
@@ -462,10 +480,10 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
       return selection.data.Activity.ContactId || selection.data.Activity.LeadId;
     },
     navigateToContactOrLead: function navigateToContactOrLead(theAction, selection) {
-      var entry = selection.data.Activity;
-      var entity = this.resolveContactOrLeadEntity(entry);
-      var viewId = void 0;
-      var options = void 0;
+      const entry = selection.data.Activity;
+      const entity = this.resolveContactOrLeadEntity(entry);
+      let viewId;
+      let options;
 
       switch (entity) {
         case 'Contact':
@@ -485,19 +503,19 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
         default:
       }
 
-      var view = App.getView(viewId);
+      const view = App.getView(viewId);
 
       if (view && options) {
         view.show(options);
       }
     },
     navigateToDetailView: function navigateToDetailView(key, descriptor, additionalOptions) {
-      var myListOptions = additionalOptions || {};
+      const myListOptions = additionalOptions || {};
       myListOptions.returnTo = this.id;
       this.inherited(arguments, [key, descriptor, myListOptions]);
     },
     resolveContactOrLeadEntity: function resolveContactOrLeadEntity(entry) {
-      var exists = this.existsRE;
+      const exists = this.existsRE;
 
       if (entry) {
         if (exists.test(entry.LeadId)) {
@@ -509,7 +527,7 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     recordCallToHistory: function recordCallToHistory(complete, entry) {
-      var tempEntry = {
+      const tempEntry = {
         $name: 'History',
         Type: 'atPhoneCall',
         ContactName: entry.Activity.ContactName,
@@ -527,21 +545,21 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
     },
 
     navigateToHistoryInsert: function navigateToHistoryInsert(type, entry, complete) {
-      var view = App.getView(this.historyEditView);
+      const view = App.getView(this.historyEditView);
       if (view) {
         _Environment2.default.refreshActivityLists();
         view.show({
           title: _ActivityTypeText2.default[type],
           template: {},
-          entry: entry,
+          entry,
           insert: true
         }, {
-          complete: complete
+          complete
         });
       }
     },
     createBriefcaseEntity: function createBriefcaseEntity(entry) {
-      var entity = {
+      const entity = {
         entityId: entry.Activity.$key,
         entityName: 'Activity',
         options: {
@@ -553,9 +571,9 @@ define('crm/Views/Activity/MyList', ['module', 'exports', 'dojo/_base/declare', 
       return entity;
     },
     activateEntry: function activateEntry(params) {
-      var entry = this.entries[params.myActivityKey];
+      const entry = this.entries[params.myActivityKey];
       if (entry) {
-        var activityParams = params;
+        const activityParams = params;
         activityParams.descriptor = this._model.getEntityDescription(entry.Activity);
         this.inherited(activateEntry, arguments, [activityParams]);
       } else {

--- a/src-out/Views/Activity/Recurring.js
+++ b/src-out/Views/Activity/Recurring.js
@@ -23,16 +23,24 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
     };
   }
 
-  var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
-    return typeof obj;
-  } : function (obj) {
-    return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-  };
+  const resource = (0, _I18n2.default)('activityRecurring'); /* Copyright 2017 Infor
+                                                              *
+                                                              * Licensed under the Apache License, Version 2.0 (the "License");
+                                                              * you may not use this file except in compliance with the License.
+                                                              * You may obtain a copy of the License at
+                                                              *
+                                                              *    http://www.apache.org/licenses/LICENSE-2.0
+                                                              *
+                                                              * Unless required by applicable law or agreed to in writing, software
+                                                              * distributed under the License is distributed on an "AS IS" BASIS,
+                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                              * See the License for the specific language governing permissions and
+                                                              * limitations under the License.
+                                                              */
 
-  var resource = (0, _I18n2.default)('activityRecurring');
-  var dtFormatResource = (0, _I18n2.default)('activityEditDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('activityEditDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.Recurring', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.Recurring', [_Edit2.default], {
     // Localization
     startingText: resource.startingText,
     endingText: resource.endingText,
@@ -88,10 +96,10 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
     },
     resetUI: function resetUI() {
       // hide or reveal and set fields according to panel/RecurPeriod
-      var rp = parseInt(this.fields.RecurPeriod.getValue(), 10);
-      var startDate = this.fields.StartDate.getValue();
-      var interval = this.fields.RecurPeriodSpec.getValue() % 65536;
-      var showthese = 'Interval,AfterCompletion,';
+      const rp = parseInt(this.fields.RecurPeriod.getValue(), 10);
+      const startDate = this.fields.StartDate.getValue();
+      const interval = this.fields.RecurPeriodSpec.getValue() % 65536;
+      let showthese = 'Interval,AfterCompletion,';
 
       if (!_Recurrence2.default.isAfterCompletion(rp)) {
         showthese += 'RecurIterations,EndDate,';
@@ -139,7 +147,7 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
           showthese = '';
       }
 
-      for (var i in this.fields) {
+      for (const i in this.fields) {
         if (showthese.indexOf(i) >= 0) {
           this.fields[i].show();
         } else {
@@ -163,7 +171,7 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       this.fields.Scale.setValue(_Recurrence2.default.getPanel(parseInt(this.fields.RecurPeriod.getValue(), 10), true));
     },
     onAfterCompletionChange: function onAfterCompletionChange(value) {
-      var rp = parseInt(this.fields.RecurPeriod.getValue(), 10);
+      let rp = parseInt(this.fields.RecurPeriod.getValue(), 10);
 
       if (value) {
         rp += '0258'.indexOf(rp) >= 0 ? 1 : 2;
@@ -185,10 +193,10 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       this.resetUI();
     },
     onIntervalChange: function onIntervalChange(value, field) {
-      var currentSpec = parseInt(this.fields.RecurPeriodSpec.getValue(), 10);
-      var interval = currentSpec % 65536;
+      const currentSpec = parseInt(this.fields.RecurPeriodSpec.getValue(), 10);
+      const interval = currentSpec % 65536;
 
-      var theValue = parseInt(value, 10);
+      const theValue = parseInt(value, 10);
       if (theValue && theValue > 0) {
         this.fields.RecurPeriodSpec.setValue(currentSpec - interval + parseInt(theValue, 10));
         this.fields.EndDate.setValue(_Recurrence2.default.calcEndDate(this.fields.StartDate.getValue(), this.getRecurrence()).toDate());
@@ -200,10 +208,10 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       this.summarize();
     },
     onRecurIterationsChange: function onRecurIterationsChange(value) {
-      var theValue = parseInt(value, 10);
+      const theValue = parseInt(value, 10);
       if (theValue && theValue > 0) {
         this.entry.RecurIterations = value;
-        var newEndDate = _Recurrence2.default.calcEndDate(this.fields.StartDate.getValue(), this.getRecurrence()).toDate();
+        const newEndDate = _Recurrence2.default.calcEndDate(this.fields.StartDate.getValue(), this.getRecurrence()).toDate();
 
         if (newEndDate !== this.fields.EndDate.getValue()) {
           this.fields.EndDate.setValue(newEndDate);
@@ -217,7 +225,7 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
     },
     onEndDateChange: function onEndDateChange(value) {
       if (value >= this.fields.StartDate.getValue()) {
-        var iterations = _Recurrence2.default.calcRecurIterations(value, this.fields.StartDate.getValue(), this.fields.Interval.getValue(), this.fields.RecurPeriod.getValue());
+        const iterations = _Recurrence2.default.calcRecurIterations(value, this.fields.StartDate.getValue(), this.fields.Interval.getValue(), this.fields.RecurPeriod.getValue());
 
         if (iterations !== parseInt(this.fields.RecurIterations.getValue(), 10)) {
           this.fields.RecurIterations.setValue(iterations);
@@ -230,8 +238,8 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       this.summarize();
     },
     onDayChange: function onDayChange(value, field) {
-      var startDate = this.fields.StartDate.getValue();
-      var maxValue = moment(startDate).daysInMonth();
+      const startDate = this.fields.StartDate.getValue();
+      const maxValue = moment(startDate).daysInMonth();
 
       if (value > 0 && value <= maxValue) {
         startDate.setDate(value);
@@ -249,17 +257,17 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
     },
     onStartDateChange: function onStartDateChange(value, field) {
       // when field alters StartDate, other fields need to be adjusted
-      var weekdays = _Recurrence2.default.getWeekdays(parseInt(this.fields.RecurPeriodSpec.getValue(), 10));
-      var panel = parseInt(this.fields.RecurPeriod.getValue(), 10);
-      var theValue = parseInt(value.key || value, 10);
-      var startDate = this.fields.StartDate.getValue();
-      var weekday = startDate.getDay();
-      var ordWeek = parseInt((startDate.getDate() - 1) / 7, 10) + 1;
+      const weekdays = _Recurrence2.default.getWeekdays(parseInt(this.fields.RecurPeriodSpec.getValue(), 10));
+      const panel = parseInt(this.fields.RecurPeriod.getValue(), 10);
+      const theValue = parseInt(value.key || value, 10);
+      let startDate = this.fields.StartDate.getValue();
+      let weekday = startDate.getDay();
+      let ordWeek = parseInt((startDate.getDate() - 1) / 7, 10) + 1;
 
       switch (field.name) {
         case 'Weekdays':
           // only change StartDate if original weekday not included
-          for (var wd = 0; wd < 7; wd++) {
+          for (let wd = 0; wd < 7; wd++) {
             if (weekdays[wd] && !weekdays[weekday]) {
               weekday = wd;
             }
@@ -295,11 +303,11 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       this.fields.Day.setValue(startDate.getDate());
       this.fields.OrdWeekday.setValue(startDate.getDay());
 
-      var weekData = this.createOrdData(this.formatSingleWeekday(startDate.getDay()));
+      const weekData = this.createOrdData(this.formatSingleWeekday(startDate.getDay()));
       this.fields.OrdWeek.data = weekData;
       this.summarize();
-      var key = this.fields.OrdWeek.getValue();
-      if ((typeof key === 'undefined' ? 'undefined' : _typeof(key)) === 'object') {
+      let key = this.fields.OrdWeek.getValue();
+      if (typeof key === 'object') {
         key = key.$key;
         this.fields.OrdWeek.setValue(weekData.$resources[key]);
       } else if (!isNaN(parseInt(key, 10))) {
@@ -307,10 +315,10 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       }
     },
     onScaleChange: function onScaleChange(value) {
-      var startDate = this.fields.StartDate.getValue();
-      var afterCompletion = this.fields.AfterCompletion.getValue() ? 1 : 0;
-      var interval = parseInt(this.fields.Interval.getValue(), 10);
-      var recurPeriod = parseInt(this.fields.RecurPeriod.getValue(), 10);
+      const startDate = this.fields.StartDate.getValue();
+      const afterCompletion = this.fields.AfterCompletion.getValue() ? 1 : 0;
+      const interval = parseInt(this.fields.Interval.getValue(), 10);
+      let recurPeriod = parseInt(this.fields.RecurPeriod.getValue(), 10);
 
       switch (parseInt(value.key, 10)) {
         case 0:
@@ -356,10 +364,10 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
     },
 
     formatWeekdays: function formatWeekdays(selections) {
-      var values = [];
-      var weekdays = [0, 0, 0, 0, 0, 0, 0];
+      const values = [];
+      const weekdays = [0, 0, 0, 0, 0, 0, 0];
 
-      for (var key in selections) {
+      for (const key in selections) {
         if (selections[key]) {
           values.push(this.weekDaysText[key]);
           weekdays[key] = 1;
@@ -391,10 +399,10 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       return _Recurrence2.default.ordText[parseInt(selection, 10)];
     },
     preselectWeekdays: function preselectWeekdays() {
-      var previousSelections = [];
-      var weekdays = _Recurrence2.default.getWeekdays(this.fields.RecurPeriodSpec.getValue());
+      const previousSelections = [];
+      const weekdays = _Recurrence2.default.getWeekdays(this.fields.RecurPeriodSpec.getValue());
 
-      for (var i = 0; i < weekdays.length; i++) {
+      for (let i = 0; i < weekdays.length; i++) {
         if (weekdays[i]) {
           previousSelections.push(i);
         }
@@ -402,9 +410,9 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       return previousSelections;
     },
     createScaleData: function createScaleData() {
-      var list = [];
+      const list = [];
 
-      for (var opt in this.frequencyOptionsText) {
+      for (const opt in this.frequencyOptionsText) {
         if (this.frequencyOptionsText.hasOwnProperty(opt)) {
           list.push({
             $key: opt,
@@ -418,9 +426,9 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       };
     },
     createWeekdaysData: function createWeekdaysData() {
-      var list = [];
+      const list = [];
 
-      this.weekDaysText.forEach(function (name, idx) {
+      this.weekDaysText.forEach((name, idx) => {
         list.push({
           $key: idx,
           $descriptor: name
@@ -432,8 +440,8 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       };
     },
     createMonthsData: function createMonthsData() {
-      var list = [];
-      this.monthsText.forEach(function (name, idx) {
+      const list = [];
+      this.monthsText.forEach((name, idx) => {
         list.push({
           $key: idx,
           $descriptor: name
@@ -443,12 +451,10 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
         $resources: list
       };
     },
-    createOrdData: function createOrdData() {
-      var day = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+    createOrdData: function createOrdData(day = '') {
+      const list = [];
 
-      var list = [];
-
-      for (var ord in _Recurrence2.default.ordText) {
+      for (const ord in _Recurrence2.default.ordText) {
         if (_Recurrence2.default.ordText.hasOwnProperty(ord)) {
           list.push({
             $key: ord,
@@ -469,7 +475,7 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       this.entry.StartDate = argos.Convert.toDateFromString(values.StartDate); // TODO: Avoid global
       this.entry.EndDate = _Recurrence2.default.calcEndDate(values.StartDate, values).toDate();
       this.entry.Recurring = typeof values.Recurring === 'string' ? /^true$/i.test(values.Recurring) : values.Recurring;
-      var ord = _Recurrence2.default.getOrd(this.entry);
+      const ord = _Recurrence2.default.getOrd(this.entry);
       this.entry.Interval = values.RecurPeriodSpec % 65536;
       this.entry.AfterCompletion = _Recurrence2.default.isAfterCompletion(values.RecurPeriod);
       this.entry.Day = this.entry.StartDate.getDate();
@@ -479,9 +485,9 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       this.entry.OrdMonth = ord.month;
 
       // Even hidden and falsy fields need their values set (not from parent)
-      for (var name in this.fields) {
+      for (const name in this.fields) {
         if (this.fields.hasOwnProperty(name)) {
-          var field = this.fields[name];
+          const field = this.fields[name];
           // 0 (Daily panel) or false (AfterCompletion) are legitimate values!
           if (typeof this.entry[name] !== 'undefined') {
             field.setValue(this.entry[name]);
@@ -492,7 +498,7 @@ define('crm/Views/Activity/Recurring', ['module', 'exports', 'dojo/_base/declare
       this.resetUI();
     },
     getValues: function getValues() {
-      var o = this.getRecurrence();
+      const o = this.getRecurrence();
 
       o.Recurring = o.RecurPeriod >= 0;
       o.EndDate = _Recurrence2.default.calcEndDate(o.StartDate, o).toDate();

--- a/src-out/Views/Activity/TypesList.js
+++ b/src-out/Views/Activity/TypesList.js
@@ -36,24 +36,28 @@ define('crm/Views/Activity/TypesList', ['module', 'exports', 'dojo/_base/declare
     };
   }
 
-  var resource = (0, _I18n2.default)('activityTypesList'); /* Copyright 2017 Infor
-                                                            *
-                                                            * Licensed under the Apache License, Version 2.0 (the "License");
-                                                            * you may not use this file except in compliance with the License.
-                                                            * You may obtain a copy of the License at
-                                                            *
-                                                            *    http://www.apache.org/licenses/LICENSE-2.0
-                                                            *
-                                                            * Unless required by applicable law or agreed to in writing, software
-                                                            * distributed under the License is distributed on an "AS IS" BASIS,
-                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                            * See the License for the specific language governing permissions and
-                                                            * limitations under the License.
-                                                            */
+  const resource = (0, _I18n2.default)('activityTypesList'); /* Copyright 2017 Infor
+                                                              *
+                                                              * Licensed under the Apache License, Version 2.0 (the "License");
+                                                              * you may not use this file except in compliance with the License.
+                                                              * You may obtain a copy of the License at
+                                                              *
+                                                              *    http://www.apache.org/licenses/LICENSE-2.0
+                                                              *
+                                                              * Unless required by applicable law or agreed to in writing, software
+                                                              * distributed under the License is distributed on an "AS IS" BASIS,
+                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                              * See the License for the specific language governing permissions and
+                                                              * limitations under the License.
+                                                              */
 
-  var __class = (0, _declare2.default)('crm.Views.Activity.TypesList', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Activity.TypesList', [_List2.default], {
     // Templates
-    liRowTemplate: new Simplate(['<li data-action="activateEntry" data-key="{%= $.$key %}" data-descriptor="{%: $.$descriptor %}">', '{% if ($.icon) { %}', '<button type="button" class="btn-icon hide-focus list-item-selector visible">\n      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.icon || "" %}"></use>\n      </svg>\n    </button>', '{% } else if ($.iconClass) { %}', '<div class="{%= $.iconClass %}"></div>', '{% } %}', '{%! $$.itemTemplate %}', '</li>']),
+    liRowTemplate: new Simplate(['<li data-action="activateEntry" data-key="{%= $.$key %}" data-descriptor="{%: $.$descriptor %}">', '{% if ($.icon) { %}', `<button type="button" class="btn-icon hide-focus list-item-selector visible">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.icon || "" %}"></use>
+      </svg>
+    </button>`, '{% } else if ($.iconClass) { %}', '<div class="{%= $.iconClass %}"></div>', '{% } %}', '{%! $$.itemTemplate %}', '</li>']),
     itemTemplate: new Simplate(['<h4 class="', '{% if ($.icon) { %}', 'list-item-content', '{% } %} ">', '{%: $.$descriptor %}</h4>']),
     isCardView: false,
     // Localization
@@ -82,18 +86,18 @@ define('crm/Views/Activity/TypesList', ['module', 'exports', 'dojo/_base/declare
     activityTypeIcon: activityTypeIcons.default,
     activateEntry: function activateEntry(params) {
       if (params.key) {
-        var view = App.getView(params.key === 'event' ? this.eventEditView : this.editView);
+        let view = App.getView(params.key === 'event' ? this.eventEditView : this.editView);
 
         if (this.options.unscheduled === true) {
           view = App.getView(this.unscheduledView);
         }
 
         if (view) {
-          var source = this.options && this.options.source;
+          const source = this.options && this.options.source;
           view.show({
             insert: true,
             entry: this.options && this.options.entry || null,
-            source: source,
+            source,
             activityType: params.key,
             title: this.activityTypeText[params.key],
             returnTo: this.options && this.options.returnTo,
@@ -106,7 +110,7 @@ define('crm/Views/Activity/TypesList', ['module', 'exports', 'dojo/_base/declare
       }
     },
     refreshRequiredFor: function refreshRequiredFor(options) {
-      var toReturn = void 0;
+      let toReturn;
       if (this.options) {
         toReturn = options;
       } else {
@@ -118,10 +122,10 @@ define('crm/Views/Activity/TypesList', ['module', 'exports', 'dojo/_base/declare
       return false;
     },
     createStore: function createStore() {
-      var list = [];
-      var eventViews = ['calendar_view', 'calendar_monthlist', 'calendar_weeklist', 'calendar_daylist', 'calendar_yearlist'];
+      const list = [];
+      const eventViews = ['calendar_view', 'calendar_monthlist', 'calendar_weeklist', 'calendar_daylist', 'calendar_yearlist'];
 
-      for (var i = 0; i < this.activityTypeOrder.length; i++) {
+      for (let i = 0; i < this.activityTypeOrder.length; i++) {
         list.push({
           $key: this.activityTypeOrder[i],
           $descriptor: this.activityTypeText[this.activityTypeOrder[i]],
@@ -134,7 +138,7 @@ define('crm/Views/Activity/TypesList', ['module', 'exports', 'dojo/_base/declare
         list.pop(); // remove event for non event views
       }
 
-      var store = new _Memory2.default({
+      const store = new _Memory2.default({
         data: list
       });
       return store;

--- a/src-out/Views/ActivityAttendee/Detail.js
+++ b/src-out/Views/ActivityAttendee/Detail.js
@@ -32,9 +32,9 @@ define('crm/Views/ActivityAttendee/Detail', ['module', 'exports', 'dojo/_base/de
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityAttendeeDetail');
+  const resource = (0, _I18n2.default)('activityAttendeeDetail');
 
-  var __class = (0, _declare2.default)('crm.Views.ActivityAttendee.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.ActivityAttendee.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     entityText: resource.entityText,

--- a/src-out/Views/ActivityAttendee/Edit.js
+++ b/src-out/Views/ActivityAttendee/Edit.js
@@ -32,9 +32,9 @@ define('crm/Views/ActivityAttendee/Edit', ['module', 'exports', 'dojo/_base/decl
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityAttendeeEdit');
+  const resource = (0, _I18n2.default)('activityAttendeeEdit');
 
-  var __class = (0, _declare2.default)('crm.Views.ActivityAttendee.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.ActivityAttendee.Edit', [_Edit2.default], {
     // Localization
     nameText: resource.nameText,
     accountText: resource.accountText,
@@ -57,11 +57,7 @@ define('crm/Views/ActivityAttendee/Edit', ['module', 'exports', 'dojo/_base/decl
         this.refreshRequired = false; // Indicate to _EditBase we don't want to refresh or set any loading flags
         this.inherited(beforeTransitionTo, arguments);
         this.inserting = true;
-        var _options = this.options,
-            activityEntity = _options.activityEntity,
-            entity = _options.entity,
-            entityType = _options.entityType;
-
+        const { activityEntity, entity, entityType } = this.options;
 
         this.fields.Name.setValue(entity.$descriptor);
         this.fields.AccountName.setValue(entity.Company || entity.AccountName);

--- a/src-out/Views/ActivityAttendee/List.js
+++ b/src-out/Views/ActivityAttendee/List.js
@@ -40,9 +40,9 @@ define('crm/Views/ActivityAttendee/List', ['module', 'exports', 'dojo/_base/decl
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityAttendeeList');
+  const resource = (0, _I18n2.default)('activityAttendeeList');
 
-  var __class = (0, _declare2.default)('crm.Views.ActivityAttendee.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.ActivityAttendee.List', [_List2.default], {
     // Localization
     titleText: resource.titleText,
     callPhoneActionText: resource.callPhoneActionText,
@@ -64,7 +64,7 @@ define('crm/Views/ActivityAttendee/List', ['module', 'exports', 'dojo/_base/decl
     modelName: _Names2.default.ACTIVITYATTENDEE,
 
     callPhone: function callPhone(params) {
-      this.invokeActionItemBy(function (a) {
+      this.invokeActionItemBy(a => {
         return a.id === 'callPhone';
       }, params.key);
     },
@@ -72,7 +72,7 @@ define('crm/Views/ActivityAttendee/List', ['module', 'exports', 'dojo/_base/decl
       return _Format2.default.phone(phone);
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(Name) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(Name) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     },
     getTitle: function getTitle(entry) {
       if (!entry) {
@@ -82,20 +82,18 @@ define('crm/Views/ActivityAttendee/List', ['module', 'exports', 'dojo/_base/decl
       return this._model && this._model.getEntityDescription(entry) || entry.Name;
     },
     deleteAttendee: function deleteAttendee(_, selection) {
-      var _this = this;
-
       App.modal.createSimpleDialog({
         title: 'alert',
         content: this.confirmDeleteText,
-        getContent: function getContent() {}
-      }).then(function () {
-        var entry = selection && selection.data;
-        var model = _this.getModel();
-        model.deleteEntry(entry.$key).then(function () {
+        getContent: () => {}
+      }).then(() => {
+        const entry = selection && selection.data;
+        const model = this.getModel();
+        model.deleteEntry(entry.$key).then(() => {
           _connect2.default.publish('/app/refresh', [{
-            resourceKind: _this.resourceKind
+            resourceKind: this.resourceKind
           }]);
-          _this.forceRefresh();
+          this.forceRefresh();
         });
       });
     },

--- a/src-out/Views/ActivityAttendee/TypesList.js
+++ b/src-out/Views/ActivityAttendee/TypesList.js
@@ -32,11 +32,15 @@ define('crm/Views/ActivityAttendee/TypesList', ['module', 'exports', 'dojo/_base
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('activityAttendeeTypesList');
+  const resource = (0, _I18n2.default)('activityAttendeeTypesList');
 
-  var __class = (0, _declare2.default)('crm.Views.ActivityAttendee.TypesList', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.ActivityAttendee.TypesList', [_List2.default], {
     // Templates
-    liRowTemplate: new Simplate(['<li data-action="activateEntry" data-key="{%= $.$key %}" data-descriptor="{%: $.$descriptor %}">', '{% if ($.icon) { %}', '<button type="button" class="btn-icon hide-focus list-item-selector visible">\n      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.icon || "" %}"></use>\n      </svg>\n    </button>', '{% } else if ($.iconClass) { %}', '<div class="{%= $.iconClass %}"></div>', '{% } %}', '{%! $$.itemTemplate %}', '</li>']),
+    liRowTemplate: new Simplate(['<li data-action="activateEntry" data-key="{%= $.$key %}" data-descriptor="{%: $.$descriptor %}">', '{% if ($.icon) { %}', `<button type="button" class="btn-icon hide-focus list-item-selector visible">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%: $.icon || "" %}"></use>
+      </svg>
+    </button>`, '{% } else if ($.iconClass) { %}', '<div class="{%= $.iconClass %}"></div>', '{% } %}', '{%! $$.itemTemplate %}', '</li>']),
     itemTemplate: new Simplate(['<h4 class="', '{% if ($.icon) { %}', 'list-item-content', '{% } %} ">', '{%: $.$descriptor %}</h4>']),
     isCardView: false,
     // Localization
@@ -63,7 +67,7 @@ define('crm/Views/ActivityAttendee/TypesList', ['module', 'exports', 'dojo/_base
     activateEntry: function activateEntry(params) {
       this.selectedAttendeeType = params.key;
       if (this.selectedAttendeeType) {
-        var view = App.getView(this.attendeeTypeLookup[this.selectedAttendeeType]);
+        const view = App.getView(this.attendeeTypeLookup[this.selectedAttendeeType]);
         if (view) {
           view.show({
             title: this.attendeeTypeText[this.selectedAttendeeType],
@@ -97,14 +101,14 @@ define('crm/Views/ActivityAttendee/TypesList', ['module', 'exports', 'dojo/_base
       }
     },
     onSelectContactOrLead: function onSelectContactOrLead() {
-      var view = App.getPrimaryActiveView();
-      var selectionModel = view.get('selectionModel');
+      const view = App.getPrimaryActiveView();
+      const selectionModel = view.get('selectionModel');
 
       if (view && selectionModel) {
-        var selections = selectionModel.getSelections();
+        const selections = selectionModel.getSelections();
 
-        var entry = void 0;
-        for (var selectionKey in selections) {
+        let entry;
+        for (const selectionKey in selections) {
           if (selections.hasOwnProperty(selectionKey)) {
             entry = selections[selectionKey].data;
             break;
@@ -115,7 +119,7 @@ define('crm/Views/ActivityAttendee/TypesList', ['module', 'exports', 'dojo/_base
       }
     },
     navigateToEditView: function navigateToEditView(entry) {
-      var view = App.getView(this.editView);
+      const view = App.getView(this.editView);
       view.show({
         insert: true,
         entityType: this.selectedAttendeeType,
@@ -126,7 +130,7 @@ define('crm/Views/ActivityAttendee/TypesList', ['module', 'exports', 'dojo/_base
       });
     },
     refreshRequiredFor: function refreshRequiredFor(options) {
-      var toReturn = void 0;
+      let toReturn;
       if (this.options) {
         toReturn = options;
       } else {
@@ -138,9 +142,9 @@ define('crm/Views/ActivityAttendee/TypesList', ['module', 'exports', 'dojo/_base
       return false;
     },
     createStore: function createStore() {
-      var list = [];
+      const list = [];
 
-      for (var i = 0; i < this.attendeeTypeOrder.length; i++) {
+      for (let i = 0; i < this.attendeeTypeOrder.length; i++) {
         list.push({
           $key: this.attendeeTypeOrder[i],
           $descriptor: this.attendeeTypeText[this.attendeeTypeOrder[i]],
@@ -148,7 +152,7 @@ define('crm/Views/ActivityAttendee/TypesList', ['module', 'exports', 'dojo/_base
         });
       }
 
-      var store = new _Memory2.default({
+      const store = new _Memory2.default({
         data: list
       });
       return store;

--- a/src-out/Views/AddAccountContact.js
+++ b/src-out/Views/AddAccountContact.js
@@ -27,22 +27,22 @@ define('crm/Views/AddAccountContact', ['module', 'exports', 'dojo/_base/declare'
     };
   }
 
-  var resource = (0, _I18n2.default)('addAccountContact'); /* Copyright 2017 Infor
-                                                            *
-                                                            * Licensed under the Apache License, Version 2.0 (the "License");
-                                                            * you may not use this file except in compliance with the License.
-                                                            * You may obtain a copy of the License at
-                                                            *
-                                                            *    http://www.apache.org/licenses/LICENSE-2.0
-                                                            *
-                                                            * Unless required by applicable law or agreed to in writing, software
-                                                            * distributed under the License is distributed on an "AS IS" BASIS,
-                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                            * See the License for the specific language governing permissions and
-                                                            * limitations under the License.
-                                                            */
+  const resource = (0, _I18n2.default)('addAccountContact'); /* Copyright 2017 Infor
+                                                              *
+                                                              * Licensed under the Apache License, Version 2.0 (the "License");
+                                                              * you may not use this file except in compliance with the License.
+                                                              * You may obtain a copy of the License at
+                                                              *
+                                                              *    http://www.apache.org/licenses/LICENSE-2.0
+                                                              *
+                                                              * Unless required by applicable law or agreed to in writing, software
+                                                              * distributed under the License is distributed on an "AS IS" BASIS,
+                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                              * See the License for the specific language governing permissions and
+                                                              * limitations under the License.
+                                                              */
 
-  var __class = (0, _declare2.default)('crm.Views.AddAccountContact', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.AddAccountContact', [_Edit2.default], {
     // Localization
     accountNameText: resource.accountNameText,
     accountStatusTitleText: resource.accountStatusTitleText,
@@ -86,7 +86,7 @@ define('crm/Views/AddAccountContact', ['module', 'exports', 'dojo/_base/declare'
       this.connect(this.fields['Contacts.$resources[0].Address'], 'onChange', this.onContactAddressChange);
     },
     getValues: function getValues() {
-      var values = this.inherited(getValues, arguments);
+      const values = this.inherited(getValues, arguments);
 
       _Utility2.default.setValue(values, 'Contacts.$resources[0].$name', 'Contact');
       _Utility2.default.setValue(values, 'Contacts.$resources[0].AccountName', values.AccountName);
@@ -94,14 +94,14 @@ define('crm/Views/AddAccountContact', ['module', 'exports', 'dojo/_base/declare'
       return values;
     },
     formatDependentPicklist: function formatDependentPicklist(dependentValue, fmt) {
-      var dependValue = dependentValue;
+      let dependValue = dependentValue;
       if (!_lang2.default.isArray(dependValue)) {
         dependValue = [dependValue];
       }
       return _string2.default.substitute(fmt, [dependValue]);
     },
     onInsertCompleted: function onInsertCompleted(entry) {
-      var view = App.getView('account_detail');
+      const view = App.getView('account_detail');
       if (view) {
         view.show({
           descriptor: entry.$descriptor,
@@ -114,8 +114,8 @@ define('crm/Views/AddAccountContact', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     onContactAddressChange: function onContactAddressChange(value) {
-      var address = void 0;
-      var address1 = void 0;
+      let address;
+      let address1;
       // Copy contact address down into the account address if the account address is not set
       if (this.fields.Address) {
         address = this.fields.Address.getValue();

--- a/src-out/Views/Address/Edit.js
+++ b/src-out/Views/Address/Edit.js
@@ -36,9 +36,9 @@ define('crm/Views/Address/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('addressEdit');
+  const resource = (0, _I18n2.default)('addressEdit');
 
-  var __class = (0, _declare2.default)('crm.Views.Address.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Address.Edit', [_Edit2.default], {
     // Localization
     address1Text: resource.address1Text,
     address2Text: resource.address2Text,
@@ -77,7 +77,7 @@ define('crm/Views/Address/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       this.connect(this.fields.Country, 'onChange', this.onCountryChange);
     },
     onCountryChange: function onCountryChange(value) {
-      var locale = _Format2.default.countryCultures[value] || 'en-US';
+      const locale = _Format2.default.countryCultures[value] || 'en-US';
       this.hideFieldsForLocale(locale);
     },
     /*
@@ -86,13 +86,13 @@ define('crm/Views/Address/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
      * @param locale Localization string (Ex: 'en-US' or 'de-DE')
      */
     hideFieldsForLocale: function hideFieldsForLocale(locale) {
-      var fieldsToHide = this.localeFieldHidden[locale];
+      const fieldsToHide = this.localeFieldHidden[locale];
       if (!fieldsToHide) {
         return;
       }
 
-      for (var i = 0; i < fieldsToHide.length; i++) {
-        var field = this.fields[fieldsToHide[i]];
+      for (let i = 0; i < fieldsToHide.length; i++) {
+        const field = this.fields[fieldsToHide[i]];
         if (field) {
           field.hide();
         }

--- a/src-out/Views/Address/List.js
+++ b/src-out/Views/Address/List.js
@@ -32,9 +32,9 @@ define('crm/Views/Address/List', ['module', 'exports', 'dojo/_base/declare', '..
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('addressList');
+  const resource = (0, _I18n2.default)('addressList');
 
-  var __class = (0, _declare2.default)('crm.Views.Address.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Address.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.$descriptor %}</p>', '<p class="micro-text">{%= $$.format.address($, true) %}</p>']),
 
@@ -54,8 +54,8 @@ define('crm/Views/Address/List', ['module', 'exports', 'dojo/_base/declare', '..
     isCardView: false,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Description) like "' + q + '%" or upper(City) like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Description) like "${q}%" or upper(City) like "${q}%")`;
     },
     // Disable Add/Insert on toolbar
     createToolLayout: function createToolLayout() {
@@ -64,8 +64,8 @@ define('crm/Views/Address/List', ['module', 'exports', 'dojo/_base/declare', '..
       });
     },
     selectEntry: function selectEntry(params) {
-      var row = $(params.$source).closest('[data-key]')[0];
-      var key = row ? $(row).attr('data-key') : false;
+      const row = $(params.$source).closest('[data-key]')[0];
+      const key = row ? $(row).attr('data-key') : false;
 
       if (this._selectionModel && key) {
         App.showMapForAddress(_Format2.default.address(this.entries[key], true, ' '));

--- a/src-out/Views/AreaCategoryIssue/AreaLookup.js
+++ b/src-out/Views/AreaCategoryIssue/AreaLookup.js
@@ -19,22 +19,22 @@ define('crm/Views/AreaCategoryIssue/AreaLookup', ['module', 'exports', 'dojo/_ba
     };
   }
 
-  var resource = (0, _I18n2.default)('areaCategoryIssue_AreaLookup'); /* Copyright 2021 Infor
-                                                                       *
-                                                                       * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                       * you may not use this file except in compliance with the License.
-                                                                       * You may obtain a copy of the License at
-                                                                       *
-                                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                       *
-                                                                       * Unless required by applicable law or agreed to in writing, software
-                                                                       * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                       * See the License for the specific language governing permissions and
-                                                                       * limitations under the License.
-                                                                       */
+  const resource = (0, _I18n2.default)('areaCategoryIssue_AreaLookup'); /* Copyright 2021 Infor
+                                                                         *
+                                                                         * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                         * you may not use this file except in compliance with the License.
+                                                                         * You may obtain a copy of the License at
+                                                                         *
+                                                                         *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                         *
+                                                                         * Unless required by applicable law or agreed to in writing, software
+                                                                         * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                         * See the License for the specific language governing permissions and
+                                                                         * limitations under the License.
+                                                                         */
 
-  var __class = (0, _declare2.default)('crm.Views.AreaCategoryIssue.AreaLookup', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.AreaCategoryIssue.AreaLookup', [_List2.default], {
     format: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.$descriptor %}</p>']),

--- a/src-out/Views/AreaCategoryIssue/CategoryLookup.js
+++ b/src-out/Views/AreaCategoryIssue/CategoryLookup.js
@@ -19,22 +19,22 @@ define('crm/Views/AreaCategoryIssue/CategoryLookup', ['module', 'exports', 'dojo
     };
   }
 
-  var resource = (0, _I18n2.default)('areaCategoryIssue_CategoryLookup'); /* Copyright 2021 Infor
-                                                                           *
-                                                                           * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                           * you may not use this file except in compliance with the License.
-                                                                           * You may obtain a copy of the License at
-                                                                           *
-                                                                           *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                           *
-                                                                           * Unless required by applicable law or agreed to in writing, software
-                                                                           * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                           * See the License for the specific language governing permissions and
-                                                                           * limitations under the License.
-                                                                           */
+  const resource = (0, _I18n2.default)('areaCategoryIssue_CategoryLookup'); /* Copyright 2021 Infor
+                                                                             *
+                                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                             * you may not use this file except in compliance with the License.
+                                                                             * You may obtain a copy of the License at
+                                                                             *
+                                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                             *
+                                                                             * Unless required by applicable law or agreed to in writing, software
+                                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                             * See the License for the specific language governing permissions and
+                                                                             * limitations under the License.
+                                                                             */
 
-  var __class = (0, _declare2.default)('crm.Views.AreaCategoryIssue.CategoryLookup', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.AreaCategoryIssue.CategoryLookup', [_List2.default], {
     format: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.$descriptor %}</p>']),

--- a/src-out/Views/AreaCategoryIssue/IssueLookup.js
+++ b/src-out/Views/AreaCategoryIssue/IssueLookup.js
@@ -19,22 +19,22 @@ define('crm/Views/AreaCategoryIssue/IssueLookup', ['module', 'exports', 'dojo/_b
     };
   }
 
-  var resource = (0, _I18n2.default)('areaCategoryIssue_IssueLookup'); /* Copyright 2021 Infor
-                                                                        *
-                                                                        * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                        * you may not use this file except in compliance with the License.
-                                                                        * You may obtain a copy of the License at
-                                                                        *
-                                                                        *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                        *
-                                                                        * Unless required by applicable law or agreed to in writing, software
-                                                                        * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                        * See the License for the specific language governing permissions and
-                                                                        * limitations under the License.
-                                                                        */
+  const resource = (0, _I18n2.default)('areaCategoryIssue_IssueLookup'); /* Copyright 2021 Infor
+                                                                          *
+                                                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                          * you may not use this file except in compliance with the License.
+                                                                          * You may obtain a copy of the License at
+                                                                          *
+                                                                          *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                          *
+                                                                          * Unless required by applicable law or agreed to in writing, software
+                                                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                          * See the License for the specific language governing permissions and
+                                                                          * limitations under the License.
+                                                                          */
 
-  var __class = (0, _declare2.default)('crm.Views.AreaCategoryIssue.IssueLookup', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.AreaCategoryIssue.IssueLookup', [_List2.default], {
     format: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.$descriptor %}</p>']),

--- a/src-out/Views/AreaCategoryIssueLookup.js
+++ b/src-out/Views/AreaCategoryIssueLookup.js
@@ -32,9 +32,9 @@ define('crm/Views/AreaCategoryIssueLookup', ['module', 'exports', 'dojo/_base/de
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('areaCategoryIssueLookup');
+  const resource = (0, _I18n2.default)('areaCategoryIssueLookup');
 
-  var __class = (0, _declare2.default)('crm.Views.AreaCategoryIssueLookup', [_List2.default, _LegacySDataListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.AreaCategoryIssueLookup', [_List2.default, _LegacySDataListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.$descriptor %}</p>']),
 
@@ -68,13 +68,13 @@ define('crm/Views/AreaCategoryIssueLookup', ['module', 'exports', 'dojo/_base/de
       }
     },
     processFeed: function processFeed(feed) {
-      var theFeed = feed;
+      let theFeed = feed;
       // assume order is preserved
       if (theFeed) {
         this.createCacheFrom(feed);
       }
 
-      var use = this.cache;
+      let use = this.cache;
 
       if (use && this.active && this.active.Area) {
         use = use[this.active.Area];
@@ -88,21 +88,21 @@ define('crm/Views/AreaCategoryIssueLookup', ['module', 'exports', 'dojo/_base/de
       this.inherited(arguments, [theFeed]);
     },
     createCacheFrom: function createCacheFrom(feed) {
-      var feedLength = feed.$resources.length;
+      const feedLength = feed.$resources.length;
       this.cache = {};
 
-      for (var i = 0; i < feedLength; i += 1) {
-        var entry = feed.$resources[i];
-        var area = this.cache[entry.Area] || (this.cache[entry.Area] = {});
-        var category = area[entry.Category] || (area[entry.Category] = {});
+      for (let i = 0; i < feedLength; i += 1) {
+        const entry = feed.$resources[i];
+        const area = this.cache[entry.Area] || (this.cache[entry.Area] = {});
+        const category = area[entry.Category] || (area[entry.Category] = {});
 
         category[entry.Issue] = true;
       }
     },
     buildFeedFrom: function buildFeedFrom(segment) {
-      var list = [];
+      const list = [];
 
-      for (var n in segment) {
+      for (const n in segment) {
         if (segment.hasOwnProperty(n)) {
           list.push({
             $key: n,

--- a/src-out/Views/Attachment/AddAttachment.js
+++ b/src-out/Views/Attachment/AddAttachment.js
@@ -36,9 +36,9 @@ define('crm/Views/Attachment/AddAttachment', ['module', 'exports', 'dojo/_base/d
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('attachmentAdd');
+  const resource = (0, _I18n2.default)('attachmentAdd');
 
-  var __class = (0, _declare2.default)('crm.Views.Attachment.AddAttachment', [_FileSelect2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Attachment.AddAttachment', [_FileSelect2.default], {
     // Localization
     titleText: resource.titleText,
 
@@ -46,11 +46,11 @@ define('crm/Views/Attachment/AddAttachment', ['module', 'exports', 'dojo/_base/d
     id: 'attachment_Add',
 
     onUploadFiles: function onUploadFiles() {
-      var self = this;
+      const self = this;
       if (this._files && this._files.length > 0) {
         this.inherited(onUploadFiles, arguments);
-        var fileItems = this.getFileItems();
-        var am = new _AttachmentManager2.default();
+        const fileItems = this.getFileItems();
+        const am = new _AttachmentManager2.default();
 
         am.onSuccessUpdate = function onSuccessUpdate() {
           _Environment2.default.refreshAttachmentViews();
@@ -64,7 +64,7 @@ define('crm/Views/Attachment/AddAttachment', ['module', 'exports', 'dojo/_base/d
         };
 
         am.onUpdateProgress = function onUpdateProgress(percent) {
-          var msg = _Format2.default.percent(percent / 100);
+          const msg = _Format2.default.percent(percent / 100);
           self.onUpdateProgress(msg);
         };
 

--- a/src-out/Views/Attachment/List.js
+++ b/src-out/Views/Attachment/List.js
@@ -27,25 +27,25 @@ define('crm/Views/Attachment/List', ['module', 'exports', 'dojo/_base/declare', 
     };
   }
 
-  var resource = (0, _I18n2.default)('attachmentList'); /* Copyright 2017 Infor
-                                                         *
-                                                         * Licensed under the Apache License, Version 2.0 (the "License");
-                                                         * you may not use this file except in compliance with the License.
-                                                         * You may obtain a copy of the License at
-                                                         *
-                                                         *    http://www.apache.org/licenses/LICENSE-2.0
-                                                         *
-                                                         * Unless required by applicable law or agreed to in writing, software
-                                                         * distributed under the License is distributed on an "AS IS" BASIS,
-                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                         * See the License for the specific language governing permissions and
-                                                         * limitations under the License.
-                                                         */
+  const resource = (0, _I18n2.default)('attachmentList'); /* Copyright 2017 Infor
+                                                           *
+                                                           * Licensed under the Apache License, Version 2.0 (the "License");
+                                                           * you may not use this file except in compliance with the License.
+                                                           * You may obtain a copy of the License at
+                                                           *
+                                                           *    http://www.apache.org/licenses/LICENSE-2.0
+                                                           *
+                                                           * Unless required by applicable law or agreed to in writing, software
+                                                           * distributed under the License is distributed on an "AS IS" BASIS,
+                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                           * See the License for the specific language governing permissions and
+                                                           * limitations under the License.
+                                                           */
 
-  var hashTagResource = (0, _I18n2.default)('attachmentListHashTags');
-  var dtFormatResource = (0, _I18n2.default)('attachmentListDateTimeFormat');
+  const hashTagResource = (0, _I18n2.default)('attachmentListHashTags');
+  const dtFormatResource = (0, _I18n2.default)('attachmentListDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Attachment.List', [_List2.default, _RightDrawerListMixin3.default, _LegacySDataListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Attachment.List', [_List2.default, _RightDrawerListMixin3.default, _LegacySDataListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['{% if ($.dataType === "R") { %}', '{%! $$.fileTemplate %}', '{% } else { %}', '{%! $$.urlTemplate %}', '{% } %}']),
     fileTemplate: new Simplate(['{% if ($.attachDate) { %}', '<p class="micro-text"><span>({%: $$.buildUploadedText($.attachDate) %})</span></p>', '{% } %}', '<p class="micro-text"><span>{%: crm.Format.fileSize($.fileSize) %}</span></p>', '<p class="micro-text"><span>{%: crm.Utility.getFileExtension($.fileName) %} </span></p>', '{% if($.user) { %}', '<p class="micro-text"><span>{%: $.user.$descriptor  %}</span></p>', '{% } %}']),
@@ -87,22 +87,22 @@ define('crm/Views/Attachment/List', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     createRequest: function createRequest() {
-      var request = this.inherited(createRequest, arguments);
+      const request = this.inherited(createRequest, arguments);
       request.setQueryArg('_includeFile', 'false');
       return request;
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(description) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(description) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     },
     getLink: function getLink(attachment) {
-      var toReturn = void 0;
+      let toReturn;
       if (attachment.url) {
-        var href = attachment.url || '';
-        href = href.indexOf('http') < 0 ? 'http://' + href : href;
-        toReturn = '<a class="hyperlink" href="' + href + '" target="_blank" title="' + attachment.url + '">' + attachment.$descriptor + '</a>';
+        let href = attachment.url || '';
+        href = href.indexOf('http') < 0 ? `http://${href}` : href;
+        toReturn = `<a class="hyperlink" href="${href}" target="_blank" title="${attachment.url}">${attachment.$descriptor}</a>`;
       } else {
         if (attachment.fileExists) {
-          toReturn = '<a class="hyperlink" href="javascript: Sage.Utility.File.Attachment.getAttachment(\'' + attachment.$key + '\');" title="' + attachment.$descriptor + '">' + attachment.$descriptor + '</a>';
+          toReturn = `<a class="hyperlink" href="javascript: Sage.Utility.File.Attachment.getAttachment('${attachment.$key}');" title="${attachment.$descriptor}">${attachment.$descriptor}</a>`;
         } else {
           toReturn = attachment.$descriptor;
         }
@@ -128,12 +128,12 @@ define('crm/Views/Attachment/List', ['module', 'exports', 'dojo/_base/declare', 
       bmp: 'overlay-line'
     },
     getItemIconClass: function getItemIconClass(entry) {
-      var fileName = entry && entry.fileName;
-      var type = _Utility2.default.getFileExtension(fileName);
-      var cls = this.itemIconClass;
+      const fileName = entry && entry.fileName;
+      let type = _Utility2.default.getFileExtension(fileName);
+      let cls = this.itemIconClass;
       if (type) {
         type = type.substr(1); // Remove the '.' from the ext.
-        var typeCls = this.fileIconByType[type];
+        const typeCls = this.fileIconByType[type];
         if (typeCls) {
           cls = typeCls;
         }
@@ -152,16 +152,16 @@ define('crm/Views/Attachment/List', ['module', 'exports', 'dojo/_base/declare', 
     },
     hasBeenTouched: function hasBeenTouched(entry) {
       if (entry.modifyDate) {
-        var modifiedDate = moment(_Convert2.default.toDateFromString(entry.modifyDate));
-        var currentDate = moment().endOf('day');
-        var weekAgo = moment().subtract(1, 'weeks');
+        const modifiedDate = moment(_Convert2.default.toDateFromString(entry.modifyDate));
+        const currentDate = moment().endOf('day');
+        const weekAgo = moment().subtract(1, 'weeks');
 
         return modifiedDate.isAfter(weekAgo) && modifiedDate.isBefore(currentDate);
       }
       return false;
     },
     buildUploadedText: function buildUploadedText(date) {
-      var modifiedDate = moment(date).toDate();
+      const modifiedDate = moment(date).toDate();
       return _string2.default.substitute(this.uploadedOnText, [_Format2.default.date(modifiedDate), _Format2.default.date(modifiedDate, App.is24HourClock() ? this.attachmentTimeFormatText24 : this.attachmentTimeFormatText)]);
     }
   });

--- a/src-out/Views/Attachment/MyAttachmentList.js
+++ b/src-out/Views/Attachment/MyAttachmentList.js
@@ -15,30 +15,30 @@ define('crm/Views/Attachment/MyAttachmentList', ['module', 'exports', 'dojo/_bas
     };
   }
 
-  var resource = (0, _I18n2.default)('attachmentMyList'); /* Copyright 2017 Infor
-                                                           *
-                                                           * Licensed under the Apache License, Version 2.0 (the "License");
-                                                           * you may not use this file except in compliance with the License.
-                                                           * You may obtain a copy of the License at
-                                                           *
-                                                           *    http://www.apache.org/licenses/LICENSE-2.0
-                                                           *
-                                                           * Unless required by applicable law or agreed to in writing, software
-                                                           * distributed under the License is distributed on an "AS IS" BASIS,
-                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                           * See the License for the specific language governing permissions and
-                                                           * limitations under the License.
-                                                           */
+  const resource = (0, _I18n2.default)('attachmentMyList'); /* Copyright 2017 Infor
+                                                             *
+                                                             * Licensed under the Apache License, Version 2.0 (the "License");
+                                                             * you may not use this file except in compliance with the License.
+                                                             * You may obtain a copy of the License at
+                                                             *
+                                                             *    http://www.apache.org/licenses/LICENSE-2.0
+                                                             *
+                                                             * Unless required by applicable law or agreed to in writing, software
+                                                             * distributed under the License is distributed on an "AS IS" BASIS,
+                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                             * See the License for the specific language governing permissions and
+                                                             * limitations under the License.
+                                                             */
 
-  var __class = (0, _declare2.default)('crm.Views.Attachment.MyAttachmentList', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Attachment.MyAttachmentList', [_List2.default], {
     id: 'myattachment_list',
     titleText: resource.titleText,
     queryWhere: function queryWhere() {
-      var q = this._formatUserKey(App.context.user.$key);
-      return 'createUser eq "' + q + '"';
+      const q = this._formatUserKey(App.context.user.$key);
+      return `createUser eq "${q}"`;
     },
     _formatUserKey: function _formatUserKey(userKey) {
-      var key = userKey;
+      let key = userKey;
       if (key === 'ADMIN') {
         key = 'ADMIN       '; // The attachment feed is picky and requires the Admin key to be padded to a 12 char.
       }

--- a/src-out/Views/Attachment/ViewAttachment.js
+++ b/src-out/Views/Attachment/ViewAttachment.js
@@ -27,24 +27,24 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
     };
   }
 
-  var resource = (0, _I18n2.default)('attachmentView'); /* Copyright 2017 Infor
-                                                         *
-                                                         * Licensed under the Apache License, Version 2.0 (the "License");
-                                                         * you may not use this file except in compliance with the License.
-                                                         * You may obtain a copy of the License at
-                                                         *
-                                                         *    http://www.apache.org/licenses/LICENSE-2.0
-                                                         *
-                                                         * Unless required by applicable law or agreed to in writing, software
-                                                         * distributed under the License is distributed on an "AS IS" BASIS,
-                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                         * See the License for the specific language governing permissions and
-                                                         * limitations under the License.
-                                                         */
+  const resource = (0, _I18n2.default)('attachmentView'); /* Copyright 2017 Infor
+                                                           *
+                                                           * Licensed under the Apache License, Version 2.0 (the "License");
+                                                           * you may not use this file except in compliance with the License.
+                                                           * You may obtain a copy of the License at
+                                                           *
+                                                           *    http://www.apache.org/licenses/LICENSE-2.0
+                                                           *
+                                                           * Unless required by applicable law or agreed to in writing, software
+                                                           * distributed under the License is distributed on an "AS IS" BASIS,
+                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                           * See the License for the specific language governing permissions and
+                                                           * limitations under the License.
+                                                           */
 
-  var dtFormatResource = (0, _I18n2.default)('attachmentViewDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('attachmentViewDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Attachment.ViewAttachment', [_Detail2.default, _LegacySDataDetailMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Attachment.ViewAttachment', [_Detail2.default, _LegacySDataDetailMixin3.default], {
     // Localization
     detailsText: resource.detailsText,
     descriptionText: resource.descriptionText,
@@ -94,11 +94,7 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
       }
     },
     onTransitionTo: function onTransitionTo() {
-      var _this = this;
-
-      var _renderFn = _Utility2.default.debounce(function () {
-        return _this.renderPdf();
-      }, this.RENDER_DELAY);
+      const _renderFn = _Utility2.default.debounce(() => this.renderPdf(), this.RENDER_DELAY);
       $(window).on('resize.attachment', _renderFn);
       $(window).on('applicationmenuclose.attachment', _renderFn);
       $(window).on('applicationmenuopen.attachment', _renderFn);
@@ -128,12 +124,12 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
       this._loadAttachmentView(entry);
     },
     createRequest: function createRequest() {
-      var request = this.inherited(createRequest, arguments);
+      const request = this.inherited(createRequest, arguments);
       request.setQueryArg('_includeFile', 'false');
       return request;
     },
     createEntryForDelete: function createEntryForDelete(e) {
-      var entry = {
+      const entry = {
         $key: e.$key,
         $etag: e.$etag,
         $name: e.$name
@@ -192,8 +188,6 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
       this.renderPdfPage(this.pdfCurrentPage);
     },
     renderPdfPage: function renderPdfPage(pageNumber) {
-      var _this2 = this;
-
       if (pageNumber < 1 || this.pdfDoc === null) {
         return;
       }
@@ -206,32 +200,32 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
         return;
       }
 
-      var box = _domGeometry2.default.getMarginBox(this.domNode);
-      this.pdfDoc.getPage(pageNumber).then(function (page) {
-        var scale = _this2.pdfScale;
-        var viewport = page.getViewport({ scale: scale });
-        var canvas = document.getElementById('pdfViewer');
-        var context = canvas.getContext('2d');
-        var desiredWidth = box.w;
+      const box = _domGeometry2.default.getMarginBox(this.domNode);
+      this.pdfDoc.getPage(pageNumber).then(page => {
+        const scale = this.pdfScale;
+        let viewport = page.getViewport({ scale });
+        const canvas = document.getElementById('pdfViewer');
+        const context = canvas.getContext('2d');
+        const desiredWidth = box.w;
         viewport = page.getViewport({ scale: desiredWidth / viewport.width });
         canvas.height = viewport.height < box.h ? box.h : viewport.height;
         canvas.width = viewport.width;
 
-        var renderContext = {
+        const renderContext = {
           canvasContext: context,
-          viewport: viewport
+          viewport
         };
 
-        _this2.pdfIsLoading = true;
-        var renderTask = page.render(renderContext);
-        renderTask.promise.then(function () {
-          _this2.pdfCurrentPage = pageNumber;
-          _this2.pdfIsLoading = false;
-          _this2.updatePageStats();
-        }, function (reason) {
-          _this2.pdfIsLoading = false;
-          var fileName = _this2.entry && _this2.entry.fileName;
-          var message = 'Failed to render page ' + pageNumber + ' for PDF "' + fileName + '".';
+        this.pdfIsLoading = true;
+        const renderTask = page.render(renderContext);
+        renderTask.promise.then(() => {
+          this.pdfCurrentPage = pageNumber;
+          this.pdfIsLoading = false;
+          this.updatePageStats();
+        }, reason => {
+          this.pdfIsLoading = false;
+          const fileName = this.entry && this.entry.fileName;
+          const message = `Failed to render page ${pageNumber} for PDF "${fileName}".`;
           console.error(message, reason); // eslint-disable-line
           _ErrorManager2.default.addSimpleError(message, reason);
         });
@@ -242,43 +236,39 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
         return;
       }
 
-      var node = $('.page-stats', this.attachmentViewerNode).first();
-      node.text(this.pdfCurrentPage + ' / ' + this.pdfTotalPages);
+      const node = $('.page-stats', this.attachmentViewerNode).first();
+      node.text(`${this.pdfCurrentPage} / ${this.pdfTotalPages}`);
     },
     loadPdfDocument: function loadPdfDocument(responseInfo) {
-      var _this3 = this;
-
       if (this.pdfDoc !== null) {
         this.pdfDoc.destroy();
         this.pdfDoc = null;
       }
 
-      var dataResponse = _Utility2.default.base64ArrayBuffer(responseInfo.response);
-      var task = window.pdfjsLib.getDocument({ data: atob(dataResponse) });
+      const dataResponse = _Utility2.default.base64ArrayBuffer(responseInfo.response);
+      const task = window.pdfjsLib.getDocument({ data: atob(dataResponse) });
       this.pdfIsLoading = true;
-      task.promise.then(function (pdf) {
-        _this3.pdfIsLoading = false;
-        _this3.pdfDoc = pdf;
-        _this3.pdfCurrentPage = 1;
-        _this3.pdfTotalPages = pdf.numPages;
-        _this3.renderPdfPage(1);
-      }, function (reason) {
-        _this3.pdfIsLoading = false;
-        var fileName = _this3.entry && _this3.entry.fileName;
-        var message = 'The PDF "' + fileName + '" failed to load.';
+      task.promise.then(pdf => {
+        this.pdfIsLoading = false;
+        this.pdfDoc = pdf;
+        this.pdfCurrentPage = 1;
+        this.pdfTotalPages = pdf.numPages;
+        this.renderPdfPage(1);
+      }, reason => {
+        this.pdfIsLoading = false;
+        const fileName = this.entry && this.entry.fileName;
+        const message = `The PDF "${fileName}" failed to load.`;
         console.error(message, reason); // eslint-disable-line
         _ErrorManager2.default.addSimpleError(message, reason);
       });
     },
     _loadAttachmentView: function _loadAttachmentView(entry) {
-      var _this4 = this;
-
-      var am = new _AttachmentManager2.default();
-      var CHROME_DATA_URI_LIMIT = 2097152;
-      var description = void 0;
-      var isFile = void 0;
-      var fileType = void 0;
-      var loaded = void 0;
+      const am = new _AttachmentManager2.default();
+      const CHROME_DATA_URI_LIMIT = 2097152;
+      let description;
+      let isFile;
+      let fileType;
+      let loaded;
 
       if (!entry.url) {
         description = entry.description;
@@ -286,16 +276,16 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
         isFile = true;
       } else {
         isFile = false;
-        description = entry.description + ' (' + entry.url + ')';
+        description = `${entry.description} (${entry.url})`;
         fileType = 'url';
       }
 
-      var data = {
+      const data = {
         fileName: entry.fileName,
         fileSize: entry.fileSize,
-        fileType: fileType,
+        fileType,
         url: '',
-        description: description
+        description
       };
 
       if (isFile) {
@@ -303,19 +293,19 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
         if (this._isfileTypeAllowed(fileType)) {
           if (this._isfileTypeImage(fileType)) {
             $(this.attachmentViewerNode).append(this.attachmentViewImageTemplate.apply(data, this));
-            var tpl = $(this.downloadingTemplate.apply(this));
+            const tpl = $(this.downloadingTemplate.apply(this));
             $(this.attachmentViewerNode).prepend(tpl);
             $(this.domNode).addClass('list-loading');
-            var self = this;
-            var attachmentid = entry.$key;
+            const self = this;
+            const attachmentid = entry.$key;
             // dataurl
-            am.getAttachmentFile(attachmentid, 'arraybuffer', function (responseInfo) {
-              var rData = _Utility2.default.base64ArrayBuffer(responseInfo.response);
-              self.dataURL = 'data:' + responseInfo.contentType + ';base64,' + rData;
+            am.getAttachmentFile(attachmentid, 'arraybuffer', responseInfo => {
+              const rData = _Utility2.default.base64ArrayBuffer(responseInfo.response);
+              self.dataURL = `data:${responseInfo.contentType};base64,${rData}`;
 
-              var image = new Image();
+              const image = new Image();
 
-              var loadHandler = function loadHandler() {
+              const loadHandler = function loadHandler() {
                 if (loaded) {
                   return;
                 }
@@ -341,7 +331,7 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
             });
           } else {
             // View file type in Iframe
-            var _attachmentid = entry.$key;
+            const attachmentid = entry.$key;
 
             if (fileType === '.pdf') {
               $(this.attachmentViewerNode).append(this.pdfViewTemplate.apply(data, this));
@@ -351,29 +341,29 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
               $('.last-page-button', this.attachmentViewerNode).on('click', this.onLastPageClick.bind(this));
               $('.zoom-in', this.attachmentViewerNode).on('click', this.onZoomInClick.bind(this));
               $('.zoom-out', this.attachmentViewerNode).on('click', this.onZoomOutClick.bind(this));
-              am.getAttachmentFile(_attachmentid, 'arraybuffer', function (responseInfo) {
-                _this4.loadPdfDocument(responseInfo);
+              am.getAttachmentFile(attachmentid, 'arraybuffer', responseInfo => {
+                this.loadPdfDocument(responseInfo);
               });
             } else {
               $(this.attachmentViewerNode).append(this.attachmentViewTemplate.apply(data, this));
-              var _tpl = $(this.downloadingTemplate.apply(this));
-              $(this.attachmentViewerNode).prepend(_tpl);
+              const tpl = $(this.downloadingTemplate.apply(this));
+              $(this.attachmentViewerNode).prepend(tpl);
               $(this.domNode).addClass('list-loading');
 
-              am.getAttachmentFile(_attachmentid, 'arraybuffer', function (responseInfo) {
-                var rData = _Utility2.default.base64ArrayBuffer(responseInfo.response);
+              am.getAttachmentFile(attachmentid, 'arraybuffer', responseInfo => {
+                const rData = _Utility2.default.base64ArrayBuffer(responseInfo.response);
                 if (rData.length >= CHROME_DATA_URI_LIMIT) {
                   window.saveAs(new Blob([new Uint8Array(responseInfo.response, 0, responseInfo.response.length)]), responseInfo.fileName);
                   return;
                 }
-                var dataUrl = 'data:' + responseInfo.contentType + ';base64,' + rData;
-                $(_tpl).addClass('display-none');
-                var iframe = document.getElementById('attachment-Iframe');
+                const dataUrl = `data:${responseInfo.contentType};base64,${rData}`;
+                $(tpl).addClass('display-none');
+                const iframe = document.getElementById('attachment-Iframe');
                 iframe.onload = function iframeOnLoad() {
-                  $(_tpl).addClass('display-none');
+                  $(tpl).addClass('display-none');
                 };
-                $(_tpl).addClass('display-none');
-                _this4.setSrc(iframe, dataUrl);
+                $(tpl).addClass('display-none');
+                this.setSrc(iframe, dataUrl);
               });
             }
           }
@@ -384,21 +374,21 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
       } else {
         // url Attachment
         $(this.attachmentViewerNode).append(this.attachmentViewTemplate.apply(data, this));
-        var url = am.getAttachmenturlByEntity(entry);
+        const url = am.getAttachmenturlByEntity(entry);
         $(this.domNode).addClass('list-loading');
-        var _tpl2 = $(this.downloadingTemplate.apply(this));
-        $(this.attachmentViewerNode).prepend(_tpl2);
-        var iframe = document.getElementById('attachment-Iframe');
+        const tpl = $(this.downloadingTemplate.apply(this));
+        $(this.attachmentViewerNode).prepend(tpl);
+        const iframe = document.getElementById('attachment-Iframe');
         iframe.onload = function iframeOnLoad() {
-          $(_tpl2).addClass('display-none');
+          $(tpl).addClass('display-none');
         };
         this.setSrc(iframe, url);
-        $(_tpl2).addClass('display-none');
+        $(tpl).addClass('display-none');
       }
     },
     _isfileTypeImage: function _isfileTypeImage(fileType) {
-      var fType = fileType.substr(fileType.lastIndexOf('.') + 1).toLowerCase();
-      var imageTypes = void 0;
+      const fType = fileType.substr(fileType.lastIndexOf('.') + 1).toLowerCase();
+      let imageTypes;
 
       if (App.imageFileTypes) {
         imageTypes = App.imageFileTypes;
@@ -419,8 +409,8 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
       return false;
     },
     _isfileTypeAllowed: function _isfileTypeAllowed(fileType) {
-      var fType = fileType.substr(fileType.lastIndexOf('.') + 1).toLowerCase();
-      var fileTypes = void 0;
+      const fType = fileType.substr(fileType.lastIndexOf('.') + 1).toLowerCase();
+      let fileTypes;
 
       if (App.nonViewableFileTypes) {
         fileTypes = App.nonViewableFileTypes;
@@ -440,12 +430,12 @@ define('crm/Views/Attachment/ViewAttachment', ['module', 'exports', 'dojo/_base/
       return false;
     },
     _sizeImage: function _sizeImage(containerNode, image) {
-      var contentBox = $(containerNode).parent(); // hack to get parent dimensions since child containers occupy 0 height as they are not absolute anymore
-      var iH = image.height;
-      var iW = image.width;
-      var wH = contentBox.height();
-      var wW = contentBox.width();
-      var scale = 1;
+      const contentBox = $(containerNode).parent(); // hack to get parent dimensions since child containers occupy 0 height as they are not absolute anymore
+      const iH = image.height;
+      const iW = image.width;
+      let wH = contentBox.height();
+      let wW = contentBox.width();
+      let scale = 1;
 
       if (wH > 200) {
         wH = wH - 50;

--- a/src-out/Views/Briefcase/List.js
+++ b/src-out/Views/Briefcase/List.js
@@ -27,20 +27,20 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
     };
   }
 
-  var resource = (0, _I18n2.default)('briefcaseList'); /* Copyright 2017 Infor
-                                                        *
-                                                        * Licensed under the Apache License, Version 2.0 (the "License");
-                                                        * you may not use this file except in compliance with the License.
-                                                        * You may obtain a copy of the License at
-                                                        *
-                                                        *    http://www.apache.org/licenses/LICENSE-2.0
-                                                        *
-                                                        * Unless required by applicable law or agreed to in writing, software
-                                                        * distributed under the License is distributed on an "AS IS" BASIS,
-                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                        * See the License for the specific language governing permissions and
-                                                        * limitations under the License.
-                                                        */
+  const resource = (0, _I18n2.default)('briefcaseList'); /* Copyright 2017 Infor
+                                                          *
+                                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                                          * you may not use this file except in compliance with the License.
+                                                          * You may obtain a copy of the License at
+                                                          *
+                                                          *    http://www.apache.org/licenses/LICENSE-2.0
+                                                          *
+                                                          * Unless required by applicable law or agreed to in writing, software
+                                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                          * See the License for the specific language governing permissions and
+                                                          * limitations under the License.
+                                                          */
 
   exports.default = (0, _declare2.default)('crm.Views.Briefcase', [_ListBase3.default, _ListOfflineMixin3.default], {
     id: 'briefcase_list',
@@ -60,7 +60,7 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
       return true;
     },
     getModel: function getModel() {
-      var model = App.ModelManager.getModel('Briefcase', _Types2.default.OFFLINE);
+      const model = App.ModelManager.getModel('Briefcase', _Types2.default.OFFLINE);
       return model;
     },
     getTitle: function getTitle(entry) {
@@ -76,7 +76,7 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
       return options;
     },
     createToolLayout: function createToolLayout() {
-      var tools = {
+      const tools = {
         tbar: [{
           id: 'resync',
           svg: 'roles',
@@ -91,7 +91,7 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
       return [];
     },
     getItemIconClass: function getItemIconClass(entry) {
-      var iconClass = void 0;
+      let iconClass;
       iconClass = entry.iconClass;
       if (!iconClass) {
         iconClass = 'url';
@@ -99,13 +99,13 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
       return iconClass;
     },
     navigateToDetailView: function navigateToDetailView(key, descriptor, additionalOptions) {
-      var entry = this.entries && this.entries[key];
+      const entry = this.entries && this.entries[key];
       this.navigateToOfflineDetailView(entry, additionalOptions);
     },
     navigateToOnlineDetailView: function navigateToDetailView(entry, additionalOptions) {
-      var view = this.app.getView(entry.viewId);
+      const view = this.app.getView(entry.viewId);
 
-      var options = {
+      let options = {
         descriptor: entry.description, // keep for backwards compat
         title: entry.description,
         key: entry.entityId,
@@ -121,8 +121,8 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
       }
     },
     navigateToOfflineDetailView: function navigateToOfflineDetailView(entry, additionalOptions) {
-      var view = this.getDetailView(entry.entityName);
-      var options = {
+      const view = this.getDetailView(entry.entityName);
+      let options = {
         descriptor: entry.description, // keep for backwards compat
         title: entry.description,
         key: entry.entityId,
@@ -143,8 +143,8 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
       }
     },
     getDetailView: function getDetailView(entityName) {
-      var viewId = this.detailView + '_' + entityName;
-      var view = this.app.getView(viewId);
+      const viewId = `${this.detailView}_${entityName}`;
+      let view = this.app.getView(viewId);
 
       if (view) {
         return view;
@@ -178,32 +178,30 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
       }]);
     },
     navToOnlineView: function navToOnlineVie(action, selection) {
-      var briefcaseId = selection.tag.attributes['data-key'].value;
-      var briefcase = this.entries[briefcaseId];
+      const briefcaseId = selection.tag.attributes['data-key'].value;
+      const briefcase = this.entries[briefcaseId];
       this.navigateToOnlineDetailView(briefcase);
     },
     navToOfflineView: function navToOfflineView(action, selection) {
-      var briefcaseId = selection.tag.attributes['data-key'].value;
-      var briefcase = this.entries[briefcaseId];
+      const briefcaseId = selection.tag.attributes['data-key'].value;
+      const briefcase = this.entries[briefcaseId];
       this.navigateToOfflineDetailView(briefcase);
     },
     removeItemAction: function removeItemAction(action, selection) {
-      var _this = this;
-
       // eslint-disable-line
-      var briefcaseId = selection.tag.attributes['data-key'].value;
-      _Manager2.default.removeBriefcase(briefcaseId).then(function () {
-        _this.clear();
-        _this.refreshRequired = true;
-        _this.refresh();
-      }, function (error) {
+      const briefcaseId = selection.tag.attributes['data-key'].value;
+      _Manager2.default.removeBriefcase(briefcaseId).then(() => {
+        this.clear();
+        this.refreshRequired = true;
+        this.refresh();
+      }, error => {
         console.error(error); // eslint-disable-line
       });
     },
     reBriefcaseItemAction: function reBriefcase(action, selection) {
       // eslint-disable-line
-      var briefcaseId = selection.tag.attributes['data-key'].value;
-      var briefcase = this.entries[briefcaseId];
+      const briefcaseId = selection.tag.attributes['data-key'].value;
+      const briefcase = this.entries[briefcaseId];
       if (briefcase) {
         this.briefCaseItem(briefcase);
       }
@@ -214,7 +212,7 @@ define('crm/Views/Briefcase/List', ['module', 'exports', 'dojo/_base/declare', '
       this.refresh();
     },
     createBriefcaseEntity: function createBriefcaseEntity(entry) {
-      var entity = {
+      const entity = {
         entityId: entry.entityId,
         entityName: entry.entityName,
         options: {

--- a/src-out/Views/Calendar/CalendarView.js
+++ b/src-out/Views/Calendar/CalendarView.js
@@ -48,24 +48,24 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
     };
   }
 
-  var resource = (0, _I18n2.default)('calendarView'); /* Copyright 2017 Infor
-                                                       *
-                                                       * Licensed under the Apache License, Version 2.0 (the "License");
-                                                       * you may not use this file except in compliance with the License.
-                                                       * You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing, software
-                                                       * distributed under the License is distributed on an "AS IS" BASIS,
-                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                       * See the License for the specific language governing permissions and
-                                                       * limitations under the License.
-                                                       */
+  const resource = (0, _I18n2.default)('calendarView'); /* Copyright 2017 Infor
+                                                         *
+                                                         * Licensed under the Apache License, Version 2.0 (the "License");
+                                                         * you may not use this file except in compliance with the License.
+                                                         * You may obtain a copy of the License at
+                                                         *
+                                                         *    http://www.apache.org/licenses/LICENSE-2.0
+                                                         *
+                                                         * Unless required by applicable law or agreed to in writing, software
+                                                         * distributed under the License is distributed on an "AS IS" BASIS,
+                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                         * See the License for the specific language governing permissions and
+                                                         * limitations under the License.
+                                                         */
 
-  var dtFormatResource = (0, _I18n2.default)('calendarViewDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('calendarViewDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Calendar.CalendarView', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Calendar.CalendarView', [_List2.default], {
     // Localization
     titleText: resource.titleText,
     monthTitleFormatText: dtFormatResource.monthTitleFormatText,
@@ -95,7 +95,11 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
     // Templates
     widgetTemplate: new Simplate(['<div id="{%= $.id %}" data-title="{%= $.titleText %}" class="overthrow panel {%= $.cls %}" {% if ($.resourceKind) { %}data-resource-kind="{%= $.resourceKind %}"{% } %}>', '<div class="overthrow scroller" data-dojo-attach-point="scrollerNode">', '<div class="panel-content">', '<div class="calendarContainer" data-dojo-attach-point="calendarNode"></div>', '<div class="event-content event-hidden listview" data-dojo-attach-point="eventContainerNode">', '<ul class="list-content" data-dojo-attach-point="eventContentNode"></ul>', '{%! $.eventMoreTemplate %}', '</div>', '<div class="activity-content listview" data-dojo-attach-point="activityContainerNode">', '<ul class="list-content" data-dojo-attach-point="activityContentNode"></ul>', '{%! $.activityMoreTemplate %}', '</div>', '<div style="clear:both"></div>', '</div>', '</div>', '</div>']),
     activityRowTemplate: new Simplate(['<li class="activityEntry" data-action="activateEntry" data-key="{%= $.$key %}" data-descriptor="{%: $.$descriptor %}" data-activity-type="{%: $.Type %}">', '{%! $$.activityIconTemplate %}', '{%! $$.activityHeaderTemplate %}', '{%! $$.activityContentTemplate %}', '{%! $$.activityFooterTemplate %}', '</li>']),
-    activityIconTemplate: new Simplate(['<div class="activityEntry__icon">', '<button type="button" class="btn-icon hide-focus">\n      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%= $$.activityTypeIcon[$.Type] %}"></use>\n      </svg>\n    </button></div>']),
+    activityIconTemplate: new Simplate(['<div class="activityEntry__icon">', `<button type="button" class="btn-icon hide-focus">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%= $$.activityTypeIcon[$.Type] %}"></use>
+      </svg>
+    </button></div>`]),
     activityHeaderTemplate: new Simplate(['<div class="activityEntry__header">', '<div class="header__content">', '<p class="listview-heading">{%: $.Description %}</p>', '<p class="listview-subheading">{%! $$.activityNameTemplate %}</p>', '</div>', '<div class="header__timeStamp">', '<span class="timeStamp__time listview-subheading">', '{% if ($.Timeless) { %}', '{%= $$.allDayText %}', '{% } else if ($$.activityTypeIcon[$.Type]) { %}', '{%: crm.Format.date($.StartDate, (App.is24HourClock()) ? $$.startTimeFormatText24 : $$.startTimeFormatText) %}', '{% } else { %}', '{%! $$.eventTimeTemplate %}', '{% } %}', '</span>', '</div>', '</div>']),
     activityContentTemplate: new Simplate(['<div class="activityEntry__content">', '{% if ($.Notes) { %}', '{%: $$.Utility.trimText($.Notes, $$.trimTo) %}', '{% } %}', '</div>']),
     activityFooterTemplate: new Simplate(['<div class="activityEntry__footer">', '</div>']),
@@ -103,10 +107,21 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
     activityMoreTemplate: new Simplate(['<div class="list-more" data-dojo-attach-point="activityMoreNode">', '<button class="button" data-action="activateActivityMore">', '<span data-dojo-attach-point="activityRemainingContentNode">{%= $.countMoreText %}</span>', '</button>', '</div>']),
     eventRowTemplate: new Simplate(['<li data-action="activateEntry" data-key="{%= $.$key %}" data-descriptor="{%: $.$descriptor %}" data-activity-type="Event">', '{%! $$.eventIconTemplate %}', '{%! $$.activityHeaderTemplate %}', '{%! $$.activityFooterTemplate %}', '</li>']),
     eventTimeTemplate: new Simplate(['{%: crm.Format.date($.StartDate, $$.eventDateFormatText) %}', '&nbsp;-&nbsp;', '{%: crm.Format.date($.EndDate, $$.eventDateFormatText) %}']),
-    eventIconTemplate: new Simplate(['<div class="activityEntry__icon">', '<button type="button" class="btn-icon hide-focus">\n      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%= $$.activityTypeIcon.event %}"></use>\n      </svg>\n    </button>', '</div>']),
+    eventIconTemplate: new Simplate(['<div class="activityEntry__icon">', `<button type="button" class="btn-icon hide-focus">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-{%= $$.activityTypeIcon.event %}"></use>
+      </svg>
+    </button>`, '</div>']),
     eventMoreTemplate: new Simplate(['<div class="list-more" data-dojo-attach-point="eventMoreNode">', '<button class="button" data-action="activateEventMore">', '<span data-dojo-attach-point="eventRemainingContentNode">{%= $.countMoreText %}</span>', '</button>', '</div>']),
     headerRowTemplate: new Simplate(['<li data-descriptor="{%: $.day %}">', '<div class="dayHeader">', '<h4 class="header__title">{%: $.day %}</h4>', '</div>', '</li>']),
-    weekSelectTemplate: new Simplate(['<div class="switch">\n        <input\n          type="checkbox"\n          name="weekToggleNode"\n          id="weekToggleNode"\n          class="switch" />\n        <label class="toggleWeekOrDay" for="weekToggleNode">{%= $.dayText %}</label>\n      </div>']),
+    weekSelectTemplate: new Simplate([`<div class="switch">
+        <input
+          type="checkbox"
+          name="weekToggleNode"
+          id="weekToggleNode"
+          class="switch" />
+        <label class="toggleWeekOrDay" for="weekToggleNode">{%= $.dayText %}</label>
+      </div>`]),
     attributeMap: {
       calendarContent: {
         node: 'contentNode',
@@ -178,12 +193,12 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
     },
     changeDayActivities: function changeDayActivities() {
       $(this.activityContainerNode).removeClass('list-loading');
-      var multiDays = [];
-      var entries = void 0;
+      let multiDays = [];
+      let entries;
 
       if (this._showMulti) {
-        var dateIterator = this.currentDate.clone().startOf('week');
-        for (var i = 0; i < this.multiSelect; i++) {
+        const dateIterator = this.currentDate.clone().startOf('week');
+        for (let i = 0; i < this.multiSelect; i++) {
           entries = this.monthActivities[dateIterator.format('YYYY-MM-DD')];
           if (entries) {
             multiDays = multiDays.concat(entries);
@@ -204,27 +219,24 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
 
       return;
     },
-    createActivityRows: function createActivityRows() {
-      var entries = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-      var day = arguments[1];
-
-      var count = entries.length;
+    createActivityRows: function createActivityRows(entries = [], day) {
+      const count = entries.length;
       if (count > 0) {
-        var activityDocfrag = document.createDocumentFragment();
-        var eventDocfrag = document.createDocumentFragment();
+        const activityDocfrag = document.createDocumentFragment();
+        const eventDocfrag = document.createDocumentFragment();
         if (this._showMulti) {
-          var headerNode = $(this.headerRowTemplate.apply({ day: day }, this)).get(0);
+          const headerNode = $(this.headerRowTemplate.apply({ day }, this)).get(0);
           // Create the day header for whatever type comes first (activity or event)
-          var first = this.entries[entries[0]];
+          const first = this.entries[entries[0]];
           if (this.activityTypeIcon[first.Type]) {
             activityDocfrag.appendChild(headerNode);
           } else {
             eventDocfrag.appendChild(headerNode);
           }
         }
-        for (var i = 0; i < count; i++) {
-          var entry = this.entries[entries[i]];
-          var rowNode = void 0;
+        for (let i = 0; i < count; i++) {
+          const entry = this.entries[entries[i]];
+          let rowNode;
           if (this.activityTypeIcon[entry.Type]) {
             try {
               rowNode = $(this.activityRowTemplate.apply(entry, this)).get(0);
@@ -260,8 +272,8 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       if (this._eventStore) {
         return this._eventStore;
       }
-      var temp = this.get('store');
-      var store = Object.assign({}, temp);
+      const temp = this.get('store');
+      const store = Object.assign({}, temp);
       Object.setPrototypeOf(store, Object.getPrototypeOf(temp));
       store.select = this.eventQuerySelect;
       store.resourceKind = this.eventResourceKind;
@@ -272,48 +284,46 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       return store;
     },
     formatQueryActivity: function formatQueryActivity(value) {
-      var startDate = value.clone().startOf('month');
-      var endDate = value.clone().endOf('month');
+      const startDate = value.clone().startOf('month');
+      const endDate = value.clone().endOf('month');
       return _string2.default.substitute(['UserActivities.UserId eq "${0}" and Type ne "atLiterature" and (', '(Timeless eq false and StartDate', ' between @${1}@ and @${2}@) or ', '(Timeless eq true and StartDate', ' between @${3}@ and @${4}@))'].join(''), [App.context.user && App.context.user.$key, _Convert2.default.toIsoStringFromDate(startDate.toDate()), _Convert2.default.toIsoStringFromDate(endDate.toDate()), startDate.format('YYYY-MM-DDT00:00:00[Z]'), endDate.format('YYYY-MM-DDT23:59:59[Z]')]);
     },
     formatQueryEvent: function formatQueryEvent(value) {
-      var user = App.context.user && App.context.user.$key;
-      var start = _Convert2.default.toIsoStringFromDate(value.clone().startOf('month').toDate());
-      var end = _Convert2.default.toIsoStringFromDate(value.clone().endOf('month').toDate());
-      return 'UserId eq "' + user + '" and ((StartDate gt @' + start + '@ or EndDate gt @' + start + '@) and StartDate lt @' + end + '@)';
+      const user = App.context.user && App.context.user.$key;
+      const start = _Convert2.default.toIsoStringFromDate(value.clone().startOf('month').toDate());
+      const end = _Convert2.default.toIsoStringFromDate(value.clone().endOf('month').toDate());
+      return `UserId eq "${user}" and ((StartDate gt @${start}@ or EndDate gt @${start}@) and StartDate lt @${end}@)`;
     },
     highlightActivities: function highlightActivities() {
-      var _this = this;
-
-      this._calendar.weeksNode.childNodes.forEach(function (week) {
-        week.childNodes.forEach(function (day) {
-          if (!_this.monthActivities[$(day).attr('data-date')]) {
-            _this._calendar.removeActive(day);
+      this._calendar.weeksNode.childNodes.forEach(week => {
+        week.childNodes.forEach(day => {
+          if (!this.monthActivities[$(day).attr('data-date')]) {
+            this._calendar.removeActive(day);
             return;
           }
-          if (!_this._calendar.isActive(day)) {
-            day.subValue = _this.monthActivities[$(day).attr('data-date')];
-            _this._calendar.setActiveDay(day);
+          if (!this._calendar.isActive(day)) {
+            day.subValue = this.monthActivities[$(day).attr('data-date')];
+            this._calendar.setActiveDay(day);
           }
         });
       });
       return this;
     },
     navigateToDetailView: function navigateToDetailView(key, _descriptor) {
-      var descriptor = _descriptor;
-      var entry = this.entries[key];
-      var detailView = entry.isEvent ? this.eventDetailView : this.activityDetailView;
-      var view = App.getView(detailView);
+      let descriptor = _descriptor;
+      const entry = this.entries[key];
+      const detailView = entry.isEvent ? this.eventDetailView : this.activityDetailView;
+      const view = App.getView(detailView);
       descriptor = entry.isEvent ? descriptor : entry.Description;
       if (view) {
         view.show({
           title: descriptor,
-          key: key
+          key
         });
       }
     },
     navigateToInsertView: function navigateToInsertView() {
-      var view = App.getView(this.insertView || this.editView);
+      const view = App.getView(this.insertView || this.editView);
 
       if (!this.options) {
         this.options = {};
@@ -345,7 +355,7 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       return this.tools;
     },
     navigateToNewUnscheduled: function navigateToNewUnscheduled() {
-      var additionalOptions = {
+      const additionalOptions = {
         unscheduled: true
       };
 
@@ -353,7 +363,7 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
     },
     onToolLayoutCreated: function onToolLayoutCreated(tools) {
       if (tools && !this._refreshAdded && !window.App.supportsTouch()) {
-        var refreshTool = {
+        const refreshTool = {
           id: 'refresh',
           svg: 'refresh',
           action: 'refresh'
@@ -367,27 +377,25 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       this.inherited(onToolLayoutCreated, arguments);
     },
     process: function process(store, entries, isEvent) {
-      var _this2 = this;
-
       if (entries.length > 0) {
-        entries.forEach(function (entryPreProcess) {
-          var entry = _this2._processEntry(entryPreProcess);
+        entries.forEach(entryPreProcess => {
+          const entry = this._processEntry(entryPreProcess);
           // If key comes back with nothing, check that the store is properly
           // setup with an idProperty
           entry.isEvent = isEvent;
-          var entryKey = store.getIdentity(entry);
-          _this2.entries[entryKey] = entry;
-          var startDate = moment(_Convert2.default.toDateFromString(entry.StartDate));
+          const entryKey = store.getIdentity(entry);
+          this.entries[entryKey] = entry;
+          const startDate = moment(_Convert2.default.toDateFromString(entry.StartDate));
           if (entry.Timeless) {
             startDate.subtract({
               minutes: startDate.utcOffset()
             });
           }
-          var date = startDate.format('YYYY-MM-DD');
-          if (_this2.monthActivities[date]) {
-            _this2.monthActivities[date].push(entryKey);
+          const date = startDate.format('YYYY-MM-DD');
+          if (this.monthActivities[date]) {
+            this.monthActivities[date].push(entryKey);
           } else {
-            _this2.monthActivities[date] = [entryKey];
+            this.monthActivities[date] = [entryKey];
           }
         });
       }
@@ -397,7 +405,7 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
         return;
       }
 
-      var store = this.get('store');
+      const store = this.get('store');
 
       this.process(store, entries, false);
     },
@@ -405,7 +413,7 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       if (!entries) {
         return;
       }
-      var store = this.createEventStore();
+      const store = this.createEventStore();
 
       this.process(store, entries, true);
     },
@@ -420,8 +428,6 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       this.refreshData();
     },
     refreshData: function refreshData() {
-      var _this3 = this;
-
       this._dataLoaded = false;
       this._eventStore = null;
       $(this.activityContainerNode).addClass('list-loading');
@@ -432,12 +438,12 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       this.monthActivities = [];
       this.activityQuery = this.formatQueryActivity(this.currentDate);
       this.eventQuery = this.formatQueryEvent(this.currentDate);
-      Promise.all([this.requestData(), this.requestEventData()]).then(function () {
-        $(_this3.activityContentNode).empty();
-        $(_this3.eventContentNode).empty();
-        _this3.highlightActivities();
-        _this3.changeDayActivities();
-        _this3._dataLoaded = true;
+      Promise.all([this.requestData(), this.requestEventData()]).then(() => {
+        $(this.activityContentNode).empty();
+        $(this.eventContentNode).empty();
+        this.highlightActivities();
+        this.changeDayActivities();
+        this._dataLoaded = true;
       });
     },
     render: function render() {
@@ -448,7 +454,7 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       if (!this._calendar) {
         this._calendar = new _Calendar2.default({ id: 'calendar-view__calendar', noClearButton: true });
         $(this.calendarNode).append(this._calendar.domNode);
-        var toggle = $(this.weekSelectTemplate.apply(this)).get(0);
+        const toggle = $(this.weekSelectTemplate.apply(this)).get(0);
         $(this._calendar.footerNode).append(toggle);
         (0, _on2.default)($(toggle).children()[0], 'click', this.toggleMultiSelect.bind(this));
         this._calendar.onChangeDay = this.onChangeDay.bind(this);
@@ -468,18 +474,18 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       this.selectDay();
     },
     requestData: function requestData() {
-      var store = this.get('store');
+      const store = this.get('store');
       if (store) {
         // attempt to use a dojo store
-        var queryOptions = {
+        const queryOptions = {
           count: this.pageSize,
           start: this.position
         };
 
         this._applyStateToQueryOptions(queryOptions);
 
-        var queryExpression = this._buildQueryExpression(this.activityQuery) || null;
-        var queryResults = store.query(queryExpression, queryOptions);
+        const queryExpression = this._buildQueryExpression(this.activityQuery) || null;
+        const queryResults = store.query(queryExpression, queryOptions);
 
         (0, _when2.default)(queryResults, this.processData.bind(this), this._onQueryError.bind(this, queryOptions));
 
@@ -489,18 +495,18 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       console.warn('Error requesting data, no store was defined. Did you mean to mixin _SDataListMixin to your list view?'); // eslint-disable-line
     },
     requestEventData: function requestEventData() {
-      var store = this.createEventStore();
+      const store = this.createEventStore();
       if (store) {
         // attempt to use a dojo store
-        var queryOptions = {
+        const queryOptions = {
           count: this.pageSize,
           start: this.position
         };
 
         this._applyStateToQueryOptions(queryOptions);
 
-        var queryExpression = this._buildQueryExpression(this.eventQuery) || null;
-        var queryResults = store.query(queryExpression, queryOptions);
+        const queryExpression = this._buildQueryExpression(this.eventQuery) || null;
+        const queryResults = store.query(queryExpression, queryOptions);
 
         (0, _when2.default)(queryResults, this.processEventData.bind(this), this._onQueryError.bind(this, queryOptions));
 
@@ -510,7 +516,7 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       console.warn('Error requesting data, no store was defined. Did you mean to mixin _SDataListMixin to your list view?'); // eslint-disable-line
     },
     selectDay: function selectDay() {
-      var selected = this._calendar.getSelectedDateMoment();
+      const selected = this._calendar.getSelectedDateMoment();
       if (this.currentDate && this._dataLoaded) {
         $(this.activityContentNode).empty();
         $(this.eventContentNode).empty();
@@ -533,9 +539,7 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
     startup: function startup() {
       this.inherited(startup, arguments);
     },
-    toggleMultiSelect: function toggleMultiSelect(_ref) {
-      var currentTarget = _ref.currentTarget;
-
+    toggleMultiSelect: function toggleMultiSelect({ currentTarget }) {
       this._showMulti = !this._showMulti;
       if (this._showMulti) {
         $(currentTarget).next().html(this.weekText);
@@ -548,9 +552,7 @@ define('crm/Views/Calendar/CalendarView', ['module', 'exports', 'argos/Convert',
       $(this.eventContentNode).empty();
       this.changeDayActivities();
     },
-    _buildQueryExpression: function _buildQueryExpression() {
-      var queryParam = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-
+    _buildQueryExpression: function _buildQueryExpression(queryParam = {}) {
       return _lang2.default.mixin(queryParam || {}, this.options && (this.options.query || this.options.where));
     },
     transitionAway: function transitionAway() {

--- a/src-out/Views/Calendar/DayView.js
+++ b/src-out/Views/Calendar/DayView.js
@@ -57,10 +57,10 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('calendarDayView');
-  var dtFormatResource = (0, _I18n2.default)('calendarDayViewDateTimeFormat');
+  const resource = (0, _I18n2.default)('calendarDayView');
+  const dtFormatResource = (0, _I18n2.default)('calendarDayViewDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Calendar.DayView', [_List2.default, _LegacySDataListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Calendar.DayView', [_List2.default, _LegacySDataListMixin3.default], {
     // Localization
     titleText: resource.titleText,
     eventDateFormatText: dtFormatResource.eventDateFormatText,
@@ -152,12 +152,12 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
       this.currentDate = moment().startOf('day');
     },
     toggleGroup: function toggleGroup(params) {
-      var node = params.$source;
+      const node = params.$source;
       if (node && node.parentNode) {
         $(node).toggleClass('collapsed');
         $(node.parentNode).toggleClass('collapsed-event');
 
-        var button = this.collapseButton;
+        const button = this.collapseButton;
 
         if (button) {
           $(button).toggleClass(this.toggleCollapseClass);
@@ -178,7 +178,7 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
       this.requestEventData();
     },
     requestEventData: function requestEventData() {
-      var request = this.createEventRequest();
+      const request = this.createEventRequest();
       request.read({
         success: this.onRequestEventDataSuccess,
         failure: this.onRequestEventDataFailure,
@@ -197,20 +197,20 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
       this.processEventFeed(feed);
     },
     createEventRequest: function createEventRequest() {
-      var eventSelect = this.eventQuerySelect;
-      var eventWhere = this.getEventQuery();
-      var request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setCount(this.eventPageSize).setStartIndex(1).setResourceKind('events').setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.expandExpression(eventSelect).join(',')).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Where, eventWhere);
+      const eventSelect = this.eventQuerySelect;
+      const eventWhere = this.getEventQuery();
+      const request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setCount(this.eventPageSize).setStartIndex(1).setResourceKind('events').setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.expandExpression(eventSelect).join(',')).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Where, eventWhere);
       return request;
     },
     getEventQuery: function getEventQuery() {
       return _string2.default.substitute(['UserId eq "${0}" and (', '(StartDate gt @${1}@ or EndDate gt @${1}@) and ', 'StartDate lt @${2}@', ')'].join(''), [App.context.user && App.context.user.$key, _Convert2.default.toIsoStringFromDate(this.currentDate.clone().startOf('day').toDate()), _Convert2.default.toIsoStringFromDate(this.currentDate.clone().endOf('day').toDate())]);
     },
     activateEventMore: function activateEventMore() {
-      var view = App.getView('event_related');
+      const view = App.getView('event_related');
       if (view) {
-        var where = this.getEventQuery();
+        const where = this.getEventQuery();
         view.show({
-          where: where
+          where
         });
       }
     },
@@ -221,9 +221,9 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
       $(this.eventContainerNode).removeClass('event-hidden');
     },
     processEventFeed: function processEventFeed(feed) {
-      var r = feed.$resources;
-      var feedLength = r.length;
-      var o = [];
+      const r = feed.$resources;
+      const feedLength = r.length;
+      const o = [];
       this.eventFeed = feed;
 
       if (feedLength === 0) {
@@ -232,8 +232,8 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
       }
       this.showEventList();
 
-      for (var i = 0; i < feedLength; i++) {
-        var row = r[i];
+      for (let i = 0; i < feedLength; i++) {
+        const row = r[i];
         row.isEvent = true;
         this.entries[row.$key] = row;
         o.push(this.eventRowTemplate.apply(row, this));
@@ -250,13 +250,13 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
       this.set('eventListContent', o.join(''));
     },
     processFeed: function processFeed(feed) {
-      var r = feed.$resources;
-      var feedLength = r.length;
-      var o = [];
+      const r = feed.$resources;
+      const feedLength = r.length;
+      const o = [];
 
       this.feed = feed;
-      for (var i = 0; i < feedLength; i++) {
-        var row = r[i];
+      for (let i = 0; i < feedLength; i++) {
+        const row = r[i];
         row.isEvent = false;
         this.entries[row.$key] = row;
         o.push(this.rowTemplate.apply(row, this));
@@ -289,7 +289,7 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
         this.processShowOptions(options);
       }
 
-      var theOptions = options || {};
+      const theOptions = options || {};
       theOptions.where = this.formatQueryForActivities();
 
       this.set('dateContent', this.currentDate.format(this.dateHeaderFormatText));
@@ -337,21 +337,21 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
       this.refresh();
     },
     formatQueryForActivities: function formatQueryForActivities() {
-      var queryWhere = ['UserActivities.UserId eq "${0}" and Type ne "atLiterature" and (', '(Timeless eq false and StartDate between @${1}@ and @${2}@) or ', '(Timeless eq true and StartDate between @${3}@ and @${4}@))'].join('');
+      const queryWhere = ['UserActivities.UserId eq "${0}" and Type ne "atLiterature" and (', '(Timeless eq false and StartDate between @${1}@ and @${2}@) or ', '(Timeless eq true and StartDate between @${3}@ and @${4}@))'].join('');
 
-      var startDate = this.currentDate.clone().startOf('day').toDate();
-      var endDate = this.currentDate.clone().endOf('day').toDate();
+      const startDate = this.currentDate.clone().startOf('day').toDate();
+      const endDate = this.currentDate.clone().endOf('day').toDate();
 
       return _string2.default.substitute(queryWhere, [App.context.user && App.context.user.$key, _Convert2.default.toIsoStringFromDate(startDate), _Convert2.default.toIsoStringFromDate(endDate), this.currentDate.format('YYYY-MM-DDT00:00:00[Z]'), this.currentDate.format('YYYY-MM-DDT23:59:59[Z]')]);
     },
     selectEntry: function selectEntry(params) {
-      var row = $(params.$source).closest('[data-key]')[0];
-      var key = row ? row.getAttribute('data-key') : false;
+      const row = $(params.$source).closest('[data-key]')[0];
+      const key = row ? row.getAttribute('data-key') : false;
 
       this.navigateToDetailView(key);
     },
     selectDate: function selectDate() {
-      var options = {
+      const options = {
         date: this.currentDate,
         showTimePicker: false,
         timeless: false,
@@ -370,35 +370,35 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
           }]
         }
       };
-      var view = App.getView(this.datePickerView);
+      const view = App.getView(this.datePickerView);
       if (view) {
         view.show(options);
       }
     },
     selectDateSuccess: function selectDateSuccess() {
-      var view = App.getPrimaryActiveView();
+      const view = App.getPrimaryActiveView();
       this.currentDate = moment(view.getDateTime()).startOf('day');
       this.refresh();
       ReUI.back();
     },
     navigateToWeekView: function navigateToWeekView() {
-      var view = App.getView(this.weekView);
-      var navDate = this.currentDate ? this.currentDate : moment().startOf('day');
-      var options = {
+      const view = App.getView(this.weekView);
+      const navDate = this.currentDate ? this.currentDate : moment().startOf('day');
+      const options = {
         currentDate: navDate.valueOf()
       };
       view.show(options);
     },
     navigateToMonthView: function navigateToMonthView() {
-      var view = App.getView(this.monthView);
-      var navDate = this.currentDate ? this.currentDate : moment().startOf('day');
-      var options = {
+      const view = App.getView(this.monthView);
+      const navDate = this.currentDate ? this.currentDate : moment().startOf('day');
+      const options = {
         currentDate: navDate.valueOf()
       };
       view.show(options);
     },
     navigateToInsertView: function navigateToInsertView() {
-      var view = App.getView(this.insertView || this.editView);
+      const view = App.getView(this.insertView || this.editView);
 
       this.options.currentDate = this.currentDate.format('YYYY-MM-DD') || moment().startOf('day');
       if (view) {
@@ -411,15 +411,15 @@ define('crm/Views/Calendar/DayView', ['module', 'exports', 'dojo/_base/declare',
       }
     },
     navigateToDetailView: function navigateToDetailView(key, descriptor) {
-      var entry = this.entries[key];
-      var detailView = entry.isEvent ? this.eventDetailView : this.activityDetailView;
-      var view = App.getView(detailView);
+      const entry = this.entries[key];
+      const detailView = entry.isEvent ? this.eventDetailView : this.activityDetailView;
+      const view = App.getView(detailView);
 
-      var theDescriptor = entry.isEvent ? descriptor : entry.Description;
+      const theDescriptor = entry.isEvent ? descriptor : entry.Description;
       if (view) {
         view.show({
           title: theDescriptor,
-          key: key
+          key
         });
       }
     }

--- a/src-out/Views/Calendar/MonthView.js
+++ b/src-out/Views/Calendar/MonthView.js
@@ -42,24 +42,24 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
     };
   }
 
-  var resource = (0, _I18n2.default)('calendarMonthView'); /* Copyright 2017 Infor
-                                                            *
-                                                            * Licensed under the Apache License, Version 2.0 (the "License");
-                                                            * you may not use this file except in compliance with the License.
-                                                            * You may obtain a copy of the License at
-                                                            *
-                                                            *    http://www.apache.org/licenses/LICENSE-2.0
-                                                            *
-                                                            * Unless required by applicable law or agreed to in writing, software
-                                                            * distributed under the License is distributed on an "AS IS" BASIS,
-                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                            * See the License for the specific language governing permissions and
-                                                            * limitations under the License.
-                                                            */
+  const resource = (0, _I18n2.default)('calendarMonthView'); /* Copyright 2017 Infor
+                                                              *
+                                                              * Licensed under the Apache License, Version 2.0 (the "License");
+                                                              * you may not use this file except in compliance with the License.
+                                                              * You may obtain a copy of the License at
+                                                              *
+                                                              *    http://www.apache.org/licenses/LICENSE-2.0
+                                                              *
+                                                              * Unless required by applicable law or agreed to in writing, software
+                                                              * distributed under the License is distributed on an "AS IS" BASIS,
+                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                              * See the License for the specific language governing permissions and
+                                                              * limitations under the License.
+                                                              */
 
-  var dtFormatResource = (0, _I18n2.default)('calendarMonthViewDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('calendarMonthViewDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Calendar.MonthView', [_List2.default, _LegacySDataListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Calendar.MonthView', [_List2.default, _LegacySDataListMixin3.default], {
     // Localization
     titleText: resource.titleText,
     todayText: resource.todayText,
@@ -202,21 +202,21 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       this.navigateToDayView();
     },
     activateEventMore: function activateEventMore() {
-      var view = App.getView('event_related');
-      var where = this.getSelectedDateEventQuery();
+      const view = App.getView('event_related');
+      const where = this.getSelectedDateEventQuery();
       if (view) {
         view.show({
-          where: where
+          where
         });
       }
     },
     toggleGroup: function toggleGroup(params) {
-      var node = params.$source;
+      const node = params.$source;
       if (node && node.parentNode) {
         $(node).toggleClass('collapsed');
         $(node.parentNode).toggleClass('collapsed-event');
 
-        var button = this.collapseButton;
+        const button = this.collapseButton;
 
         if (button) {
           $(button).toggleClass(this.toggleCollapseClass);
@@ -242,7 +242,7 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       return this.currentDate.clone().endOf('month');
     },
     getTodayMonthActivities: function getTodayMonthActivities() {
-      var today = moment().startOf('day');
+      const today = moment().startOf('day');
 
       if (this.currentDate.format('YYYY-MM') === today.format('YYYY-MM')) {
         this.currentDate = today;
@@ -278,10 +278,10 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       this.cancelRequests(this.monthRequests);
       this.monthRequests = [];
 
-      var request = this.createRequest();
+      const request = this.createRequest();
       request.setContractName(this.contractName || 'system');
 
-      var xhr = request.read({
+      const xhr = request.read({
         success: this.onRequestDataSuccess,
         failure: this.onRequestDataFailure,
         aborted: this.onRequestDataAborted,
@@ -290,9 +290,9 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       this.monthRequests.push(xhr);
     },
     createEventRequest: function createEventRequest() {
-      var querySelect = this.eventQuerySelect;
-      var queryWhere = this.getEventQuery();
-      var request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setCount(this.pageSize).setStartIndex(1).setResourceKind('events').setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.expandExpression(querySelect).join(',')).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Where, queryWhere);
+      const querySelect = this.eventQuerySelect;
+      const queryWhere = this.getEventQuery();
+      const request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setCount(this.pageSize).setStartIndex(1).setResourceKind('events').setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.expandExpression(querySelect).join(',')).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Where, queryWhere);
 
       return request;
     },
@@ -300,8 +300,8 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       this.cancelRequests(this.monthEventRequests);
       this.monthEventRequests = [];
 
-      var request = this.createEventRequest();
-      var xhr = request.read({
+      const request = this.createEventRequest();
+      const xhr = request.read({
         success: this.onRequestEventDataSuccess,
         failure: this.onRequestEventDataFailure,
         aborted: this.onRequestEventDataAborted,
@@ -320,13 +320,13 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       this.processEventFeed(feed);
     },
     getActivityQuery: function getActivityQuery() {
-      var startDate = this.getFirstDayOfCurrentMonth();
-      var endDate = this.getLastDayOfCurrentMonth();
+      const startDate = this.getFirstDayOfCurrentMonth();
+      const endDate = this.getLastDayOfCurrentMonth();
       return _string2.default.substitute(['UserActivities.UserId eq "${0}" and Type ne "atLiterature" and (', '(Timeless eq false and StartDate', ' between @${1}@ and @${2}@) or ', '(Timeless eq true and StartDate', ' between @${3}@ and @${4}@))'].join(''), [App.context.user && App.context.user.$key, _Convert2.default.toIsoStringFromDate(startDate.toDate()), _Convert2.default.toIsoStringFromDate(endDate.toDate()), startDate.format('YYYY-MM-DDT00:00:00[Z]'), endDate.format('YYYY-MM-DDT23:59:59[Z]')]);
     },
     getEventQuery: function getEventQuery() {
-      var startDate = this.getFirstDayOfCurrentMonth();
-      var endDate = this.getLastDayOfCurrentMonth();
+      const startDate = this.getFirstDayOfCurrentMonth();
+      const endDate = this.getLastDayOfCurrentMonth();
       return _string2.default.substitute(['UserId eq "${0}" and (', '(StartDate gt @${1}@ or EndDate gt @${1}@) and ', 'StartDate lt @${2}@', ')'].join(''), [App.context.user && App.context.user.$key, _Convert2.default.toIsoStringFromDate(startDate.toDate()), _Convert2.default.toIsoStringFromDate(endDate.toDate())]);
     },
     processFeed: function processFeed(feed) {
@@ -334,11 +334,11 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
         return;
       }
 
-      var r = feed.$resources;
+      const r = feed.$resources;
       this.feed = feed;
 
-      for (var i = 0; i < r.length; i++) {
-        var row = r[i];
+      for (let i = 0; i < r.length; i++) {
+        const row = r[i];
 
         // Preserve the isEvent flag if we have an existing entry for it already,
         // the order of processFeed and processEventFeed is not predictable
@@ -346,14 +346,14 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
 
         this.entries[row.$key] = row;
 
-        var startDay = moment(_Convert2.default.toDateFromString(row.StartDate));
+        const startDay = moment(_Convert2.default.toDateFromString(row.StartDate));
         if (r[i].Timeless) {
           startDay.subtract({
             minutes: startDay.utcOffset()
           });
         }
 
-        var dateIndex = startDay.format('YYYY-MM-DD');
+        const dateIndex = startDay.format('YYYY-MM-DD');
         this.dateCounts[dateIndex] = this.dateCounts[dateIndex] ? this.dateCounts[dateIndex] + 1 : 1;
       }
 
@@ -364,22 +364,22 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
         return;
       }
 
-      var r = feed.$resources;
-      var feedLength = r.length;
+      const r = feed.$resources;
+      const feedLength = r.length;
       this.eventFeed = feed;
 
-      for (var i = 0; i < feedLength; i++) {
-        var row = r[i];
+      for (let i = 0; i < feedLength; i++) {
+        const row = r[i];
         // Preserve the isEvent flag if we have an existing entry for it already,
         // the order of processFeed and processEventFeed is not predictable
         row.isEvent = this.entries[row.$key] && this.entries[row.$key].isEvent;
         this.entries[row.$key] = row;
 
-        var startDay = moment(_Convert2.default.toDateFromString(row.StartDate));
-        var endDay = _Convert2.default.toDateFromString(row.EndDate);
+        const startDay = moment(_Convert2.default.toDateFromString(row.StartDate));
+        const endDay = _Convert2.default.toDateFromString(row.EndDate);
 
         while (startDay.valueOf() <= endDay.valueOf()) {
-          var dateIndex = startDay.format('YYYY-MM-DD');
+          const dateIndex = startDay.format('YYYY-MM-DD');
           this.dateCounts[dateIndex] = this.dateCounts[dateIndex] ? this.dateCounts[dateIndex] + 1 : 1;
           startDay.add({
             days: 1
@@ -391,23 +391,21 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
     },
 
     highlightActivities: function highlightActivities() {
-      var _this = this;
-
-      $('.old-calendar-day').each(function (i, node) {
-        var dataDate = $(node).attr('data-date');
-        if (!_this.dateCounts[dataDate]) {
+      $('.old-calendar-day').each((i, node) => {
+        const dataDate = $(node).attr('data-date');
+        if (!this.dateCounts[dataDate]) {
           return;
         }
 
         $(node).addClass('activeDay');
 
-        var countMarkup = _string2.default.substitute(_this.calendarActivityCountTemplate, [_this.dateCounts[dataDate]]);
-        var existingCount = $(node).children('div');
+        const countMarkup = _string2.default.substitute(this.calendarActivityCountTemplate, [this.dateCounts[dataDate]]);
+        const existingCount = $(node).children('div');
 
         if (existingCount.length > 0) {
           $(existingCount[0]).empty().append(countMarkup);
         } else {
-          $(node).prepend('<div>' + countMarkup + '</div>');
+          $(node).prepend(`<div>${countMarkup}</div>`);
         }
       }, this);
     },
@@ -436,7 +434,7 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
         return;
       }
 
-      requests.forEach(function (xhr) {
+      requests.forEach(xhr => {
         if (xhr) {
           // if request was fulfilled by offline storage, xhr will be undefined
           xhr.abort();
@@ -447,7 +445,7 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       this.cancelRequests(this.selectedDateRequests);
       this.selectedDateRequests = [];
 
-      var request = this.createSelectedDateRequest({
+      const request = this.createSelectedDateRequest({
         pageSize: this.activityPageSize,
         resourceKind: 'activities',
         contractName: 'system',
@@ -455,7 +453,7 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
         queryWhere: this.getSelectedDateActivityQuery()
       });
 
-      var xhr = request.read({
+      const xhr = request.read({
         success: this.onRequestSelectedDateActivityDataSuccess,
         failure: this.onRequestDataFailure,
         aborted: this.onRequestDataAborted,
@@ -467,7 +465,7 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       this.cancelRequests(this.selectedDateEventRequests);
       this.selectedDateEventRequests = [];
 
-      var request = this.createSelectedDateRequest({
+      const request = this.createSelectedDateRequest({
         pageSize: this.eventPageSize,
         resourceKind: 'events',
         contractName: 'dynamic',
@@ -475,7 +473,7 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
         queryWhere: this.getSelectedDateEventQuery()
       });
 
-      var xhr = request.read({
+      const xhr = request.read({
         success: this.onRequestSelectedDateEventDataSuccess,
         failure: this.onRequestDataFailure,
         aborted: this.onRequestDataAborted,
@@ -484,13 +482,13 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       this.selectedDateEventRequests.push(xhr);
     },
     createSelectedDateRequest: function createSelectedDateRequest(o) {
-      var request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setCount(o.pageSize).setStartIndex(1).setResourceKind(o.resourceKind).setContractName(o.contractName || App.defaultService.getContractName().text).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.OrderBy, o.queryOrderBy || this.queryOrderBy).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.expandExpression(o.querySelect).join(',')).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Where, o.queryWhere);
+      const request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setCount(o.pageSize).setStartIndex(1).setResourceKind(o.resourceKind).setContractName(o.contractName || App.defaultService.getContractName().text).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.OrderBy, o.queryOrderBy || this.queryOrderBy).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.expandExpression(o.querySelect).join(',')).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Where, o.queryWhere);
       return request;
     },
     getSelectedDateActivityQuery: function getSelectedDateActivityQuery() {
-      var activityQuery = ['UserActivities.UserId eq "${0}" and Type ne "atLiterature" and (', '(Timeless eq false and StartDate between @${1}@ and @${2}@) or ', '(Timeless eq true and StartDate between @${3}@ and @${4}@))'].join('');
+      const activityQuery = ['UserActivities.UserId eq "${0}" and Type ne "atLiterature" and (', '(Timeless eq false and StartDate between @${1}@ and @${2}@) or ', '(Timeless eq true and StartDate between @${3}@ and @${4}@))'].join('');
 
-      var results = _string2.default.substitute(activityQuery, [App.context.user && App.context.user.$key, _Convert2.default.toIsoStringFromDate(this.currentDate.toDate()), _Convert2.default.toIsoStringFromDate(this.currentDate.clone().endOf('day').toDate()), this.currentDate.format('YYYY-MM-DDT00:00:00[Z]'), this.currentDate.format('YYYY-MM-DDT23:59:59[Z]')]);
+      const results = _string2.default.substitute(activityQuery, [App.context.user && App.context.user.$key, _Convert2.default.toIsoStringFromDate(this.currentDate.toDate()), _Convert2.default.toIsoStringFromDate(this.currentDate.clone().endOf('day').toDate()), this.currentDate.format('YYYY-MM-DDT00:00:00[Z]'), this.currentDate.format('YYYY-MM-DDT23:59:59[Z]')]);
 
       return results;
     },
@@ -504,12 +502,12 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
 
       $(this.activityContainerNode).removeClass('list-loading');
 
-      var r = feed.$resources;
-      var feedLength = r.length;
-      var o = [];
+      const r = feed.$resources;
+      const feedLength = r.length;
+      const o = [];
 
-      for (var i = 0; i < feedLength; i++) {
-        var row = r[i];
+      for (let i = 0; i < feedLength; i++) {
+        const row = r[i];
         row.isEvent = false;
         this.entries[row.$key] = row;
         o.push(this.activityRowTemplate.apply(row, this));
@@ -535,9 +533,9 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
         return false;
       }
 
-      var r = feed.$resources;
-      var feedLength = r.length;
-      var o = [];
+      const r = feed.$resources;
+      const feedLength = r.length;
+      const o = [];
 
       this.eventFeed = feed;
 
@@ -547,8 +545,8 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       }
       this.showEventList();
 
-      for (var i = 0; i < feedLength; i++) {
-        var row = r[i];
+      for (let i = 0; i < feedLength; i++) {
+        const row = r[i];
         row.isEvent = true;
         this.entries[row.$key] = row;
         o.push(this.eventRowTemplate.apply(row, this));
@@ -566,28 +564,28 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
     },
 
     renderCalendar: function renderCalendar() {
-      var calHTML = [];
-      var startingDay = this.getFirstDayOfCurrentMonth().day();
-      var dayDate = this.currentDate.clone().startOf('month');
-      var monthLength = this.currentDate.daysInMonth();
-      var weekEnds = [0, 6];
-      var weekendClass = '';
-      var day = 1;
+      const calHTML = [];
+      const startingDay = this.getFirstDayOfCurrentMonth().day();
+      const dayDate = this.currentDate.clone().startOf('month');
+      const monthLength = this.currentDate.daysInMonth();
+      const weekEnds = [0, 6];
+      let weekendClass = '';
+      let day = 1;
 
       calHTML.push(this.calendarStartTemplate);
 
       calHTML.push(this.calendarWeekHeaderStartTemplate);
-      for (var i = 0; i <= 6; i++) {
+      for (let i = 0; i <= 6; i++) {
         calHTML.push(_string2.default.substitute(this.calendarWeekHeaderTemplate, [this.weekDaysShortText[i]]));
       }
       calHTML.push(this.calendarWeekHeaderEndTemplate);
 
       // Weeks
-      for (var _i = 0; _i <= 6; _i++) {
+      for (let i = 0; i <= 6; i++) {
         calHTML.push(this.calendarWeekStartTemplate);
         // Days
-        for (var j = 0; j <= 6; j++) {
-          if (day <= monthLength && (_i > 0 || j >= startingDay)) {
+        for (let j = 0; j <= 6; j++) {
+          if (day <= monthLength && (i > 0 || j >= startingDay)) {
             dayDate.date(day);
             weekendClass = weekEnds.indexOf(j) !== -1 ? ' weekend' : '';
             calHTML.push(_string2.default.substitute(this.calendarDayTemplate, [day, weekendClass, dayDate.format('YYYY-MM-DD')]));
@@ -627,7 +625,7 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       }
     },
     highlightCurrentDate: function highlightCurrentDate() {
-      var selectedDate = '.old-calendar-day[data-date=' + this.currentDate.format('YYYY-MM-DD') + ']';
+      const selectedDate = `.old-calendar-day[data-date=${this.currentDate.format('YYYY-MM-DD')}]`;
 
       if (this.selectedDateNode) {
         $(this.selectedDateNode).removeClass('selected');
@@ -644,27 +642,27 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
     highlightToday: function highlightToday() {
       // Remove the existing "today" highlight class because it might be out of date,
       // like when we tick past midnight.
-      var todayCls = '.old-calendar-day.today';
-      var todayNode = $(todayCls, this.contentNode)[0];
+      let todayCls = '.old-calendar-day.today';
+      let todayNode = $(todayCls, this.contentNode)[0];
       if (todayNode) {
         $(todayNode).removeClass('today');
       }
 
       // Get the updated "today"
-      todayCls = '.old-calendar-day[data-date=' + moment().format('YYYY-MM-DD') + ']';
+      todayCls = `.old-calendar-day[data-date=${moment().format('YYYY-MM-DD')}]`;
       todayNode = $(todayCls, this.contentNode)[0];
       if (todayNode) {
         $(todayNode).addClass('today');
       }
     },
     selectEntry: function selectEntry(params) {
-      var row = $(params.$source).closest('[data-key]')[0];
-      var key = row ? row.getAttribute('data-key') : false;
+      const row = $(params.$source).closest('[data-key]')[0];
+      const key = row ? row.getAttribute('data-key') : false;
 
       this.navigateToDetailView(key);
     },
     selectDate: function selectDate() {
-      var options = {
+      const options = {
         date: this.currentDate.toDate(),
         showTimePicker: false,
         timeless: false,
@@ -683,33 +681,33 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
           }]
         }
       };
-      var view = App.getView(this.datePickerView);
+      const view = App.getView(this.datePickerView);
       if (view) {
         view.show(options);
       }
     },
     selectDateSuccess: function selectDateSuccess() {
-      var view = App.getPrimaryActiveView();
+      const view = App.getPrimaryActiveView();
       this.currentDate = moment(view.getDateTime()).startOf('day');
       this.refresh();
       ReUI.back();
     },
     navigateToWeekView: function navigateToWeekView() {
-      var view = App.getView(this.weekView);
-      var options = {
+      const view = App.getView(this.weekView);
+      const options = {
         currentDate: this.currentDate.valueOf() || moment().startOf('day')
       };
       view.show(options);
     },
     navigateToDayView: function navigateToDayView() {
-      var view = App.getView(this.dayView);
-      var options = {
+      const view = App.getView(this.dayView);
+      const options = {
         currentDate: this.currentDate.valueOf() || moment().startOf('day')
       };
       view.show(options);
     },
     navigateToInsertView: function navigateToInsertView() {
-      var view = App.getView(this.insertView || this.editView);
+      const view = App.getView(this.insertView || this.editView);
 
       if (!this.options) {
         this.options = {};
@@ -726,15 +724,15 @@ define('crm/Views/Calendar/MonthView', ['module', 'exports', 'dojo/_base/declare
       }
     },
     navigateToDetailView: function navigateToDetailView(key, _descriptor) {
-      var descriptor = _descriptor;
-      var entry = this.entries[key];
-      var detailView = entry.isEvent ? this.eventDetailView : this.activityDetailView;
-      var view = App.getView(detailView);
+      let descriptor = _descriptor;
+      const entry = this.entries[key];
+      const detailView = entry.isEvent ? this.eventDetailView : this.activityDetailView;
+      const view = App.getView(detailView);
       descriptor = entry.isEvent ? descriptor : entry.Description;
       if (view) {
         view.show({
           title: descriptor,
-          key: key
+          key
         });
       }
     }

--- a/src-out/Views/Calendar/WeekView.js
+++ b/src-out/Views/Calendar/WeekView.js
@@ -57,10 +57,10 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('calendarWeekView');
-  var dtFormatResource = (0, _I18n2.default)('calendarWeekViewDateTimeFormat');
+  const resource = (0, _I18n2.default)('calendarWeekView');
+  const dtFormatResource = (0, _I18n2.default)('calendarWeekViewDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Calendar.WeekView', [_List2.default, _LegacySDataListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Calendar.WeekView', [_List2.default, _LegacySDataListMixin3.default], {
     // Localization
     titleText: resource.titleText,
     weekTitleFormatText: dtFormatResource.weekTitleFormatText,
@@ -162,12 +162,12 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       this.currentDate = this.todayDate.clone();
     },
     toggleGroup: function toggleGroup(params) {
-      var node = params.$source;
+      const node = params.$source;
       if (node && node.parentNode) {
         $(node).toggleClass('collapsed');
         $(node.parentNode).toggleClass('collapsed-event');
 
-        var button = this.collapseButton;
+        const button = this.collapseButton;
 
         if (button) {
           $(button).toggleClass(this.toggleCollapseClass);
@@ -204,16 +204,16 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       this.refresh();
     },
     setWeekQuery: function setWeekQuery() {
-      var setDate = this.currentDate || this.todayDate;
+      const setDate = this.currentDate || this.todayDate;
       this.weekStartDate = this.getStartDay(setDate);
       this.weekEndDate = this.getEndDay(setDate);
       this.queryWhere = _string2.default.substitute(['UserActivities.UserId eq "${0}" and Type ne "atLiterature" and (', '(Timeless eq false and StartDate between @${1}@ and @${2}@) or ', '(Timeless eq true and StartDate between @${3}@ and @${4}@))'].join(''), [App.context.user && App.context.user.$key, _Convert2.default.toIsoStringFromDate(this.weekStartDate.toDate()), _Convert2.default.toIsoStringFromDate(this.weekEndDate.toDate()), this.weekStartDate.format('YYYY-MM-DDT00:00:00[Z]'), this.weekEndDate.format('YYYY-MM-DDT23:59:59[Z]')]);
     },
     setWeekTitle: function setWeekTitle() {
-      var start = this.getStartDay(this.currentDate);
-      var end = this.getEndDay(this.currentDate);
+      const start = this.getStartDay(this.currentDate);
+      const end = this.getEndDay(this.currentDate);
 
-      this.set('dateContent', start.format(this.weekTitleFormatText) + '-' + end.format(this.weekTitleFormatText));
+      this.set('dateContent', `${start.format(this.weekTitleFormatText)}-${end.format(this.weekTitleFormatText)}`);
     },
     isInCurrentWeek: function isInCurrentWeek(date) {
       return date.valueOf() > this.weekStartDate.valueOf() && date.valueOf() < this.weekEndDate.valueOf();
@@ -221,12 +221,12 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
     processFeed: function processFeed(feed) {
       this.feed = feed;
 
-      var todayNode = this.addTodayDom();
-      var entryGroups = this.entryGroups;
-      var feedLength = feed.$resources.length;
-      var entryOrder = [];
-      var dateCompareString = 'YYYY-MM-DD';
-      var o = [];
+      const todayNode = this.addTodayDom();
+      const entryGroups = this.entryGroups;
+      const feedLength = feed.$resources.length;
+      const entryOrder = [];
+      const dateCompareString = 'YYYY-MM-DD';
+      const o = [];
       this.set('listContent', '');
 
       // If we fetched a page that has no data due to un-reliable counts,
@@ -238,9 +238,9 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
           entryGroups[this.todayDate.format(dateCompareString)] = [todayNode];
         }
 
-        for (var i = 0; i < feed.$resources.length; i++) {
-          var currentEntry = feed.$resources[i];
-          var startDate = _Convert2.default.toDateFromString(currentEntry.StartDate);
+        for (let i = 0; i < feed.$resources.length; i++) {
+          const currentEntry = feed.$resources[i];
+          let startDate = _Convert2.default.toDateFromString(currentEntry.StartDate);
           if (currentEntry.Timeless) {
             startDate = this.dateToUTC(startDate);
           }
@@ -248,8 +248,8 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
           currentEntry.isEvent = false;
           this.entries[currentEntry.$key] = currentEntry;
 
-          var currentDateCompareKey = moment(currentEntry.StartDate).format(dateCompareString);
-          var currentGroup = entryGroups[currentDateCompareKey];
+          const currentDateCompareKey = moment(currentEntry.StartDate).format(dateCompareString);
+          let currentGroup = entryGroups[currentDateCompareKey];
           if (currentGroup) {
             if (currentEntry.Timeless) {
               currentGroup.splice(1, 0, this.rowTemplate.apply(currentEntry, this));
@@ -263,13 +263,13 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
           entryGroups[currentDateCompareKey] = currentGroup;
         }
 
-        for (var entryGroup in entryGroups) {
+        for (const entryGroup in entryGroups) {
           if (entryGroups.hasOwnProperty(entryGroup)) {
             entryOrder.push(moment(entryGroup, dateCompareString));
           }
         }
 
-        entryOrder.sort(function (a, b) {
+        entryOrder.sort((a, b) => {
           if (a.valueOf() < b.valueOf()) {
             return 1;
           } else if (a.valueOf() > b.valueOf()) {
@@ -279,9 +279,9 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
           return 0;
         });
 
-        var entryOrderLength = entryOrder.length;
-        for (var _i = 0; _i < entryOrderLength; _i++) {
-          o.push(entryGroups[entryOrder[_i].format(dateCompareString)].join('') + this.groupEndTemplate.apply(this));
+        const entryOrderLength = entryOrder.length;
+        for (let i = 0; i < entryOrderLength; i++) {
+          o.push(entryGroups[entryOrder[i].format(dateCompareString)].join('') + this.groupEndTemplate.apply(this));
         }
 
         if (o.length > 0) {
@@ -299,7 +299,7 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
         return null;
       }
 
-      var todayEntry = {
+      const todayEntry = {
         StartDate: this.todayDate.toDate(),
         headerClass: 'currentDate'
       };
@@ -310,7 +310,7 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds());
     },
     requestEventData: function requestEventData() {
-      var request = this.createEventRequest();
+      const request = this.createEventRequest();
       request.read({
         success: this.onRequestEventDataSuccess,
         failure: this.onRequestEventDataFailure,
@@ -329,14 +329,14 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       this.processEventFeed(feed);
     },
     createEventRequest: function createEventRequest() {
-      var querySelect = this.eventQuerySelect;
-      var queryWhere = this.getEventQuery();
-      var request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setCount(this.eventPageSize).setStartIndex(1).setResourceKind('events').setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.expandExpression(querySelect).join(',')).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Where, queryWhere);
+      const querySelect = this.eventQuerySelect;
+      const queryWhere = this.getEventQuery();
+      const request = new Sage.SData.Client.SDataResourceCollectionRequest(this.getService()).setCount(this.eventPageSize).setStartIndex(1).setResourceKind('events').setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Select, this.expandExpression(querySelect).join(',')).setQueryArg(Sage.SData.Client.SDataUri.QueryArgNames.Where, queryWhere);
       return request;
     },
     getEventQuery: function getEventQuery() {
-      var startDate = this.weekStartDate;
-      var endDate = this.weekEndDate;
+      const startDate = this.weekStartDate;
+      const endDate = this.weekEndDate;
       return _string2.default.substitute(['UserId eq "${0}" and (', '(StartDate gt @${1}@ or EndDate gt @${1}@) and ', 'StartDate lt @${2}@', ')'].join(''), [App.context.user && App.context.user.$key, startDate.format('YYYY-MM-DDT00:00:00[Z]'), endDate.format('YYYY-MM-DDT23:59:59[Z]')]);
     },
     hideEventList: function hideEventList() {
@@ -346,8 +346,8 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       $(this.eventContainerNode).removeClass('event-hidden');
     },
     processEventFeed: function processEventFeed(feed) {
-      var o = [];
-      var feedLength = feed.$resources.length;
+      const o = [];
+      const feedLength = feed.$resources.length;
 
       if (feedLength === 0) {
         this.hideEventList();
@@ -356,8 +356,8 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
 
       this.showEventList();
 
-      for (var i = 0; i < feedLength; i++) {
-        var event = feed.$resources[i];
+      for (let i = 0; i < feedLength; i++) {
+        const event = feed.$resources[i];
         event.isEvent = true;
         event.StartDate = moment(_Convert2.default.toDateFromString(event.StartDate));
         event.EndDate = moment(_Convert2.default.toDateFromString(event.EndDate));
@@ -376,7 +376,7 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       this.set('eventListContent', o.join(''));
     },
     refresh: function refresh() {
-      var startDate = this.currentDate.clone();
+      const startDate = this.currentDate.clone();
       this.currentDate = startDate.clone();
       this.weekStartDate = this.getStartDay(startDate);
       this.weekEndDate = this.getEndDay(startDate);
@@ -401,11 +401,11 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     activateEventMore: function activateEventMore() {
-      var view = App.getView('event_related');
-      var where = this.getEventQuery();
+      const view = App.getView('event_related');
+      const where = this.getEventQuery();
       if (view) {
         view.show({
-          where: where
+          where
         });
       }
     },
@@ -416,13 +416,13 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       this.set('listContent', this.loadingTemplate.apply(this));
     },
     selectEntry: function selectEntry(params) {
-      var row = $(params.$source).closest('[data-key]')[0];
-      var key = row ? row.getAttribute('data-key') : false;
+      const row = $(params.$source).closest('[data-key]')[0];
+      const key = row ? row.getAttribute('data-key') : false;
 
       this.navigateToDetailView(key);
     },
     selectDate: function selectDate() {
-      var options = {
+      const options = {
         date: this.currentDate.toDate(),
         showTimePicker: false,
         timeless: false,
@@ -441,33 +441,33 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
           }]
         }
       };
-      var view = App.getView(this.datePickerView);
+      const view = App.getView(this.datePickerView);
       if (view) {
         view.show(options);
       }
     },
     selectDateSuccess: function selectDateSuccess() {
-      var view = App.getPrimaryActiveView();
+      const view = App.getPrimaryActiveView();
       this.currentDate = moment(view.getDateTime()).startOf('day');
       this.refresh();
       ReUI.back();
     },
     navigateToDayView: function navigateToDayView() {
-      var view = App.getView(this.activityListView);
-      var options = {
+      const view = App.getView(this.activityListView);
+      const options = {
         currentDate: this.currentDate.toDate().valueOf() || moment().startOf('day').valueOf()
       };
       view.show(options);
     },
     navigateToMonthView: function navigateToMonthView() {
-      var view = App.getView(this.monthView);
-      var options = {
+      const view = App.getView(this.monthView);
+      const options = {
         currentDate: this.currentDate.toDate().valueOf() || moment().startOf('day').valueOf()
       };
       view.show(options);
     },
     navigateToInsertView: function navigateToInsertView() {
-      var view = App.getView(this.insertView || this.editView);
+      const view = App.getView(this.insertView || this.editView);
 
       this.options.currentDate = this.currentDate.format('YYYY-MM-DD') || moment().startOf('day');
       if (view) {
@@ -480,16 +480,16 @@ define('crm/Views/Calendar/WeekView', ['module', 'exports', 'dojo/_base/declare'
       }
     },
     navigateToDetailView: function navigateToDetailView(key, descriptor) {
-      var entry = this.entries[key];
-      var detailView = entry.isEvent ? this.eventDetailView : this.activityDetailView;
-      var view = App.getView(detailView);
+      const entry = this.entries[key];
+      const detailView = entry.isEvent ? this.eventDetailView : this.activityDetailView;
+      const view = App.getView(detailView);
 
-      var theDescriptor = entry.isEvent ? descriptor : entry.Description;
+      const theDescriptor = entry.isEvent ? descriptor : entry.Description;
 
       if (view) {
         view.show({
           title: theDescriptor,
-          key: key
+          key
         });
       }
     }

--- a/src-out/Views/Charts/GenericBar.js
+++ b/src-out/Views/Charts/GenericBar.js
@@ -26,7 +26,7 @@ define('crm/Views/Charts/GenericBar', ['module', 'exports', 'dojo/_base/declare'
    * @mixes module:crm/Views/Charts/_ChartMixin
    *
    */
-  var __class = (0, _declare2.default)('crm.Views.Charts.GenericBar', [_View2.default, _ChartMixin3.default], /** @lends module:crm/Views/Charts/GenericBar.prototype */{
+  const __class = (0, _declare2.default)('crm.Views.Charts.GenericBar', [_View2.default, _ChartMixin3.default], /** @lends module:crm/Views/Charts/GenericBar.prototype */{
     id: 'chart_generic_bar',
     titleText: '',
     expose: false,
@@ -57,14 +57,14 @@ define('crm/Views/Charts/GenericBar', ['module', 'exports', 'dojo/_base/declare'
 
       this.showSearchExpression();
 
-      var labels = [];
-      var seriesData = _array2.default.map(rawData, function (item) {
+      const labels = [];
+      const seriesData = _array2.default.map(rawData, item => {
         labels.push(item.$descriptor);
         return Math.round(item.value);
       });
 
-      var data = {
-        labels: labels,
+      const data = {
+        labels,
         datasets: [{
           label: 'Default',
           fillColor: this.barColor,
@@ -76,11 +76,11 @@ define('crm/Views/Charts/GenericBar', ['module', 'exports', 'dojo/_base/declare'
         this.chart.destroy();
       }
 
-      var box = _domGeometry2.default.getMarginBox(this.domNode);
+      const box = _domGeometry2.default.getMarginBox(this.domNode);
       this.contentNode.width = box.w;
       this.contentNode.height = box.h;
 
-      var ctx = this.contentNode.getContext('2d');
+      const ctx = this.contentNode.getContext('2d');
 
       this.chart = new window.Chart(ctx).Bar(data, this.chartOptions); // eslint-disable-line
     }

--- a/src-out/Views/Charts/GenericLine.js
+++ b/src-out/Views/Charts/GenericLine.js
@@ -27,7 +27,7 @@ define('crm/Views/Charts/GenericLine', ['module', 'exports', 'dojo/_base/declare
    * @mixes module:crm/Views/Charts/_ChartMixin
    *
    */
-  var __class = (0, _declare2.default)('crm.Views.Charts.GenericLine', [_View2.default, _ChartMixin3.default], /** @lends module:crm/Views/Charts/GenericLine.prototype */{
+  const __class = (0, _declare2.default)('crm.Views.Charts.GenericLine', [_View2.default, _ChartMixin3.default], /** @lends module:crm/Views/Charts/GenericLine.prototype */{
     id: 'chart_generic_line',
     titleText: '',
     expose: false,
@@ -60,14 +60,14 @@ define('crm/Views/Charts/GenericLine', ['module', 'exports', 'dojo/_base/declare
 
       this.showSearchExpression();
 
-      var labels = [];
-      var seriesData = _array2.default.map(rawData, function (item) {
+      const labels = [];
+      const seriesData = _array2.default.map(rawData, item => {
         labels.push(item.$descriptor);
         return Math.round(item.value);
       });
 
-      var data = {
-        labels: labels,
+      const data = {
+        labels,
         datasets: [{
           label: 'Default',
           strokeColor: this.lineColor,
@@ -81,11 +81,11 @@ define('crm/Views/Charts/GenericLine', ['module', 'exports', 'dojo/_base/declare
         this.chart.destroy();
       }
 
-      var box = _domGeometry2.default.getMarginBox(this.domNode);
+      const box = _domGeometry2.default.getMarginBox(this.domNode);
       this.contentNode.width = box.w;
       this.contentNode.height = box.h;
 
-      var ctx = this.contentNode.getContext('2d');
+      const ctx = this.contentNode.getContext('2d');
 
       this.chart = new window.Chart(ctx).Line(data, this.chartOptions); // eslint-disable-line
     }

--- a/src-out/Views/Charts/GenericPie.js
+++ b/src-out/Views/Charts/GenericPie.js
@@ -27,7 +27,7 @@ define('crm/Views/Charts/GenericPie', ['module', 'exports', 'dojo/_base/declare'
    * @mixes module:crm/Views/Charts/_ChartMixin
    *
    */
-  var __class = (0, _declare2.default)('crm.Views.Charts.GenericPie', [_View2.default, _ChartMixin3.default], /** @lends module:crm/Views/Charts/GenericPie.prototype */{
+  const __class = (0, _declare2.default)('crm.Views.Charts.GenericPie', [_View2.default, _ChartMixin3.default], /** @lends module:crm/Views/Charts/GenericPie.prototype */{
     id: 'chart_generic_pie',
     titleText: '',
     expose: false,
@@ -54,18 +54,16 @@ define('crm/Views/Charts/GenericPie', ['module', 'exports', 'dojo/_base/declare'
     },
 
     createChart: function createChart(rawData) {
-      var _this = this;
-
       this.inherited(createChart, arguments);
 
-      var defaultRenderAs = 'Doughnut';
+      const defaultRenderAs = 'Doughnut';
 
       this.showSearchExpression();
 
-      var data = _array2.default.map(rawData, function (item, idx) {
+      const data = _array2.default.map(rawData, (item, idx) => {
         return {
           value: Math.round(item.value),
-          color: _this._getItemColor(idx),
+          color: this._getItemColor(idx),
           highlight: '',
           label: item.name
         };
@@ -75,13 +73,13 @@ define('crm/Views/Charts/GenericPie', ['module', 'exports', 'dojo/_base/declare'
         this.chart.destroy();
       }
 
-      var box = _domGeometry2.default.getMarginBox(this.domNode);
+      const box = _domGeometry2.default.getMarginBox(this.domNode);
       this.contentNode.width = box.w;
       this.contentNode.height = box.h;
 
-      var ctx = this.contentNode.getContext('2d');
+      const ctx = this.contentNode.getContext('2d');
 
-      var chart = new window.Chart(ctx);
+      const chart = new window.Chart(ctx);
 
       // Ensure the chart has the ability to render this type
       this.renderAs = window.Chart.types.hasOwnProperty(this.renderAs) ? this.renderAs : defaultRenderAs;
@@ -90,9 +88,9 @@ define('crm/Views/Charts/GenericPie', ['module', 'exports', 'dojo/_base/declare'
       this.showLegend();
     },
     _getItemColor: function _getItemColor(index) {
-      var len = this.seriesColors.length;
-      var n = Math.floor(index / len);
-      var theIndex = index;
+      const len = this.seriesColors.length;
+      const n = Math.floor(index / len);
+      let theIndex = index;
 
       // if n is 0, the index will fall within the seriesColor array,
       // otherwise we will need to re-scale the index to fall within that array.

--- a/src-out/Views/Charts/_ChartMixin.js
+++ b/src-out/Views/Charts/_ChartMixin.js
@@ -43,7 +43,7 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
   /**
    * @module crm/Views/Charts/_ChartMixin
    */
-  var resource = (0, _I18n2.default)('chartMixin');
+  const resource = (0, _I18n2.default)('chartMixin');
 
   _lang2.default.setObject('Chart.defaults.global', {
     // Boolean - Whether to animate the chart
@@ -156,8 +156,8 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
     // tooltipTemplate can be a function as well (not in the docs, see Chart.Core.js in their repo)
     tooltipTemplate: function tooltipTemplate(valuesObject) {
       // Use the formatter on the chart view, otherwise default to label: value
-      var view = App.getPrimaryActiveView();
-      var results = void 0;
+      const view = App.getPrimaryActiveView();
+      let results;
       if (view && view.formatter) {
         results = view.formatter(valuesObject.value);
       } else {
@@ -185,7 +185,7 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
    * @classdesc Base mixin for creating chart views.
    *
    */
-  var __class = (0, _declare2.default)('crm.Views.Charts._ChartMixin', [_PullToRefreshMixin3.default], /** @lends module:crm/Views/Charts/_ChartMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views.Charts._ChartMixin', [_PullToRefreshMixin3.default], /** @lends module:crm/Views/Charts/_ChartMixin.prototype */{
     _feedData: null,
 
     /**
@@ -227,14 +227,12 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
       this.initPullToRefresh(this.scrollerNode);
     },
     onTransitionTo: function onTransitionTo() {
-      var _this = this;
-
       // Render fn is debounced to prevent too many calls as a user resizes, or
       // if it fires multiple times (onresize fires on desktop browsers with /app/setOrientation)
       // Some browsers do not fire window onResize for orientation changes.
-      var _renderFn = _Utility2.default.debounce(function () {
-        if (_this._feedData) {
-          _this.createChart(_this._feedData);
+      const _renderFn = _Utility2.default.debounce(() => {
+        if (this._feedData) {
+          this.createChart(this._feedData);
         }
       }, this.RENDER_DELAY);
 
@@ -255,15 +253,15 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
       $(window).off('applicationmenuopen.chart');
     },
     _setCanvasWidth: function _setCanvasWidth() {
-      var box = _domGeometry2.default.getMarginBox(this.domNode);
+      const box = _domGeometry2.default.getMarginBox(this.domNode);
       if (this.contentNode) {
         this.contentNode.width = box.w;
       }
     },
     _drawLoading: function _drawLoading() {
-      var node = this.contentNode;
-      var globalConfig = window.Chart.defaults.global;
-      var context = node && node.getContext && node.getContext('2d');
+      const node = this.contentNode;
+      const globalConfig = window.Chart.defaults.global;
+      const context = node && node.getContext && node.getContext('2d');
 
       if (!context) {
         return;
@@ -271,15 +269,15 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
 
       context.clearRect(0, 0, node.width, node.height);
 
-      var text = resource.loadingText;
+      const text = resource.loadingText;
 
       context.fillStyle = this.loadingFont;
-      context.font = globalConfig.tooltipFontSize + 'px ' + globalConfig.tooltipFontFamily;
+      context.font = `${globalConfig.tooltipFontSize}px ${globalConfig.tooltipFontFamily}`;
 
       // Center the text
-      var offset = Math.floor(context.measureText(text).width / 2);
-      var x = Math.floor(node.width / 2) - offset;
-      var y = 20; // padding
+      const offset = Math.floor(context.measureText(text).width / 2);
+      const x = Math.floor(node.width / 2) - offset;
+      const y = 20; // padding
       context.fillText(text, x, y, node.width);
     },
     createChart: function createChart(feedData) {
@@ -294,7 +292,7 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
     },
 
     showSearchExpression: function showSearchExpression() {
-      var app = this.app || window.App;
+      const app = this.app || window.App;
       app.setPrimaryTitle([this.title, this.getSearchExpression()].join(': '));
     },
 
@@ -317,8 +315,8 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
         return;
       }
 
-      var src = evt.srcElement.tagName === 'SPAN' ? evt.srcElement.parentElement : evt.srcElement;
-      var segment = parseInt(src.dataset.segment, 10);
+      const src = evt.srcElement.tagName === 'SPAN' ? evt.srcElement.parentElement : evt.srcElement;
+      const segment = parseInt(src.dataset.segment, 10);
       if (segment >= 0 && this.chart.showTooltip && this.chart.segments) {
         this.chart.showTooltip(this.chart.segments.slice(segment, segment + 1), false /* re-draw flag */);
       }
@@ -333,7 +331,7 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
         return;
       }
 
-      var html = this.chart.generateLegend();
+      const html = this.chart.generateLegend();
       _domAttr2.default.set(this.legendNode, {
         innerHTML: html
       });
@@ -344,7 +342,7 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
      * Charts in 3.3 no longer use the search expression node.
      */
     getSearchExpressionHeight: function getSearchExpressionHeight() {
-      var box = _domGeometry2.default.getMarginBox(this.searchExpressionNode);
+      const box = _domGeometry2.default.getMarginBox(this.searchExpressionNode);
       return box.h;
     },
 
@@ -362,7 +360,7 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
      * @since 3.3
      */
     createStore: function createStore() {
-      var store = this.parent && this.parent.store;
+      const store = this.parent && this.parent.store;
       return store;
     },
 
@@ -371,9 +369,7 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
      * @since 3.3
      */
     requestData: function requestData() {
-      var _this2 = this;
-
-      var store = this.get('store');
+      const store = this.get('store');
       if (this.chart && this.chart.destroy) {
         this.chart.destroy();
       }
@@ -385,9 +381,9 @@ define('crm/Views/Charts/_ChartMixin', ['module', 'exports', 'dojo/_base/declare
         store.query(null, {
           start: 0,
           count: this.PAGE_SIZE
-        }).then(function (data) {
-          _this2.createChart(data);
-        }, function (e) {
+        }).then(data => {
+          this.createChart(data);
+        }, e => {
           console.error(e); // eslint-disable-line
         });
       }

--- a/src-out/Views/Competitor/List.js
+++ b/src-out/Views/Competitor/List.js
@@ -15,22 +15,22 @@ define('crm/Views/Competitor/List', ['module', 'exports', 'dojo/_base/declare', 
     };
   }
 
-  var resource = (0, _I18n2.default)('competitorList'); /* Copyright 2017 Infor
-                                                         *
-                                                         * Licensed under the Apache License, Version 2.0 (the "License");
-                                                         * you may not use this file except in compliance with the License.
-                                                         * You may obtain a copy of the License at
-                                                         *
-                                                         *    http://www.apache.org/licenses/LICENSE-2.0
-                                                         *
-                                                         * Unless required by applicable law or agreed to in writing, software
-                                                         * distributed under the License is distributed on an "AS IS" BASIS,
-                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                         * See the License for the specific language governing permissions and
-                                                         * limitations under the License.
-                                                         */
+  const resource = (0, _I18n2.default)('competitorList'); /* Copyright 2017 Infor
+                                                           *
+                                                           * Licensed under the Apache License, Version 2.0 (the "License");
+                                                           * you may not use this file except in compliance with the License.
+                                                           * You may obtain a copy of the License at
+                                                           *
+                                                           *    http://www.apache.org/licenses/LICENSE-2.0
+                                                           *
+                                                           * Unless required by applicable law or agreed to in writing, software
+                                                           * distributed under the License is distributed on an "AS IS" BASIS,
+                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                           * See the License for the specific language governing permissions and
+                                                           * limitations under the License.
+                                                           */
 
-  var __class = (0, _declare2.default)('crm.Views.Competitor.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Competitor.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%= $.CompetitorName %}</p>', '{% if ($.WebAddress) { %}<p class="micro-text">{%= $.WebAddress %}</p>{% } %}']),
 
@@ -47,8 +47,8 @@ define('crm/Views/Competitor/List', ['module', 'exports', 'dojo/_base/declare', 
     resourceKind: 'competitors',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery);
-      return '(CompetitorName like "%' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery);
+      return `(CompetitorName like "%${q}%")`;
     }
   });
 

--- a/src-out/Views/Configure.js
+++ b/src-out/Views/Configure.js
@@ -32,9 +32,9 @@ define('crm/Views/Configure', ['module', 'exports', 'dojo/_base/declare', 'dojo/
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('configure');
+  const resource = (0, _I18n2.default)('configure');
 
-  var __class = (0, _declare2.default)('crm.Views.Configure', [_ConfigureBase3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Configure', [_ConfigureBase3.default], {
     // Localization
     titleText: resource.titleText,
 
@@ -53,19 +53,19 @@ define('crm/Views/Configure', ['module', 'exports', 'dojo/_base/declare', 'dojo/
       App.persistPreferences();
 
       ReUI.back();
-      var view = App.getView('left_drawer');
+      const view = App.getView('left_drawer');
       if (view) {
         view.refresh();
       }
     },
     createStore: function createStore() {
-      var exposed = App.getExposedViews();
-      var order = this.getSavedOrderedKeys();
-      var list = [];
+      const exposed = App.getExposedViews();
+      const order = this.getSavedOrderedKeys();
+      let list = [];
 
       // De-dup id's
-      var all = order.concat(exposed);
-      var reduced = all.reduce(function (previous, current) {
+      const all = order.concat(exposed);
+      let reduced = all.reduce((previous, current) => {
         if (previous.indexOf(current) === -1) {
           previous.push(current);
         }
@@ -74,13 +74,13 @@ define('crm/Views/Configure', ['module', 'exports', 'dojo/_base/declare', 'dojo/
       }, []);
 
       // The order array could have had stale id's, filter out valid views here
-      reduced = reduced.filter(function (key) {
-        var view = App.getView(key);
+      reduced = reduced.filter(key => {
+        const view = App.getView(key);
         return view && typeof view.getSecurity === 'function' && App.hasAccessTo(view.getSecurity()) && exposed.indexOf(key) !== -1;
       });
 
-      list = reduced.map(function (key) {
-        var view = App.getView(key);
+      list = reduced.map(key => {
+        const view = App.getView(key);
         return {
           $key: view.id,
           $descriptor: view.titleText,

--- a/src-out/Views/Contact/Detail.js
+++ b/src-out/Views/Contact/Detail.js
@@ -40,9 +40,9 @@ define('crm/Views/Contact/Detail', ['module', 'exports', 'dojo/_base/declare', '
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('contactDetail');
+  const resource = (0, _I18n2.default)('contactDetail');
 
-  var __class = (0, _declare2.default)('crm.Views.Contact.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Contact.Detail', [_Detail2.default], {
     // Localization
     accountText: resource.accountText,
     acctMgrText: resource.acctMgrText,
@@ -93,7 +93,7 @@ define('crm/Views/Contact/Detail', ['module', 'exports', 'dojo/_base/declare', '
       _Action2.default.navigateToHistoryInsert(entry);
     },
     recordCallToHistory: function recordCallToHistory(phoneNumber) {
-      var entry = {
+      const entry = {
         $name: 'History',
         Type: 'atPhoneCall',
         ContactName: this.entry.NameLF,
@@ -111,14 +111,14 @@ define('crm/Views/Contact/Detail', ['module', 'exports', 'dojo/_base/declare', '
       App.initiateCall(phoneNumber);
     },
     recordEmailToHistory: function recordEmailToHistory(email) {
-      var entry = {
+      const entry = {
         $name: 'History',
         Type: 'atEMail',
         ContactName: this.entry.NameLF,
         ContactId: this.entry.$key,
         AccountName: this.entry.AccountName,
         AccountId: this.entry.Account.$key,
-        Description: 'Emailed ' + this.entry.Name,
+        Description: `Emailed ${this.entry.Name}`,
         UserId: App.context && App.context.user.$key,
         UserName: App.context && App.context.user.$descriptor,
         Duration: 15,
@@ -150,7 +150,7 @@ define('crm/Views/Contact/Detail', ['module', 'exports', 'dojo/_base/declare', '
       App.navigateToActivityInsertView();
     },
     addNote: function addNote() {
-      var view = App.getView(this.noteEditView);
+      const view = App.getView(this.noteEditView);
       if (view) {
         view.show({
           template: {},

--- a/src-out/Views/Contact/Edit.js
+++ b/src-out/Views/Contact/Edit.js
@@ -23,22 +23,22 @@ define('crm/Views/Contact/Edit', ['module', 'exports', 'dojo/_base/declare', 'cr
     };
   }
 
-  var resource = (0, _I18n2.default)('contactEdit'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('contactEdit'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
-  var __class = (0, _declare2.default)('crm.Views.Contact.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Contact.Edit', [_Edit2.default], {
     // Localization
     titleText: resource.titleText,
     nameText: resource.nameText,
@@ -85,13 +85,13 @@ define('crm/Views/Contact/Edit', ['module', 'exports', 'dojo/_base/declare', 'cr
       this.requestAccount(value.key);
     },
     applyContext: function applyContext() {
-      var found = App.queryNavigationContext(function (o) {
-        var ob = o.options && o.options.source || o;
+      const found = App.queryNavigationContext(o => {
+        const ob = o.options && o.options.source || o;
         return (/^(accounts|opportunities)$/.test(ob.resourceKind) && ob.key
         );
       });
 
-      var lookup = {
+      const lookup = {
         accounts: this.applyAccountContext,
         opportunities: this.applyOpportunityContext
       };
@@ -104,8 +104,8 @@ define('crm/Views/Contact/Edit', ['module', 'exports', 'dojo/_base/declare', 'cr
       }
     },
     applyAccountContext: function applyAccountContext(context) {
-      var view = App.getView(context.id);
-      var entry = view && view.entry;
+      const view = App.getView(context.id);
+      const entry = view && view.entry;
 
       if (!entry && context.options && context.options.source && context.options.source.entry) {
         this.requestAccount(context.options.source.entry.$key);
@@ -114,7 +114,7 @@ define('crm/Views/Contact/Edit', ['module', 'exports', 'dojo/_base/declare', 'cr
       this.processAccount(entry);
     },
     requestAccount: function requestAccount(accountId) {
-      var request = new Sage.SData.Client.SDataSingleResourceRequest(this.getService()).setResourceKind('accounts').setResourceSelector('\'' + accountId + '\'').setQueryArg('select', ['AccountName', 'Address/*', 'Fax', 'MainPhone', 'WebAddress'].join(','));
+      const request = new Sage.SData.Client.SDataSingleResourceRequest(this.getService()).setResourceKind('accounts').setResourceSelector(`'${accountId}'`).setQueryArg('select', ['AccountName', 'Address/*', 'Fax', 'MainPhone', 'WebAddress'].join(','));
 
       request.allowCacheUse = true;
       request.read({
@@ -125,12 +125,12 @@ define('crm/Views/Contact/Edit', ['module', 'exports', 'dojo/_base/declare', 'cr
     },
     requestAccountFailure: function requestAccountFailure() {},
     processAccount: function processAccount(entry) {
-      var account = entry;
-      var accountName = _Utility2.default.getValue(entry, 'AccountName');
-      var webAddress = _Utility2.default.getValue(entry, 'WebAddress');
-      var mainPhone = _Utility2.default.getValue(entry, 'MainPhone');
-      var address = _Utility2.default.getValue(entry, 'Address');
-      var fax = _Utility2.default.getValue(entry, 'Fax');
+      const account = entry;
+      const accountName = _Utility2.default.getValue(entry, 'AccountName');
+      const webAddress = _Utility2.default.getValue(entry, 'WebAddress');
+      const mainPhone = _Utility2.default.getValue(entry, 'MainPhone');
+      const address = _Utility2.default.getValue(entry, 'Address');
+      const fax = _Utility2.default.getValue(entry, 'Fax');
 
       if (account) {
         this.fields.Account.setValue(account);
@@ -152,15 +152,15 @@ define('crm/Views/Contact/Edit', ['module', 'exports', 'dojo/_base/declare', 'cr
       }
     },
     applyOpportunityContext: function applyOpportunityContext(context) {
-      var view = App.getView(context.id);
-      var entry = view && view.entry;
-      var opportunityId = _Utility2.default.getValue(entry, '$key');
-      var account = _Utility2.default.getValue(entry, 'Account');
-      var accountName = _Utility2.default.getValue(entry, 'Account.AccountName');
-      var webAddress = _Utility2.default.getValue(entry, 'Account.WebAddress');
-      var mainPhone = _Utility2.default.getValue(entry, 'Account.MainPhone');
-      var address = _Utility2.default.getValue(entry, 'Account.Address');
-      var fax = _Utility2.default.getValue(entry, 'Account.Fax');
+      const view = App.getView(context.id);
+      const entry = view && view.entry;
+      const opportunityId = _Utility2.default.getValue(entry, '$key');
+      const account = _Utility2.default.getValue(entry, 'Account');
+      const accountName = _Utility2.default.getValue(entry, 'Account.AccountName');
+      const webAddress = _Utility2.default.getValue(entry, 'Account.WebAddress');
+      const mainPhone = _Utility2.default.getValue(entry, 'Account.MainPhone');
+      const address = _Utility2.default.getValue(entry, 'Account.Address');
+      const fax = _Utility2.default.getValue(entry, 'Account.Fax');
 
       if (opportunityId) {
         this.fields['Opportunities.$resources[0].Opportunity.$key'].setValue(opportunityId);
@@ -186,8 +186,8 @@ define('crm/Views/Contact/Edit', ['module', 'exports', 'dojo/_base/declare', 'cr
     },
     cleanAddressEntry: function cleanAddressEntry(address) {
       if (address) {
-        var clean = {};
-        var skip = {
+        const clean = {};
+        const skip = {
           $key: true,
           $lookup: true,
           $url: true,
@@ -198,7 +198,7 @@ define('crm/Views/Contact/Edit', ['module', 'exports', 'dojo/_base/declare', 'cr
           CreateUser: true
         };
 
-        for (var name in address) {
+        for (const name in address) {
           if (address.hasOwnProperty(name)) {
             if (!skip[name]) {
               clean[name] = address[name];

--- a/src-out/Views/Contact/List.js
+++ b/src-out/Views/Contact/List.js
@@ -27,22 +27,22 @@ define('crm/Views/Contact/List', ['module', 'exports', 'dojo/_base/declare', 'cr
     };
   }
 
-  var resource = (0, _I18n2.default)('contactList'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('contactList'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
-  var __class = (0, _declare2.default)('crm.Views.Contact.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Contact.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     format: _Format2.default,
     // Template
     // Card Layout
@@ -82,17 +82,17 @@ define('crm/Views/Contact/List', ['module', 'exports', 'dojo/_base/declare', 'cr
     groupsEnabled: true,
     enableActions: true,
     callWork: function callWork(params) {
-      this.invokeActionItemBy(function (theAction) {
+      this.invokeActionItemBy(theAction => {
         return theAction.id === 'callWork';
       }, params.key);
     },
     callMobile: function callMobile(params) {
-      this.invokeActionItemBy(function (theAction) {
+      this.invokeActionItemBy(theAction => {
         return theAction.id === 'callMobile';
       }, params.key);
     },
     sendEmail: function sendEmail(params) {
-      this.invokeActionItemBy(function (theAction) {
+      this.invokeActionItemBy(theAction => {
         return theAction.id === 'sendEmail';
       }, params.key);
     },
@@ -148,8 +148,8 @@ define('crm/Views/Contact/List', ['module', 'exports', 'dojo/_base/declare', 'cr
       }]);
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(LastNameUpper like "' + q + '%" or upper(FirstName) like "' + q + '%" or upper(NameLF) like "%' + q + '%") or (AccountName like "%' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(LastNameUpper like "${q}%" or upper(FirstName) like "${q}%" or upper(NameLF) like "%${q}%") or (AccountName like "%${q}%")`;
     }
   });
 

--- a/src-out/Views/Contract/List.js
+++ b/src-out/Views/Contract/List.js
@@ -15,22 +15,22 @@ define('crm/Views/Contract/List', ['module', 'exports', 'dojo/_base/declare', 'a
     };
   }
 
-  var resource = (0, _I18n2.default)('contractList'); /* Copyright 2017 Infor
-                                                       *
-                                                       * Licensed under the Apache License, Version 2.0 (the "License");
-                                                       * you may not use this file except in compliance with the License.
-                                                       * You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing, software
-                                                       * distributed under the License is distributed on an "AS IS" BASIS,
-                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                       * See the License for the specific language governing permissions and
-                                                       * limitations under the License.
-                                                       */
+  const resource = (0, _I18n2.default)('contractList'); /* Copyright 2017 Infor
+                                                         *
+                                                         * Licensed under the Apache License, Version 2.0 (the "License");
+                                                         * you may not use this file except in compliance with the License.
+                                                         * You may obtain a copy of the License at
+                                                         *
+                                                         *    http://www.apache.org/licenses/LICENSE-2.0
+                                                         *
+                                                         * Unless required by applicable law or agreed to in writing, software
+                                                         * distributed under the License is distributed on an "AS IS" BASIS,
+                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                         * See the License for the specific language governing permissions and
+                                                         * limitations under the License.
+                                                         */
 
-  var __class = (0, _declare2.default)('crm.Views.Contract.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Contract.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%= $.Account ? $.Account.AccountName : "" %}</p>']),
 
@@ -48,8 +48,8 @@ define('crm/Views/Contract/List', ['module', 'exports', 'dojo/_base/declare', 'a
     resourceKind: 'contracts',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery);
-      return '(ReferenceNumber like "%' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery);
+      return `(ReferenceNumber like "%${q}%")`;
     }
   });
 

--- a/src-out/Views/ErrorLog/Detail.js
+++ b/src-out/Views/ErrorLog/Detail.js
@@ -36,10 +36,10 @@ define('crm/Views/ErrorLog/Detail', ['module', 'exports', 'dojo/_base/declare', 
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('errorLogDetail');
-  var dtFormatResource = (0, _I18n2.default)('errorLogDetailDateTimeFormat');
+  const resource = (0, _I18n2.default)('errorLogDetail');
+  const dtFormatResource = (0, _I18n2.default)('errorLogDetailDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.ErrorLog.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.ErrorLog.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     detailsText: resource.detailsText,
@@ -68,7 +68,7 @@ define('crm/Views/ErrorLog/Detail', ['module', 'exports', 'dojo/_base/declare', 
     },
 
     createToolLayout: function createToolLayout() {
-      var tools = {
+      const tools = {
         tbar: []
       };
 
@@ -83,19 +83,19 @@ define('crm/Views/ErrorLog/Detail', ['module', 'exports', 'dojo/_base/declare', 
     },
 
     constructReport: function constructReport() {
-      var body = '\r\n\r\n\r\n-----------------\r\n' + _json2.default.toJson(this.entry, true);
+      const body = `\r\n\r\n\r\n-----------------\r\n${_json2.default.toJson(this.entry, true)}`;
       this.sendEmailReport(body);
     },
 
     sendEmailReport: function sendEmailReport(body) {
-      var email = this.defaultToAddress || '';
-      var subject = encodeURIComponent(this.emailSubjectText);
-      var theBody = encodeURIComponent(body);
+      const email = this.defaultToAddress || '';
+      const subject = encodeURIComponent(this.emailSubjectText);
+      const theBody = encodeURIComponent(body);
       App.initiateEmail(email, subject, theBody);
     },
 
     requestData: function requestData() {
-      var errorItem = _ErrorManager2.default.getError('$key', this.options.key);
+      const errorItem = _ErrorManager2.default.getError('$key', this.options.key);
       this.processEntry(errorItem);
     },
 

--- a/src-out/Views/ErrorLog/List.js
+++ b/src-out/Views/ErrorLog/List.js
@@ -36,10 +36,10 @@ define('crm/Views/ErrorLog/List', ['module', 'exports', 'dojo/_base/declare', 'd
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('errorLogList');
-  var dtFormatResource = (0, _I18n2.default)('errorLogListDateTimeFormat');
+  const resource = (0, _I18n2.default)('errorLogList');
+  const dtFormatResource = (0, _I18n2.default)('errorLogListDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.ErrorLog.List', [_ListBase2.default], {
+  const __class = (0, _declare2.default)('crm.Views.ErrorLog.List', [_ListBase2.default], {
     // Localization
     titleText: resource.titleText,
     errorDateFormatText: dtFormatResource.errorDateFormatText,
@@ -65,15 +65,15 @@ define('crm/Views/ErrorLog/List', ['module', 'exports', 'dojo/_base/declare', 'd
       }
     },
     createStore: function createStore() {
-      var errorItems = _ErrorManager2.default.getAllErrors();
+      const errorItems = _ErrorManager2.default.getAllErrors();
 
-      errorItems.sort(function (a, b) {
+      errorItems.sort((a, b) => {
         a.errorDateStamp = a.errorDateStamp || a.Date;
         b.errorDateStamp = b.errorDateStamp || b.Date;
         a.Date = a.errorDateStamp;
         b.Date = b.errorDateStamp;
-        var A = _Convert2.default.toDateFromString(a.errorDateStamp);
-        var B = _Convert2.default.toDateFromString(b.errorDateStamp);
+        const A = _Convert2.default.toDateFromString(a.errorDateStamp);
+        const B = _Convert2.default.toDateFromString(b.errorDateStamp);
 
         return A.valueOf() > B.valueOf();
       });

--- a/src-out/Views/Event/Detail.js
+++ b/src-out/Views/Event/Detail.js
@@ -32,10 +32,10 @@ define('crm/Views/Event/Detail', ['module', 'exports', 'dojo/_base/declare', '..
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('eventDetail');
-  var dtFormatResource = (0, _I18n2.default)('eventDetailDateTimeFormat');
+  const resource = (0, _I18n2.default)('eventDetail');
+  const dtFormatResource = (0, _I18n2.default)('eventDetailDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Event.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Event.Detail', [_Detail2.default], {
     // Localization
     actionsText: resource.actionsText,
     startTimeText: resource.startTimeText,

--- a/src-out/Views/Event/Edit.js
+++ b/src-out/Views/Event/Edit.js
@@ -19,24 +19,24 @@ define('crm/Views/Event/Edit', ['module', 'exports', 'dojo/_base/declare', '../.
     };
   }
 
-  var resource = (0, _I18n2.default)('eventEdit'); /* Copyright 2017 Infor
-                                                    *
-                                                    * Licensed under the Apache License, Version 2.0 (the "License");
-                                                    * you may not use this file except in compliance with the License.
-                                                    * You may obtain a copy of the License at
-                                                    *
-                                                    *    http://www.apache.org/licenses/LICENSE-2.0
-                                                    *
-                                                    * Unless required by applicable law or agreed to in writing, software
-                                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                    * See the License for the specific language governing permissions and
-                                                    * limitations under the License.
-                                                    */
+  const resource = (0, _I18n2.default)('eventEdit'); /* Copyright 2017 Infor
+                                                      *
+                                                      * Licensed under the Apache License, Version 2.0 (the "License");
+                                                      * you may not use this file except in compliance with the License.
+                                                      * You may obtain a copy of the License at
+                                                      *
+                                                      *    http://www.apache.org/licenses/LICENSE-2.0
+                                                      *
+                                                      * Unless required by applicable law or agreed to in writing, software
+                                                      * distributed under the License is distributed on an "AS IS" BASIS,
+                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                      * See the License for the specific language governing permissions and
+                                                      * limitations under the License.
+                                                      */
 
-  var dtFormatResource = (0, _I18n2.default)('eventEditDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('eventEditDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Event.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Event.Edit', [_Edit2.default], {
     // Localization
     titleText: resource.titleText,
     typeText: resource.typeText,
@@ -67,7 +67,7 @@ define('crm/Views/Event/Edit', ['module', 'exports', 'dojo/_base/declare', '../.
       this.connect(this.fields.StartDate, 'onChange', this.onStartDateChange);
     },
     onStartDateChange: function onStartDateChange(val) {
-      var endDate = this.fields.EndDate.getValue();
+      const endDate = this.fields.EndDate.getValue();
 
       if (endDate < val) {
         this.fields.EndDate.setValue(val);
@@ -77,9 +77,9 @@ define('crm/Views/Event/Edit', ['module', 'exports', 'dojo/_base/declare', '../.
       return this.eventTypesText[key] || text;
     },
     createTypeData: function createTypeData() {
-      var list = [];
+      const list = [];
 
-      for (var type in this.eventTypesText) {
+      for (const type in this.eventTypesText) {
         if (this.eventTypesText.hasOwnProperty(type)) {
           list.push({
             $key: type,
@@ -93,13 +93,13 @@ define('crm/Views/Event/Edit', ['module', 'exports', 'dojo/_base/declare', '../.
       };
     },
     applyUserActivityContext: function applyUserActivityContext(context) {
-      var view = App.getView(context.id);
+      const view = App.getView(context.id);
       if (view && view.currentDate) {
-        var currentDate = moment(view.currentDate).clone().startOf('day');
-        var userOptions = App.context.userOptions;
-        var startTimeOption = userOptions && userOptions['Calendar:DayStartTime'];
-        var startDate = currentDate.clone();
-        var startTime = startTimeOption && moment(startTimeOption, 'h:mma');
+        const currentDate = moment(view.currentDate).clone().startOf('day');
+        const userOptions = App.context.userOptions;
+        const startTimeOption = userOptions && userOptions['Calendar:DayStartTime'];
+        const startDate = currentDate.clone();
+        let startTime = startTimeOption && moment(startTimeOption, 'h:mma');
 
         if (startTime && !moment(currentDate).isSame(moment())) {
           startDate.hours(startTime.hours());
@@ -112,7 +112,7 @@ define('crm/Views/Event/Edit', ['module', 'exports', 'dojo/_base/declare', '../.
           });
         }
 
-        var endDate = startDate.clone().add({
+        const endDate = startDate.clone().add({
           minutes: 15
         });
 
@@ -123,15 +123,15 @@ define('crm/Views/Event/Edit', ['module', 'exports', 'dojo/_base/declare', '../.
     applyContext: function applyContext() {
       this.inherited(applyContext, arguments);
 
-      var found = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      const found = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
 
         return (/^(useractivities||activities||events)$/.test(context.resourceKind)
         );
       });
 
-      var context = found && found.options && found.options.source || found;
-      var lookup = {
+      const context = found && found.options && found.options.source || found;
+      const lookup = {
         useractivities: this.applyUserActivityContext,
         activities: this.applyUserActivityContext
       };

--- a/src-out/Views/Event/List.js
+++ b/src-out/Views/Event/List.js
@@ -15,24 +15,24 @@ define('crm/Views/Event/List', ['module', 'exports', 'dojo/_base/declare', 'argo
     };
   }
 
-  var resource = (0, _I18n2.default)('eventList'); /* Copyright 2017 Infor
-                                                    *
-                                                    * Licensed under the Apache License, Version 2.0 (the "License");
-                                                    * you may not use this file except in compliance with the License.
-                                                    * You may obtain a copy of the License at
-                                                    *
-                                                    *    http://www.apache.org/licenses/LICENSE-2.0
-                                                    *
-                                                    * Unless required by applicable law or agreed to in writing, software
-                                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                    * See the License for the specific language governing permissions and
-                                                    * limitations under the License.
-                                                    */
+  const resource = (0, _I18n2.default)('eventList'); /* Copyright 2017 Infor
+                                                      *
+                                                      * Licensed under the Apache License, Version 2.0 (the "License");
+                                                      * you may not use this file except in compliance with the License.
+                                                      * You may obtain a copy of the License at
+                                                      *
+                                                      *    http://www.apache.org/licenses/LICENSE-2.0
+                                                      *
+                                                      * Unless required by applicable law or agreed to in writing, software
+                                                      * distributed under the License is distributed on an "AS IS" BASIS,
+                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                      * See the License for the specific language governing permissions and
+                                                      * limitations under the License.
+                                                      */
 
-  var dtFormatResource = (0, _I18n2.default)('eventListDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('eventListDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Event.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Event.List', [_List2.default], {
     // Localization
     titleText: resource.titleText,
     eventDateFormatText: dtFormatResource.eventDateFormatText,
@@ -53,8 +53,8 @@ define('crm/Views/Event/List', ['module', 'exports', 'dojo/_base/declare', 'argo
     resourceKind: 'events',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Description) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Description) like "%${q}%"`;
     }
   });
 

--- a/src-out/Views/ExchangeRateLookup.js
+++ b/src-out/Views/ExchangeRateLookup.js
@@ -32,9 +32,9 @@ define('crm/Views/ExchangeRateLookup', ['module', 'exports', 'dojo/_base/declare
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('exchangeRateLookup');
+  const resource = (0, _I18n2.default)('exchangeRateLookup');
 
-  var __class = (0, _declare2.default)('crm.Views.ExchangeRateLookup', [_List2.default, _LegacySDataListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.ExchangeRateLookup', [_List2.default, _LegacySDataListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.$key %} ({%: $.Rate %})</p>']),
 
@@ -50,11 +50,11 @@ define('crm/Views/ExchangeRateLookup', ['module', 'exports', 'dojo/_base/declare
       this.processFeed();
     },
     processFeed: function processFeed() {
-      var rates = App.context && App.context.exchangeRates;
-      var list = [];
-      var feed = {};
+      const rates = App.context && App.context.exchangeRates;
+      const list = [];
+      const feed = {};
 
-      for (var prop in rates) {
+      for (const prop in rates) {
         if (rates.hasOwnProperty(prop)) {
           list.push({
             $key: prop,

--- a/src-out/Views/FooterToolbar.js
+++ b/src-out/Views/FooterToolbar.js
@@ -28,7 +28,7 @@ define('crm/Views/FooterToolbar', ['module', 'exports', 'dojo/_base/declare', 'a
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Views.FooterToolbar', [_MainToolbar2.default], {
+  const __class = (0, _declare2.default)('crm.Views.FooterToolbar', [_MainToolbar2.default], {
     // Localization
     copyrightText: '',
 
@@ -41,7 +41,7 @@ define('crm/Views/FooterToolbar', ['module', 'exports', 'dojo/_base/declare', 'a
       }
     },
     showTools: function showTools(tools) {
-      var contents = [];
+      const contents = [];
       if (tools && tools.length <= 0 || tools !== false) {
         this.show();
       } else if (tools === false) {
@@ -52,7 +52,7 @@ define('crm/Views/FooterToolbar', ['module', 'exports', 'dojo/_base/declare', 'a
       argos.MainToolbar.superclass.showTools.apply(this, arguments); // TODO: Avoid global
 
       if (tools) {
-        for (var i = 0; i < tools.length; i++) {
+        for (let i = 0; i < tools.length; i++) {
           contents.push(this.toolTemplate.apply(tools[i]));
         }
         this.set('footerContents', contents.join(''));

--- a/src-out/Views/Groups/Selector.js
+++ b/src-out/Views/Groups/Selector.js
@@ -32,9 +32,9 @@ define('crm/Views/Groups/Selector', ['module', 'exports', 'dojo/_base/declare', 
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('groupsSelector');
+  const resource = (0, _I18n2.default)('groupsSelector');
 
-  var __class = (0, _declare2.default)('crm.Views.Groups.Selector', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Groups.Selector', [_List2.default], {
     id: 'groups_configure',
     expose: false,
     enableSearch: false,
@@ -72,14 +72,14 @@ define('crm/Views/Groups/Selector', ['module', 'exports', 'dojo/_base/declare', 
     },
 
     createGroupStore: function createGroupStore(entityName) {
-      var store = null;
+      let store = null;
 
       if (typeof entityName === 'string' && entityName !== '') {
         store = new _SData2.default({
           service: App.services.crm,
           resourceKind: 'groups',
           contractName: 'system',
-          where: 'upper(family) eq \'' + entityName.toUpperCase() + '\'',
+          where: `upper(family) eq '${entityName.toUpperCase()}'`,
           orderBy: 'name asc',
           include: ['layout', 'tableAliases'],
           idProperty: '$key',
@@ -91,8 +91,8 @@ define('crm/Views/Groups/Selector', ['module', 'exports', 'dojo/_base/declare', 
       return store;
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'name like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `name like "${q}%"`;
     }
   });
 

--- a/src-out/Views/Help.js
+++ b/src-out/Views/Help.js
@@ -32,9 +32,9 @@ define('crm/Views/Help', ['module', 'exports', 'dojo/_base/declare', 'argos/_Det
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('help');
+  const resource = (0, _I18n2.default)('help');
 
-  var __class = (0, _declare2.default)('crm.Views.Help', [_DetailBase3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Help', [_DetailBase3.default], {
     // Templates
     errorTemplate: new Simplate(['<div data-dojo-attach-point="errorNode">', '<h2>{%: $.errorText %}</h2>', '<ul>', '<li>{%: $.errorMessageText %}</li>', '</ul>', '</div>']),
 
@@ -56,19 +56,17 @@ define('crm/Views/Help', ['module', 'exports', 'dojo/_base/declare', 'argos/_Det
       return this.tools && (this.tools.tbar = []);
     },
     resolveLocalizedUrl: function resolveLocalizedUrl(baseUrl, fileName) {
-      var cultureName = App.context.localization.locale || 'en';
-      var localizedUrl = baseUrl + '/' + cultureName + '/' + fileName;
+      const cultureName = App.context.localization.locale || 'en';
+      const localizedUrl = `${baseUrl}/${cultureName}/${fileName}`;
       return localizedUrl;
     },
     resolveGenericLocalizedUrl: function resolveGenericLocalizedUrl(baseUrl, fileName) {
-      var languageSpec = App.context.localization.locale || 'en';
-      var languageGen = languageSpec.indexOf('-') !== -1 ? languageSpec.split('-')[0] : languageSpec;
-      var localizedUrl = baseUrl + '/' + languageGen + '/' + fileName;
+      const languageSpec = App.context.localization.locale || 'en';
+      const languageGen = languageSpec.indexOf('-') !== -1 ? languageSpec.split('-')[0] : languageSpec;
+      const localizedUrl = `${baseUrl}/${languageGen}/${fileName}`;
       return localizedUrl;
     },
-    _sanitizeUrl: function _sanitizeUrl() {
-      var url = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-
+    _sanitizeUrl: function _sanitizeUrl(url = '') {
       // Remove trailing slashes
       return url.replace(/[\/|\\]*$/, ''); // eslint-disable-line
     },
@@ -78,12 +76,12 @@ define('crm/Views/Help', ['module', 'exports', 'dojo/_base/declare', 'argos/_Det
     processEntry: function processEntry() {
       this.inherited(processEntry, arguments);
       // Processing the layout should be done now
-      var self = this;
-      Promise.all(this.promises).then(function (results) {
-        results.forEach(function (result) {
+      const self = this;
+      Promise.all(this.promises).then(results => {
+        results.forEach(result => {
           self.processContent(result.response, result.domNode);
         });
-      }, function (e) {
+      }, e => {
         self.processContent({ responseText: self.errorTemplate.apply(self) }, e.domNode);
       });
       this.promises = [];
@@ -91,43 +89,31 @@ define('crm/Views/Help', ['module', 'exports', 'dojo/_base/declare', 'argos/_Det
     processContent: function processContent(xhr, domNode) {
       $(domNode).empty().append(xhr.responseText);
     },
-    getHelp: function getHelp(_ref, domNode) {
-      var _this = this;
-
-      var baseUrl = _ref.baseUrl,
-          fileName = _ref.fileName,
-          defaultUrl = _ref.defaultUrl;
-
-      var req = Sage.SData.Client.Ajax.request;
-      var cleanBaseUrl = this._sanitizeUrl(baseUrl);
-      return new Promise(function (resolve, reject) {
+    getHelp: function getHelp({ baseUrl, fileName, defaultUrl }, domNode) {
+      const req = Sage.SData.Client.Ajax.request;
+      const cleanBaseUrl = this._sanitizeUrl(baseUrl);
+      return new Promise((resolve, reject) => {
         req({
-          url: _this.resolveLocalizedUrl(cleanBaseUrl, fileName),
+          url: this.resolveLocalizedUrl(cleanBaseUrl, fileName),
           cache: true,
-          success: function success(response) {
-            return resolve({ response: response, domNode: domNode });
-          },
-          failure: function failure() {
+          success: response => resolve({ response, domNode }),
+          failure: () => {
             // First failure, try to get the parent locale
             req({
-              url: _this.resolveGenericLocalizedUrl(cleanBaseUrl, fileName),
+              url: this.resolveGenericLocalizedUrl(cleanBaseUrl, fileName),
               cache: true,
-              success: function success(response) {
-                return resolve({ response: response, domNode: domNode });
-              },
-              failure: function failure() {
+              success: response => resolve({ response, domNode }),
+              failure: () => {
                 // Second failure, use the default url
                 req({
                   url: defaultUrl,
                   cache: true,
-                  success: function success(response) {
-                    return resolve({ response: response, domNode: domNode });
-                  },
-                  failure: function failure(response, o) {
+                  success: response => resolve({ response, domNode }),
+                  failure: (response, o) => {
                     // The default help failed. Log the error, as something is
                     // probably wrong with the layout.
-                    _ErrorManager2.default.addError(response, o, _this.options, 'failure');
-                    reject({ response: response, o: o, domNode: domNode });
+                    _ErrorManager2.default.addError(response, o, this.options, 'failure');
+                    reject({ response, o, domNode });
                   }
                 });
               }
@@ -144,7 +130,7 @@ define('crm/Views/Help', ['module', 'exports', 'dojo/_base/declare', 'argos/_Det
         return this.layout;
       }
 
-      var layout = [];
+      const layout = [];
 
       layout.push({
         title: this.sectionTitleText,

--- a/src-out/Views/History/Detail.js
+++ b/src-out/Views/History/Detail.js
@@ -36,10 +36,10 @@ define('crm/Views/History/Detail', ['module', 'exports', 'dojo/_base/declare', '
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('historyDetail');
-  var dtFormatResource = (0, _I18n2.default)('historyDetailDateTimeFormat');
+  const resource = (0, _I18n2.default)('historyDetail');
+  const dtFormatResource = (0, _I18n2.default)('historyDetailDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.History.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.History.Detail', [_Detail2.default], {
     // Templates
     createUserTemplate: _Template2.default.nameLF,
 

--- a/src-out/Views/History/Edit.js
+++ b/src-out/Views/History/Edit.js
@@ -23,24 +23,24 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
     };
   }
 
-  var resource = (0, _I18n2.default)('historyEdit'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('historyEdit'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
-  var dtFormatResource = (0, _I18n2.default)('historyEditDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('historyEditDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.History.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.History.Edit', [_Edit2.default], {
     // Localization
     accountText: resource.accountText,
     noteDescriptionTitleText: resource.noteDescriptionTitleText,
@@ -90,16 +90,16 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       return entry && this.existsRE.test(entry.LeadId);
     },
     isInLeadContext: function isInLeadContext() {
-      var insert = this.options && this.options.insert;
-      var entry = this.options && this.options.entry;
-      var context = this._getNavContext();
-      var isLeadContext = false;
+      const insert = this.options && this.options.insert;
+      const entry = this.options && this.options.entry;
+      const context = this._getNavContext();
+      let isLeadContext = false;
 
       if (context && context.resourceKind === 'leads') {
         isLeadContext = true;
       }
 
-      var lead = insert && isLeadContext || this.isHistoryForLead(entry);
+      const lead = insert && isLeadContext || this.isHistoryForLead(entry);
       return !!lead;
     },
     beforeTransitionTo: function beforeTransitionTo() {
@@ -122,16 +122,10 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       }
     },
     _setRestrictedFieldState: function _setRestrictedFieldState() {
-      var _this = this;
-
       if (this.inserting) {
-        this.restrictedFields.forEach(function (f) {
-          return _this._enableField(_this.fields[f]);
-        });
+        this.restrictedFields.forEach(f => this._enableField(this.fields[f]));
       } else {
-        this.restrictedFields.forEach(function (f) {
-          return _this._disableField(_this.fields[f]);
-        });
+        this.restrictedFields.forEach(f => this._disableField(this.fields[f]));
       }
     },
     _disableField: function _disableField(field) {
@@ -149,19 +143,19 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       field.enable();
     },
     setOfflineNoteData: function setOfflineNoteData() {
-      var entry = this.options && this.options.selectedEntry;
+      const entry = this.options && this.options.selectedEntry;
       if (!entry) {
         return;
       }
 
       this.setUserContext();
       this.fields.Text.setValue(entry.Text);
-      var start = moment(entry.StartDate);
+      const start = moment(entry.StartDate);
       this.fields.StartDate.setValue(start.toDate());
     },
     _buildRefreshMessage: function _buildRefreshMessage() {
-      var base = this.inherited(_buildRefreshMessage, arguments);
-      var entry = this.options && this.options.selectedEntry;
+      const base = this.inherited(_buildRefreshMessage, arguments);
+      const entry = this.options && this.options.selectedEntry;
       if (entry && this.options.fromOffline) {
         base.UID = entry.UID;
       }
@@ -178,18 +172,18 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       }
     },
     onLeadChange: function onLeadChange(value, field) {
-      var selection = field.getSelection();
+      const selection = field.getSelection();
 
       if (selection && this.insert) {
         this.fields.AccountName.setValue(_Utility2.default.getValue(selection, 'Company'));
       }
     },
     onAccountChange: function onAccountChange(value) {
-      var fields = this.fields;
-      ['Contact', 'Opportunity', 'Ticket'].forEach(function (f) {
+      const fields = this.fields;
+      ['Contact', 'Opportunity', 'Ticket'].forEach(f => {
         if (value) {
           fields[f].dependsOn = 'Account';
-          fields[f].where = 'Account.Id eq "' + (value.AccountId || value.key) + '"';
+          fields[f].where = `Account.Id eq "${value.AccountId || value.key}"`;
 
           if (fields[f].currentSelection && fields[f].currentSelection.Account.$key !== (value.AccountId || value.key)) {
             fields[f].setValue(false);
@@ -203,7 +197,7 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
     },
     onAccountDependentChange: function onAccountDependentChange(value, field) {
       if (value && !field.dependsOn && field.currentSelection && field.currentSelection.Account) {
-        var accountField = this.fields.Account;
+        const accountField = this.fields.Account;
         accountField.setValue({
           AccountId: field.currentSelection.Account.$key,
           AccountName: field.currentSelection.Account.AccountName
@@ -212,32 +206,28 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       }
     },
     showFieldsForLead: function showFieldsForLead() {
-      var _this2 = this;
-
-      this.fieldsForStandard.concat(this.fieldsForStandard).forEach(function (item) {
-        if (_this2.fields[item]) {
-          _this2.fields[item].hide();
+      this.fieldsForStandard.concat(this.fieldsForStandard).forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].hide();
         }
       }, this);
 
-      this.fieldsForLeads.forEach(function (item) {
-        if (_this2.fields[item]) {
-          _this2.fields[item].show();
+      this.fieldsForLeads.forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].show();
         }
       }, this);
     },
     showFieldsForStandard: function showFieldsForStandard() {
-      var _this3 = this;
-
-      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(function (item) {
-        if (_this3.fields[item]) {
-          _this3.fields[item].hide();
+      this.fieldsForStandard.concat(this.fieldsForLeads).forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].hide();
         }
       }, this);
 
-      this.fieldsForStandard.forEach(function (item) {
-        if (_this3.fields[item]) {
-          _this3.fields[item].show();
+      this.fieldsForStandard.forEach(item => {
+        if (this.fields[item]) {
+          this.fields[item].show();
         }
       }, this);
     },
@@ -246,9 +236,9 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       this.inherited(onInsertSuccess, arguments);
     },
     applyContext: function applyContext() {
-      var found = this._getNavContext();
+      const found = this._getNavContext();
 
-      var lookup = {
+      const lookup = {
         accounts: this.applyAccountContext,
         contacts: this.applyContactContext,
         opportunities: this.applyOpportunityContext,
@@ -265,15 +255,15 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       this.fields.Text.setValue('');
     },
     setUserContext: function setUserContext() {
-      var user = App.context && App.context.user;
+      const user = App.context && App.context.user;
 
       this.fields.Type.setValue('atNote');
       this.fields.UserId.setValue(user && user.$key);
       this.fields.UserName.setValue(user && user.$descriptor);
     },
     _getNavContext: function _getNavContext() {
-      var found = App.queryNavigationContext(function (o) {
-        var context = o.options && o.options.source || o;
+      let found = App.queryNavigationContext(o => {
+        const context = o.options && o.options.source || o;
         return (/^(accounts|contacts|opportunities|leads|tickets)$/.test(context.resourceKind) && context.key
         );
       });
@@ -281,8 +271,8 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       return found;
     },
     applyAccountContext: function applyAccountContext(context) {
-      var accountField = this.fields.Account;
-      var accountValue = {
+      const accountField = this.fields.Account;
+      const accountValue = {
         AccountId: context.key,
         AccountName: context.descriptor
       };
@@ -290,15 +280,15 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       this.onAccountChange(accountValue, accountField);
     },
     applyLeadContext: function applyLeadContext(context) {
-      var view = App.getView(context.id);
-      var entry = context.entry || view && view.entry;
+      const view = App.getView(context.id);
+      const entry = context.entry || view && view.entry;
 
       if (!entry || !entry.$key) {
         return;
       }
 
-      var leadField = this.fields.Lead;
-      var leadValue = {
+      const leadField = this.fields.Lead;
+      const leadValue = {
         LeadId: entry.$key,
         LeadName: entry.$descriptor
       };
@@ -308,15 +298,15 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
 
       this.fields.AccountName.setValue(entry.Company);
 
-      var isLeadField = this.fields.IsLead;
+      const isLeadField = this.fields.IsLead;
       if (isLeadField) {
         isLeadField.setValue(context.resourceKind === 'leads');
         this.onIsLeadChange(isLeadField.getValue(), isLeadField);
       }
     },
     applyOpportunityContext: function applyOpportunityContext(context) {
-      var opportunityField = this.fields.Opportunity;
-      var accountEntry = void 0;
+      const opportunityField = this.fields.Opportunity;
+      let accountEntry;
 
       opportunityField.setValue({
         OpportunityId: context.key,
@@ -328,13 +318,13 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       if (context.entry && context.entry.Account) {
         accountEntry = context.entry.Account;
       } else {
-        var view = App.getView(context.id);
-        var entry = view && view.entry;
+        const view = App.getView(context.id);
+        const entry = view && view.entry;
         accountEntry = entry && entry.Account;
       }
 
       if (accountEntry) {
-        var accountField = this.fields.Account;
+        const accountField = this.fields.Account;
         accountField.setValue({
           AccountId: accountEntry.$key,
           AccountName: accountEntry.AccountName
@@ -345,8 +335,8 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       // todo: find a good way to get the primary contact and apply
     },
     applyContactContext: function applyContactContext(context) {
-      var contactField = this.fields.Contact;
-      var accountEntry = void 0;
+      const contactField = this.fields.Contact;
+      let accountEntry;
       contactField.setValue({
         ContactId: context.key,
         ContactName: context.descriptor
@@ -357,13 +347,13 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       if (context.entry && context.entry.Account) {
         accountEntry = context.entry.Account;
       } else {
-        var view = App.getView(context.id);
-        var entry = view && view.entry;
+        const view = App.getView(context.id);
+        const entry = view && view.entry;
         accountEntry = entry && entry.Account;
       }
 
       if (accountEntry) {
-        var accountField = this.fields.Account;
+        const accountField = this.fields.Account;
         accountField.setValue({
           AccountId: accountEntry.$key,
           AccountName: accountEntry.AccountName
@@ -372,9 +362,9 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       }
     },
     applyTicketContext: function applyTicketContext(context) {
-      var ticketField = this.fields.Ticket;
-      var accountEntry = void 0;
-      var contactEntry = void 0;
+      const ticketField = this.fields.Ticket;
+      let accountEntry;
+      let contactEntry;
       ticketField.setValue({
         TicketId: context.key,
         TicketNumber: context.descriptor
@@ -385,14 +375,14 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
         accountEntry = context.entry.Account;
         contactEntry = context.entry.Contact;
       } else {
-        var view = App.getView(context.id);
-        var entry = view && view.entry;
+        const view = App.getView(context.id);
+        const entry = view && view.entry;
         accountEntry = entry && entry.Account;
         contactEntry = entry && entry.Contact;
       }
 
       if (accountEntry) {
-        var accountField = this.fields.Account;
+        const accountField = this.fields.Account;
         accountField.setValue({
           AccountId: accountEntry.$key,
           AccountName: accountEntry.AccountName
@@ -401,7 +391,7 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       }
 
       if (contactEntry) {
-        var contactField = this.fields.Contact;
+        const contactField = this.fields.Contact;
         contactField.setValue({
           ContactId: contactEntry.$key,
           ContactName: contactEntry.NameLF
@@ -419,17 +409,17 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
     },
     setValues: function setValues(values) {
       this.inherited(setValues, arguments);
-      var isLeadField = this.fields.IsLead;
+      const isLeadField = this.fields.IsLead;
       if (this.isInLeadContext()) {
         if (isLeadField) {
           isLeadField.setValue(true);
           this.onIsLeadChange(true, isLeadField);
         }
 
-        var field = this.fields.Lead;
-        var value = _Utility2.default.getValue(values, field.applyTo, {});
+        const field = this.fields.Lead;
+        const value = _Utility2.default.getValue(values, field.applyTo, {});
         field.setValue(value, !this.inserting);
-        var leadCompany = _Utility2.default.getValue(values, 'AccountName');
+        const leadCompany = _Utility2.default.getValue(values, 'AccountName');
         if (leadCompany) {
           this.fields.AccountName.setValue(leadCompany);
         }
@@ -437,16 +427,16 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
         isLeadField.setValue(false);
       }
 
-      var longNotes = _Utility2.default.getValue(values, 'LongNotes');
+      const longNotes = _Utility2.default.getValue(values, 'LongNotes');
       if (longNotes) {
         this.fields.Text.setValue(longNotes);
       }
 
-      var insert = this.options && this.options.insert;
+      const insert = this.options && this.options.insert;
       this.context = this._getNavContext();
       // entry may have been passed as full entry, reapply context logic to extract properties
       if (insert && this.context && this.context.resourceKind) {
-        var lookup = {
+        const lookup = {
           accounts: this.applyAccountContext,
           contacts: this.applyContactContext,
           opportunities: this.applyOpportunityContext,
@@ -456,7 +446,7 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
         lookup[this.context.resourceKind].call(this, this.context);
       }
       this.enableFields();
-      var denyEdit = !this.currentUserCanEdit();
+      const denyEdit = !this.currentUserCanEdit();
       if (denyEdit) {
         this.disableFields();
       }
@@ -464,22 +454,22 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       this._setRestrictedFieldState();
     },
     disableFields: function disableFields(predicate) {
-      for (var name in this.fields) {
+      for (const name in this.fields) {
         if (!predicate || predicate(this.fields[name])) {
           this.fields[name].disable();
         }
       }
     },
     enableFields: function enableFields(predicate) {
-      for (var name in this.fields) {
+      for (const name in this.fields) {
         if (!predicate || predicate(this.fields[name])) {
           this.fields[name].enable();
         }
       }
     },
     currentUserCanEdit: function currentUserCanEdit() {
-      var entry = this.options.entry || this.entry;
-      var insert = this.options && this.options.insert;
+      const entry = this.options.entry || this.entry;
+      const insert = this.options && this.options.insert;
       if (!insert) {
         if (App.context.user.$key === 'ADMIN') {
           return true;
@@ -489,18 +479,18 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
       return true;
     },
     formatDependentQuery: function formatDependentQuery(dependentValue, format, property) {
-      var theProperty = property || '$key';
-      var propertyValue = _Utility2.default.getValue(dependentValue, theProperty);
+      const theProperty = property || '$key';
+      const propertyValue = _Utility2.default.getValue(dependentValue, theProperty);
       if (propertyValue) {
         return _string2.default.substitute(format, [propertyValue]);
       }
       return '';
     },
     getValues: function getValues() {
-      var values = this.inherited(getValues, arguments);
+      let values = this.inherited(getValues, arguments);
 
       if (this.fields.Text.isDirty()) {
-        var text = this.fields.Text.getValue();
+        const text = this.fields.Text.getValue();
 
         values = values || {};
         values.LongNotes = text;
@@ -651,7 +641,7 @@ define('crm/Views/History/Edit', ['module', 'exports', 'dojo/_base/declare', 'do
           type: 'hidden',
           validator: {
             fn: function validateUserId(value, field) {
-              var canEdit = field.owner.currentUserCanEdit();
+              const canEdit = field.owner.currentUserCanEdit();
               if (!canEdit) {
                 return true;
               }

--- a/src-out/Views/History/EditOffline.js
+++ b/src-out/Views/History/EditOffline.js
@@ -19,22 +19,22 @@ define('crm/Views/History/EditOffline', ['module', 'exports', 'dojo/_base/declar
     };
   }
 
-  var resource = (0, _I18n2.default)('historyEditOffline'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('historyEditOffline'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var __class = (0, _declare2.default)('crm.Views.History.EditOffline', [_EditBase3.default], {
+  const __class = (0, _declare2.default)('crm.Views.History.EditOffline', [_EditBase3.default], {
     // Localization
     titleText: resource.titleText,
 
@@ -44,7 +44,7 @@ define('crm/Views/History/EditOffline', ['module', 'exports', 'dojo/_base/declar
     resourceKind: 'history',
 
     getModel: function getModel() {
-      var model = App.ModelManager.getModel(_Names2.default.HISTORY, _Types2.default.OFFLINE);
+      const model = App.ModelManager.getModel(_Names2.default.HISTORY, _Types2.default.OFFLINE);
       return model;
     },
     createLayout: function createLayout() {
@@ -72,7 +72,7 @@ define('crm/Views/History/EditOffline', ['module', 'exports', 'dojo/_base/declar
     onTransitionTo: function onTransitionTo() {
       this.inherited(onTransitionTo, arguments);
       if (this.options.insert) {
-        var now = Date.now();
+        const now = Date.now();
         this.fields.UID.setValue(now);
       }
     }

--- a/src-out/Views/History/List.js
+++ b/src-out/Views/History/List.js
@@ -61,12 +61,12 @@ define('crm/Views/History/List', ['module', 'exports', 'dojo/_base/declare', '..
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('historyList');
-  var activityTypeResource = (0, _I18n2.default)('activityTypeText');
-  var hashTagResource = (0, _I18n2.default)('historyListHashTags');
-  var dtFormatResource = (0, _I18n2.default)('historyListDateTimeFormat');
+  const resource = (0, _I18n2.default)('historyList');
+  const activityTypeResource = (0, _I18n2.default)('activityTypeText');
+  const hashTagResource = (0, _I18n2.default)('historyListHashTags');
+  const dtFormatResource = (0, _I18n2.default)('historyListDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.History.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.History.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     format: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">', '{% if ($.Type === "atNote") { %}', '{%: $$.formatDate($.ModifyDate) %}', '{% } else { %}', '{%: $$.formatDate($.CompletedDate) %}', '{% } %}', '</p>', '<p class="micro-text">{%= $$.nameTemplate.apply($) %}</p>', '{% if($.Description) { %}', '<p class="micro-text">{%= $$.regardingText + $$.formatPicklist("Description")($.Description) %}</p>', '{% } %}', '<div class="note-text-item">', '<div class="note-text-wrap">', '{%: $.Notes %}', '</div>', '</div>']),
@@ -116,7 +116,7 @@ define('crm/Views/History/List', ['module', 'exports', 'dojo/_base/declare', '..
     entityName: 'History',
     hashTagQueries: {
       'my-history': function myHistory() {
-        return 'UserId eq "' + App.context.user.$key + '"';
+        return `UserId eq "${App.context.user.$key}"`;
       },
       note: 'Type eq "atNote"',
       phonecall: 'Type eq "atPhoneCall"',
@@ -164,9 +164,9 @@ define('crm/Views/History/List', ['module', 'exports', 'dojo/_base/declare', '..
       return selection.data.ContactId || selection.data.LeadId;
     },
     navigateToContactOrLead: function navigateToContactOrLead(theAction, selection) {
-      var entity = this.resolveContactOrLeadEntity(selection.data);
-      var viewId = void 0;
-      var options = void 0;
+      const entity = this.resolveContactOrLeadEntity(selection.data);
+      let viewId;
+      let options;
 
       switch (entity) {
         case 'Contact':
@@ -186,14 +186,14 @@ define('crm/Views/History/List', ['module', 'exports', 'dojo/_base/declare', '..
         default:
       }
 
-      var view = App.getView(viewId);
+      const view = App.getView(viewId);
 
       if (view && options) {
         view.show(options);
       }
     },
     resolveContactOrLeadEntity: function resolveContactOrLeadEntity(entry) {
-      var exists = this.existsRE;
+      const exists = this.existsRE;
 
       if (entry) {
         if (exists.test(entry.LeadId)) {
@@ -205,11 +205,11 @@ define('crm/Views/History/List', ['module', 'exports', 'dojo/_base/declare', '..
       }
     },
     formatDate: function formatDate(date) {
-      var startDate = moment(_Convert2.default.toDateFromString(date));
-      var nextDate = startDate.clone().add({
+      const startDate = moment(_Convert2.default.toDateFromString(date));
+      const nextDate = startDate.clone().add({
         hours: 24
       });
-      var fmt = this.dateFormatText;
+      let fmt = this.dateFormatText;
 
       if (startDate.valueOf() < nextDate.valueOf() && startDate.valueOf() > moment().startOf('day').valueOf()) {
         fmt = App.is24HourClock() ? this.hourMinuteFormatText24 : this.hourMinuteFormatText;
@@ -221,7 +221,7 @@ define('crm/Views/History/List', ['module', 'exports', 'dojo/_base/declare', '..
       return _Format2.default.picklist(this.app.picklistService, this._model, property);
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(Description) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(Description) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     },
     createIndicatorLayout: function createIndicatorLayout() {
       return this.itemIndicators || (this.itemIndicators = [{
@@ -235,24 +235,24 @@ define('crm/Views/History/List', ['module', 'exports', 'dojo/_base/declare', '..
     },
     hasBeenTouched: function hasBeenTouched(entry) {
       if (entry.ModifyDate) {
-        var modifiedDate = moment(_Convert2.default.toDateFromString(entry.ModifyDate));
-        var currentDate = moment().endOf('day');
-        var weekAgo = moment().subtract(1, 'weeks');
+        const modifiedDate = moment(_Convert2.default.toDateFromString(entry.ModifyDate));
+        const currentDate = moment().endOf('day');
+        const weekAgo = moment().subtract(1, 'weeks');
 
         return modifiedDate.isAfter(weekAgo) && modifiedDate.isBefore(currentDate);
       }
       return false;
     },
     getItemIconClass: function getItemIconClass(entry) {
-      var type = entry && entry.Type;
+      const type = entry && entry.Type;
       return this._getItemIconClass(type);
     },
     getTitle: function getTitle(entry) {
-      var type = entry && entry.Type;
+      const type = entry && entry.Type;
       return this.activityTypeText[type] || this.titleText;
     },
     _getItemIconClass: function _getItemIconClass(type) {
-      var cls = this.activityTypeIcon[type];
+      let cls = this.activityTypeIcon[type];
       if (!cls) {
         cls = this.itemIconClass;
       }
@@ -262,9 +262,9 @@ define('crm/Views/History/List', ['module', 'exports', 'dojo/_base/declare', '..
       this.inherited(init, arguments);
     },
     activateEntry: function activateEntry(params) {
-      var entry = this.entries[params.key];
+      const entry = this.entries[params.key];
       if (entry) {
-        var activityParams = params;
+        const activityParams = params;
         activityParams.descriptor = this.getTitle(entry);
         this.inherited(arguments, [activityParams]);
       } else {

--- a/src-out/Views/History/ListOffline.js
+++ b/src-out/Views/History/ListOffline.js
@@ -36,15 +36,17 @@ define('crm/Views/History/ListOffline', ['module', 'exports', 'dojo/_base/declar
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('historyListOffline');
-  var dateResource = (0, _I18n2.default)('historyListOfflineFormat');
+  const resource = (0, _I18n2.default)('historyListOffline');
+  const dateResource = (0, _I18n2.default)('historyListOfflineFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Account.ListOffline', [_ListBase3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Account.ListOffline', [_ListBase3.default], {
     // Localization
     titleText: resource.titleText,
 
     // Templates
-    itemTemplate: new Simplate(['\n    <p>{%: $.Text %}</p>\n  ']),
+    itemTemplate: new Simplate([`
+    <p>{%: $.Text %}</p>
+  `]),
 
     // View Properties
     detailView: 'history_detail_offline',
@@ -63,7 +65,7 @@ define('crm/Views/History/ListOffline', ['module', 'exports', 'dojo/_base/declar
     labelProperty: 'Text',
     enableActions: true,
     _applyStateToQueryOptions: function _applyStateToQueryOptions(queryOptions) {
-      queryOptions.filter = function (entity) {
+      queryOptions.filter = entity => {
         return entity && typeof entity.Text === 'string';
       };
 
@@ -74,13 +76,13 @@ define('crm/Views/History/ListOffline', ['module', 'exports', 'dojo/_base/declar
     },
     getTitle: function getTitle(entry) {
       if (App.is24HourClock()) {
-        return '' + _Format2.default.date(entry.$offlineDate, dateResource.dateFormatText24);
+        return `${_Format2.default.date(entry.$offlineDate, dateResource.dateFormatText24)}`;
       }
 
-      return '' + _Format2.default.date(entry.$offlineDate, dateResource.dateFormatText);
+      return `${_Format2.default.date(entry.$offlineDate, dateResource.dateFormatText)}`;
     },
     getModel: function getModel() {
-      var model = App.ModelManager.getModel(_Names2.default.HISTORY, _Types2.default.OFFLINE);
+      const model = App.ModelManager.getModel(_Names2.default.HISTORY, _Types2.default.OFFLINE);
       return model;
     },
     createActionLayout: function createActionLayout() {
@@ -101,10 +103,10 @@ define('crm/Views/History/ListOffline', ['module', 'exports', 'dojo/_base/declar
       }]);
     },
     navigateToEditView: function navigateToEditView(action, selection) {
-      var view = this.app.getView(this.editView);
-      var key = selection.data[this.idProperty];
-      var options = {
-        key: key,
+      const view = this.app.getView(this.editView);
+      const key = selection.data[this.idProperty];
+      const options = {
+        key,
         selectedEntry: selection.data,
         fromContext: this,
         insert: true,
@@ -116,11 +118,9 @@ define('crm/Views/History/ListOffline', ['module', 'exports', 'dojo/_base/declar
       }
     },
     deleteNote: function deleteNote(action, selection) {
-      var _this = this;
-
-      var selectedEntry = selection && selection.data;
-      this.removeEntry(selectedEntry).then(function () {
-        _this.forceRefresh();
+      const selectedEntry = selection && selection.data;
+      this.removeEntry(selectedEntry).then(() => {
+        this.forceRefresh();
       });
     },
     show: function show() {
@@ -128,22 +128,20 @@ define('crm/Views/History/ListOffline', ['module', 'exports', 'dojo/_base/declar
       this.inherited(show, arguments);
     },
     _onRefresh: function _onRefresh(args) {
-      var _this2 = this;
-
       this.inherited(_onRefresh, arguments);
       if (typeof args === 'undefined' || args === null) {
         return;
       }
 
-      var entry = args.data;
+      const entry = args.data;
       if (typeof entry === 'undefined' || entry == null) {
         return;
       }
 
       if (args.resourceKind === 'history' && typeof args.id === 'undefined' && typeof args.key === 'undefined') {
         entry.UID = args.UID;
-        this.removeEntry(entry).then(function () {
-          _this2.forceRefresh();
+        this.removeEntry(entry).then(() => {
+          this.forceRefresh();
         });
       }
 
@@ -153,7 +151,7 @@ define('crm/Views/History/ListOffline', ['module', 'exports', 'dojo/_base/declar
       }
     },
     removeEntry: function removeEntry(entry) {
-      var model = this.getModel();
+      const model = this.getModel();
       return model.deleteEntry(entry);
     }
   });

--- a/src-out/Views/History/RelatedView.js
+++ b/src-out/Views/History/RelatedView.js
@@ -19,22 +19,22 @@ define('crm/Views/History/RelatedView', ['module', 'exports', 'dojo/_base/declar
     };
   }
 
-  var resource = (0, _I18n2.default)('historyRelated'); /* Copyright 2017 Infor
-                                                         *
-                                                         * Licensed under the Apache License, Version 2.0 (the "License");
-                                                         * you may not use this file except in compliance with the License.
-                                                         * You may obtain a copy of the License at
-                                                         *
-                                                         *    http://www.apache.org/licenses/LICENSE-2.0
-                                                         *
-                                                         * Unless required by applicable law or agreed to in writing, software
-                                                         * distributed under the License is distributed on an "AS IS" BASIS,
-                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                         * See the License for the specific language governing permissions and
-                                                         * limitations under the License.
-                                                         */
+  const resource = (0, _I18n2.default)('historyRelated'); /* Copyright 2017 Infor
+                                                           *
+                                                           * Licensed under the Apache License, Version 2.0 (the "License");
+                                                           * you may not use this file except in compliance with the License.
+                                                           * You may obtain a copy of the License at
+                                                           *
+                                                           *    http://www.apache.org/licenses/LICENSE-2.0
+                                                           *
+                                                           * Unless required by applicable law or agreed to in writing, software
+                                                           * distributed under the License is distributed on an "AS IS" BASIS,
+                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                           * See the License for the specific language governing permissions and
+                                                           * limitations under the License.
+                                                           */
 
-  var __class = (0, _declare2.default)('crm.Views.History.RelatedView', [_RelatedViewWidget2.default], {
+  const __class = (0, _declare2.default)('crm.Views.History.RelatedView', [_RelatedViewWidget2.default], {
     // Localization
     regardingText: resource.regardingText,
     byText: resource.byText,

--- a/src-out/Views/HistoryAttendee/Detail.js
+++ b/src-out/Views/HistoryAttendee/Detail.js
@@ -32,9 +32,9 @@ define('crm/Views/HistoryAttendee/Detail', ['module', 'exports', 'dojo/_base/dec
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('historyAttendeeDetail');
+  const resource = (0, _I18n2.default)('historyAttendeeDetail');
 
-  var __class = (0, _declare2.default)('crm.Views.HistoryAttendee.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.HistoryAttendee.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     entityText: resource.entityText,

--- a/src-out/Views/HistoryAttendee/List.js
+++ b/src-out/Views/HistoryAttendee/List.js
@@ -23,22 +23,22 @@ define('crm/Views/HistoryAttendee/List', ['module', 'exports', 'dojo/_base/decla
     };
   }
 
-  var resource = (0, _I18n2.default)('historyAttendeeList'); /* Copyright 2020 Infor
-                                                              *
-                                                              * Licensed under the Apache License, Version 2.0 (the "License");
-                                                              * you may not use this file except in compliance with the License.
-                                                              * You may obtain a copy of the License at
-                                                              *
-                                                              *    http://www.apache.org/licenses/LICENSE-2.0
-                                                              *
-                                                              * Unless required by applicable law or agreed to in writing, software
-                                                              * distributed under the License is distributed on an "AS IS" BASIS,
-                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                              * See the License for the specific language governing permissions and
-                                                              * limitations under the License.
-                                                              */
+  const resource = (0, _I18n2.default)('historyAttendeeList'); /* Copyright 2020 Infor
+                                                                *
+                                                                * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                * you may not use this file except in compliance with the License.
+                                                                * You may obtain a copy of the License at
+                                                                *
+                                                                *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                *
+                                                                * Unless required by applicable law or agreed to in writing, software
+                                                                * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                * See the License for the specific language governing permissions and
+                                                                * limitations under the License.
+                                                                */
 
-  var __class = (0, _declare2.default)('crm.Views.HistoryAttendee.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.HistoryAttendee.List', [_List2.default], {
     // Localization
     titleText: resource.titleText,
     callPhoneActionText: resource.callPhoneActionText,
@@ -58,7 +58,7 @@ define('crm/Views/HistoryAttendee/List', ['module', 'exports', 'dojo/_base/decla
     modelName: _Names2.default.HISTORYATTENDEE,
 
     callPhone: function callPhone(params) {
-      this.invokeActionItemBy(function (a) {
+      this.invokeActionItemBy(a => {
         return a.id === 'callPhone';
       }, params.key);
     },
@@ -66,7 +66,7 @@ define('crm/Views/HistoryAttendee/List', ['module', 'exports', 'dojo/_base/decla
       return _Format2.default.phone(phone);
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      return 'upper(Name) like "%' + this.escapeSearchQuery(searchQuery.toUpperCase()) + '%"';
+      return `upper(Name) like "%${this.escapeSearchQuery(searchQuery.toUpperCase())}%"`;
     },
     getTitle: function getTitle(entry) {
       if (!entry) {

--- a/src-out/Views/Home.js
+++ b/src-out/Views/Home.js
@@ -19,20 +19,20 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
     };
   }
 
-  var resource = (0, _I18n2.default)('home'); /* Copyright 2017 Infor
-                                               *
-                                               * Licensed under the Apache License, Version 2.0 (the "License");
-                                               * you may not use this file except in compliance with the License.
-                                               * You may obtain a copy of the License at
-                                               *
-                                               *    http://www.apache.org/licenses/LICENSE-2.0
-                                               *
-                                               * Unless required by applicable law or agreed to in writing, software
-                                               * distributed under the License is distributed on an "AS IS" BASIS,
-                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                               * See the License for the specific language governing permissions and
-                                               * limitations under the License.
-                                               */
+  const resource = (0, _I18n2.default)('home'); /* Copyright 2017 Infor
+                                                 *
+                                                 * Licensed under the Apache License, Version 2.0 (the "License");
+                                                 * you may not use this file except in compliance with the License.
+                                                 * You may obtain a copy of the License at
+                                                 *
+                                                 *    http://www.apache.org/licenses/LICENSE-2.0
+                                                 *
+                                                 * Unless required by applicable law or agreed to in writing, software
+                                                 * distributed under the License is distributed on an "AS IS" BASIS,
+                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                 * See the License for the specific language governing permissions and
+                                                 * limitations under the License.
+                                                 */
 
   /*eslint-disable*/
 
@@ -59,13 +59,13 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
     addAccountContactView: 'add_account_contact',
     searchView: 'speedsearch_list',
 
-    navigateToView: function navigateToView(params) {
+    navigateToView: function (params) {
       var view = App.getView(params && params.view);
       if (view) {
         view.show();
       }
     },
-    addAccountContact: function addAccountContact() {
+    addAccountContact: function () {
       var view = App.getView(this.addAccountContactView);
       if (view) {
         view.show({
@@ -73,17 +73,17 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
         });
       }
     },
-    formatSearchQuery: function formatSearchQuery(searchQuery) {
+    formatSearchQuery: function (searchQuery) {
       var expression = new RegExp(searchQuery, 'i');
 
       return function (entry) {
         return expression.test(entry.title);
       };
     },
-    hasMoreData: function hasMoreData() {
+    hasMoreData: function () {
       return false;
     },
-    getGroupForEntry: function getGroupForEntry(entry) {
+    getGroupForEntry: function (entry) {
       if (entry.view) {
         return {
           tag: 'view',
@@ -101,7 +101,7 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
 
       this.connect(App, 'onRegistered', this._onRegistered);
     },
-    createToolLayout: function createToolLayout() {
+    createToolLayout: function () {
       return this.tools || (this.tools = {
         tbar: [{
           id: 'configure',
@@ -109,7 +109,7 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
         }]
       });
     },
-    createLayout: function createLayout() {
+    createLayout: function () {
       // don't need to cache as it is only re-rendered when there is a change
       var configured, layout, visible, i, view;
 
@@ -145,7 +145,7 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
 
       return layout;
     },
-    requestData: function requestData() {
+    requestData: function () {
       var layout = this._createCustomizedLayout(this.createLayout()),
           i,
           j,
@@ -171,7 +171,7 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
       this.processData(list);
     },
 
-    _onSearchExpression: function _onSearchExpression(expression) {
+    _onSearchExpression: function (expression) {
       var view = App.getView(this.searchView);
 
       if (view) {
@@ -181,26 +181,16 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
       }
     },
 
-    navigateToConfigurationView: function navigateToConfigurationView() {
+    navigateToConfigurationView: function () {
       var view = App.getView(this.configurationView);
       if (view) {
         view.show();
       }
     },
-    _onRegistered: function _onRegistered() {
+    _onRegistered: function () {
       this.refreshRequired = true;
     },
-    refreshRequiredFor: function (_refreshRequiredFor) {
-      function refreshRequiredFor() {
-        return _refreshRequiredFor.apply(this, arguments);
-      }
-
-      refreshRequiredFor.toString = function () {
-        return _refreshRequiredFor.toString();
-      };
-
-      return refreshRequiredFor;
-    }(function () {
+    refreshRequiredFor: function () {
       var visible = _lang2.default.getObject('preferences.home.visible', false, App) || [],
           i,
           shown = this.feed && this.feed['$resources'];
@@ -216,7 +206,7 @@ define('crm/Views/Home', ['module', 'exports', 'dojo/_base/declare', 'dojo/_base
       }
 
       return this.inherited(refreshRequiredFor, arguments);
-    })
+    }
   });
 
   exports.default = __class;

--- a/src-out/Views/LanguageOptions/Edit.js
+++ b/src-out/Views/LanguageOptions/Edit.js
@@ -19,22 +19,22 @@ define('crm/Views/LanguageOptions/Edit', ['module', 'exports', 'dojo/_base/decla
     };
   }
 
-  var resource = (0, _I18n2.default)('languageOptionsEdit'); /* Copyright 2017 Infor
-                                                              *
-                                                              * Licensed under the Apache License, Version 2.0 (the "License");
-                                                              * you may not use this file except in compliance with the License.
-                                                              * You may obtain a copy of the License at
-                                                              *
-                                                              *    http://www.apache.org/licenses/LICENSE-2.0
-                                                              *
-                                                              * Unless required by applicable law or agreed to in writing, software
-                                                              * distributed under the License is distributed on an "AS IS" BASIS,
-                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                              * See the License for the specific language governing permissions and
-                                                              * limitations under the License.
-                                                              */
+  const resource = (0, _I18n2.default)('languageOptionsEdit'); /* Copyright 2017 Infor
+                                                                *
+                                                                * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                * you may not use this file except in compliance with the License.
+                                                                * You may obtain a copy of the License at
+                                                                *
+                                                                *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                *
+                                                                * Unless required by applicable law or agreed to in writing, software
+                                                                * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                * See the License for the specific language governing permissions and
+                                                                * limitations under the License.
+                                                                */
 
-  var __class = (0, _declare2.default)('crm.Views.LanguageOptions.Edit', [_EditBase3.default, _RelatedViewWidgetEditMixin2.default], {
+  const __class = (0, _declare2.default)('crm.Views.LanguageOptions.Edit', [_EditBase3.default, _RelatedViewWidgetEditMixin2.default], {
     // Localization
     titleText: resource.titleText,
     // View Properties
@@ -48,16 +48,14 @@ define('crm/Views/LanguageOptions/Edit', ['module', 'exports', 'dojo/_base/decla
       }]);
     },
     requestData: function requestData() {
-      var _this = this;
-
-      return this.getLanguageOptions().then(function (data) {
-        _this._onGetComplete(data);
-      }, function (err) {
-        _this._onGetError(null, err);
+      return this.getLanguageOptions().then(data => {
+        this._onGetComplete(data);
+      }, err => {
+        this._onGetError(null, err);
       });
     },
     getLanguageOptions: function getLanguageOptions() {
-      var def = new _Deferred2.default();
+      const def = new _Deferred2.default();
       def.resolve({});
       return def.promise;
     },

--- a/src-out/Views/LanguageOptions/UsageWidget.js
+++ b/src-out/Views/LanguageOptions/UsageWidget.js
@@ -40,9 +40,9 @@ define('crm/Views/LanguageOptions/UsageWidget', ['module', 'exports', 'dojo/_bas
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('languageUsageWidget');
+  const resource = (0, _I18n2.default)('languageUsageWidget');
 
-  var __class = (0, _declare2.default)('crm.Views.LanguageOptions.UsageWidget', [_RelatedViewWidgetBase3.default], {
+  const __class = (0, _declare2.default)('crm.Views.LanguageOptions.UsageWidget', [_RelatedViewWidgetBase3.default], {
     // Localization
     regionText: resource.regionText,
     languageText: resource.languageText,
@@ -54,39 +54,37 @@ define('crm/Views/LanguageOptions/UsageWidget', ['module', 'exports', 'dojo/_bas
     cls: 'related-language-usage-widget',
     relatedContentTemplate: new Simplate(['<div class="language-usage">', '<span data-dojo-attach-point="_languageNode" ></span>', '<span data-dojo-attach-point="_regionThanNode" ></span>', '</div>']),
     onInit: function onInit() {
-      var _this = this;
-
       this.languageService = new _LanguageService2.default();
       this.onLoad();
       if (this.owner) {
-        _aspect2.default.after(this.owner, 'show', function () {
-          _this.onRefreshView();
+        _aspect2.default.after(this.owner, 'show', () => {
+          this.onRefreshView();
         });
 
-        _aspect2.default.after(this.owner, 'save', function () {
-          _this.onSave();
+        _aspect2.default.after(this.owner, 'save', () => {
+          this.onSave();
         });
       }
     },
     onLoad: function onLoad() {
-      var language = this.languageService.getLanguage('language');
-      var region = this.languageService.getRegion('region');
+      const language = this.languageService.getLanguage('language');
+      const region = this.languageService.getRegion('region');
       this.initUI(language || 'en', region || 'en');
     },
     initUI: function initUI(lang, region) {
-      var dropDownMap = function dropDownMap(key) {
+      const dropDownMap = key => {
         return {
           value: key,
           text: window.languages[key],
-          key: key
+          key
         };
       };
 
-      var locales = Object.keys(window.languages).filter(function (key) {
+      const locales = Object.keys(window.languages).filter(key => {
         return window.localeContext.supportedLocales.indexOf(key) > -1;
       }).map(dropDownMap);
 
-      var regions = Object.keys(window.languages).filter(function (key) {
+      const regions = Object.keys(window.languages).filter(key => {
         return window.regionalContext.supportedLocales.indexOf(key) > -1;
       }).map(dropDownMap);
 
@@ -143,8 +141,8 @@ define('crm/Views/LanguageOptions/UsageWidget', ['module', 'exports', 'dojo/_bas
       this.inherited(destroy, arguments);
     },
     onSave: function onSave() {
-      var language = this._languageDropdown.getValue();
-      var region = this._regionDropdown.getValue();
+      const language = this._languageDropdown.getValue();
+      const region = this._regionDropdown.getValue();
 
       try {
         this.languageService.setLanguage(language);
@@ -161,7 +159,7 @@ define('crm/Views/LanguageOptions/UsageWidget', ['module', 'exports', 'dojo/_bas
       }
     }
   });
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('languageUsageWidget', __class);
   exports.default = __class;
   module.exports = exports['default'];

--- a/src-out/Views/Lead/Detail.js
+++ b/src-out/Views/Lead/Detail.js
@@ -23,22 +23,22 @@ define('crm/Views/Lead/Detail', ['module', 'exports', 'dojo/_base/declare', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('leadDetail'); /* Copyright 2017 Infor
-                                                     *
-                                                     * Licensed under the Apache License, Version 2.0 (the "License");
-                                                     * you may not use this file except in compliance with the License.
-                                                     * You may obtain a copy of the License at
-                                                     *
-                                                     *    http://www.apache.org/licenses/LICENSE-2.0
-                                                     *
-                                                     * Unless required by applicable law or agreed to in writing, software
-                                                     * distributed under the License is distributed on an "AS IS" BASIS,
-                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                     * See the License for the specific language governing permissions and
-                                                     * limitations under the License.
-                                                     */
+  const resource = (0, _I18n2.default)('leadDetail'); /* Copyright 2017 Infor
+                                                       *
+                                                       * Licensed under the Apache License, Version 2.0 (the "License");
+                                                       * you may not use this file except in compliance with the License.
+                                                       * You may obtain a copy of the License at
+                                                       *
+                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                       *
+                                                       * Unless required by applicable law or agreed to in writing, software
+                                                       * distributed under the License is distributed on an "AS IS" BASIS,
+                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                       * See the License for the specific language governing permissions and
+                                                       * limitations under the License.
+                                                       */
 
-  var __class = (0, _declare2.default)('crm.Views.Lead.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Lead.Detail', [_Detail2.default], {
     // Localization
     accountText: resource.accountText,
     addressText: resource.addressText,
@@ -89,7 +89,7 @@ define('crm/Views/Lead/Detail', ['module', 'exports', 'dojo/_base/declare', 'doj
       _Action2.default.navigateToHistoryInsert(entry);
     },
     recordCallToHistory: function recordCallToHistory(phoneNumber) {
-      var entry = {
+      const entry = {
         $name: 'History',
         Type: 'atPhoneCall',
         AccountName: this.entry.Company,
@@ -106,7 +106,7 @@ define('crm/Views/Lead/Detail', ['module', 'exports', 'dojo/_base/declare', 'doj
       App.initiateCall(phoneNumber);
     },
     recordEmailToHistory: function recordEmailToHistory(email) {
-      var entry = {
+      const entry = {
         $name: 'History',
         Type: 'atEMail',
         AccountName: this.entry.Company,
@@ -144,7 +144,7 @@ define('crm/Views/Lead/Detail', ['module', 'exports', 'dojo/_base/declare', 'doj
       App.navigateToActivityInsertView();
     },
     addNote: function addNote() {
-      var view = App.getView(this.noteEditView);
+      const view = App.getView(this.noteEditView);
       if (view) {
         view.show({
           template: {},

--- a/src-out/Views/Lead/Edit.js
+++ b/src-out/Views/Lead/Edit.js
@@ -19,22 +19,22 @@ define('crm/Views/Lead/Edit', ['module', 'exports', 'dojo/_base/declare', '../..
     };
   }
 
-  var resource = (0, _I18n2.default)('leadEdit'); /* Copyright 2017 Infor
-                                                   *
-                                                   * Licensed under the Apache License, Version 2.0 (the "License");
-                                                   * you may not use this file except in compliance with the License.
-                                                   * You may obtain a copy of the License at
-                                                   *
-                                                   *    http://www.apache.org/licenses/LICENSE-2.0
-                                                   *
-                                                   * Unless required by applicable law or agreed to in writing, software
-                                                   * distributed under the License is distributed on an "AS IS" BASIS,
-                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                   * See the License for the specific language governing permissions and
-                                                   * limitations under the License.
-                                                   */
+  const resource = (0, _I18n2.default)('leadEdit'); /* Copyright 2017 Infor
+                                                     *
+                                                     * Licensed under the Apache License, Version 2.0 (the "License");
+                                                     * you may not use this file except in compliance with the License.
+                                                     * You may obtain a copy of the License at
+                                                     *
+                                                     *    http://www.apache.org/licenses/LICENSE-2.0
+                                                     *
+                                                     * Unless required by applicable law or agreed to in writing, software
+                                                     * distributed under the License is distributed on an "AS IS" BASIS,
+                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                     * See the License for the specific language governing permissions and
+                                                     * limitations under the License.
+                                                     */
 
-  var __class = (0, _declare2.default)('crm.Views.Lead.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Lead.Edit', [_Edit2.default], {
     // Localization
     accountText: resource.accountText,
     addressText: resource.addressText,

--- a/src-out/Views/Lead/List.js
+++ b/src-out/Views/Lead/List.js
@@ -44,9 +44,9 @@ define('crm/Views/Lead/List', ['module', 'exports', 'dojo/_base/declare', '../..
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('leadList');
+  const resource = (0, _I18n2.default)('leadList');
 
-  var __class = (0, _declare2.default)('crm.Views.Lead.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Lead.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">', '{%: $$.joinFields(" | ", [$$.formatPicklist("Title")($.Title), $.Company]) %}', '</p>', '{% if ($.WorkPhone) { %}', '<p class="micro-text">', '{%: $$.phoneAbbreviationText %} <span class="hyperlink" data-action="callWork" data-key="{%: $.$key %}">{%: argos.Format.phone($.WorkPhone) %}</span>', // TODO: Avoid global
     '</p>', '{% } %}', '{% if ($.Mobile) { %}', '<p class="micro-text">', '{%: $$.mobileAbbreviationText %} <span class="hyperlink" data-action="callMobile" data-key="{%: $.$key %}">{%: argos.Format.phone($.Mobile) %}</span>', // TODO: Avoid global
@@ -57,17 +57,17 @@ define('crm/Views/Lead/List', ['module', 'exports', 'dojo/_base/declare', '../..
       return _Utility2.default.joinFields(sep, fields);
     },
     callWork: function callWork(params) {
-      this.invokeActionItemBy(function (theAction) {
+      this.invokeActionItemBy(theAction => {
         return theAction.id === 'callWork';
       }, params.key);
     },
     callMobile: function callMobile(params) {
-      this.invokeActionItemBy(function (theAction) {
+      this.invokeActionItemBy(theAction => {
         return theAction.id === 'callMobile';
       }, params.key);
     },
     sendEmail: function sendEmail(params) {
-      this.invokeActionItemBy(function (theAction) {
+      this.invokeActionItemBy(theAction => {
         return theAction.id === 'sendEmail';
       }, params.key);
     },
@@ -109,8 +109,6 @@ define('crm/Views/Lead/List', ['module', 'exports', 'dojo/_base/declare', '../..
     allowSelection: true,
     enableActions: true,
     createActionLayout: function createActionLayout() {
-      var _this = this;
-
       return this.actions || (this.actions = [{
         id: 'edit',
         cls: 'edit',
@@ -122,27 +120,27 @@ define('crm/Views/Lead/List', ['module', 'exports', 'dojo/_base/declare', '../..
         cls: 'phone',
         label: this.callWorkActionText,
         enabled: _Action2.default.hasProperty.bindDelegate(this, 'WorkPhone'),
-        fn: function fn(act, selectionIn) {
-          var selectionOut = _this.linkLeadProperties(selectionIn);
-          _Action2.default.callPhone.call(_this, act, selectionOut, 'WorkPhone');
+        fn: (act, selectionIn) => {
+          const selectionOut = this.linkLeadProperties(selectionIn);
+          _Action2.default.callPhone.call(this, act, selectionOut, 'WorkPhone');
         }
       }, {
         id: 'callMobile',
         cls: 'phone',
         label: this.callMobileActionText,
         enabled: _Action2.default.hasProperty.bindDelegate(this, 'Mobile'),
-        fn: function fn(act, selectionIn) {
-          var selectionOut = _this.linkLeadProperties(selectionIn);
-          _Action2.default.callPhone.call(_this, act, selectionOut, 'Mobile');
+        fn: (act, selectionIn) => {
+          const selectionOut = this.linkLeadProperties(selectionIn);
+          _Action2.default.callPhone.call(this, act, selectionOut, 'Mobile');
         }
       }, {
         id: 'sendEmail',
         cls: 'mail',
         label: this.sendEmailActionText,
         enabled: _Action2.default.hasProperty.bindDelegate(this, 'Email'),
-        fn: function fn(act, selectionIn) {
-          var selectionOut = _this.linkLeadProperties(selectionIn);
-          _Action2.default.sendEmail.call(_this, act, selectionOut, 'Email');
+        fn: (act, selectionIn) => {
+          const selectionOut = this.linkLeadProperties(selectionIn);
+          _Action2.default.sendEmail.call(this, act, selectionOut, 'Email');
         }
       }, {
         id: 'addNote',
@@ -162,10 +160,8 @@ define('crm/Views/Lead/List', ['module', 'exports', 'dojo/_base/declare', '../..
       }]);
     },
 
-    linkLeadProperties: function linkLeadProperties() {
-      var selection = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-      var data = selection.data;
-
+    linkLeadProperties: function linkLeadProperties(selection = {}) {
+      const { data } = selection;
 
       if (data) {
         selection.data.LeadId = data.$key;
@@ -183,8 +179,8 @@ define('crm/Views/Lead/List', ['module', 'exports', 'dojo/_base/declare', '../..
     },
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(LastNameUpper like "' + q + '%" or upper(FirstName) like "' + q + '%" or CompanyUpper like "' + q + '%" or upper(LeadNameLastFirst) like "%' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(LastNameUpper like "${q}%" or upper(FirstName) like "${q}%" or CompanyUpper like "${q}%" or upper(LeadNameLastFirst) like "%${q}%")`;
     }
   });
 

--- a/src-out/Views/LeadSource/List.js
+++ b/src-out/Views/LeadSource/List.js
@@ -15,22 +15,22 @@ define('crm/Views/LeadSource/List', ['module', 'exports', 'dojo/_base/declare', 
     };
   }
 
-  var resource = (0, _I18n2.default)('leadSourceList'); /* Copyright 2017 Infor
-                                                         *
-                                                         * Licensed under the Apache License, Version 2.0 (the "License");
-                                                         * you may not use this file except in compliance with the License.
-                                                         * You may obtain a copy of the License at
-                                                         *
-                                                         *    http://www.apache.org/licenses/LICENSE-2.0
-                                                         *
-                                                         * Unless required by applicable law or agreed to in writing, software
-                                                         * distributed under the License is distributed on an "AS IS" BASIS,
-                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                         * See the License for the specific language governing permissions and
-                                                         * limitations under the License.
-                                                         */
+  const resource = (0, _I18n2.default)('leadSourceList'); /* Copyright 2017 Infor
+                                                           *
+                                                           * Licensed under the Apache License, Version 2.0 (the "License");
+                                                           * you may not use this file except in compliance with the License.
+                                                           * You may obtain a copy of the License at
+                                                           *
+                                                           *    http://www.apache.org/licenses/LICENSE-2.0
+                                                           *
+                                                           * Unless required by applicable law or agreed to in writing, software
+                                                           * distributed under the License is distributed on an "AS IS" BASIS,
+                                                           * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                           * See the License for the specific language governing permissions and
+                                                           * limitations under the License.
+                                                           */
 
-  var __class = (0, _declare2.default)('crm.Views.LeadSource.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.LeadSource.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">{%: $.Status %}</p>']),
 
@@ -45,8 +45,8 @@ define('crm/Views/LeadSource/List', ['module', 'exports', 'dojo/_base/declare', 
     resourceKind: 'leadsources',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Description) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Description) like "${q}%"`;
     }
   });
 

--- a/src-out/Views/LeftDrawer.js
+++ b/src-out/Views/LeftDrawer.js
@@ -23,22 +23,22 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
     };
   }
 
-  var resource = (0, _I18n2.default)('leftDrawer'); /* Copyright 2017 Infor
-                                                     *
-                                                     * Licensed under the Apache License, Version 2.0 (the "License");
-                                                     * you may not use this file except in compliance with the License.
-                                                     * You may obtain a copy of the License at
-                                                     *
-                                                     *    http://www.apache.org/licenses/LICENSE-2.0
-                                                     *
-                                                     * Unless required by applicable law or agreed to in writing, software
-                                                     * distributed under the License is distributed on an "AS IS" BASIS,
-                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                     * See the License for the specific language governing permissions and
-                                                     * limitations under the License.
-                                                     */
+  const resource = (0, _I18n2.default)('leftDrawer'); /* Copyright 2017 Infor
+                                                       *
+                                                       * Licensed under the Apache License, Version 2.0 (the "License");
+                                                       * you may not use this file except in compliance with the License.
+                                                       * You may obtain a copy of the License at
+                                                       *
+                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                       *
+                                                       * Unless required by applicable law or agreed to in writing, software
+                                                       * distributed under the License is distributed on an "AS IS" BASIS,
+                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                       * See the License for the specific language governing permissions and
+                                                       * limitations under the License.
+                                                       */
 
-  var __class = (0, _declare2.default)('crm.Views.LeftDrawer', [_GroupedList2.default], {
+  const __class = (0, _declare2.default)('crm.Views.LeftDrawer', [_GroupedList2.default], {
     // Templates
     cls: ' contextualContent',
     enablePullToRefresh: false,
@@ -79,18 +79,18 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
       this.inherited(initSoho, arguments);
     },
     shouldCloseAppMenuOnAction: function shouldCloseAppMenu() {
-      var menu = App.applicationmenu;
+      const menu = App.applicationmenu;
       return !menu.isLargerThanBreakpoint();
     },
     closeAppMenu: function closeAppMenu() {
-      var menu = App.applicationmenu;
+      const menu = App.applicationmenu;
 
       if (menu && this.shouldCloseAppMenuOnAction()) {
         menu.closeMenu();
       }
     },
     logOut: function logOut() {
-      var sure = window.confirm(this.logOutConfirmText); // eslint-disable-line
+      const sure = window.confirm(this.logOutConfirmText); // eslint-disable-line
       if (sure) {
         this.destroy();
         App.hideApplicationMenu();
@@ -99,7 +99,7 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
       }
     },
     loadAndNavigateToView: function loadAndNavigateToView(params) {
-      var view = App.getView(params && params.view);
+      const view = App.getView(params && params.view);
       this.navigateToView(view);
     },
     navigateToView: function navigateToView(view) {
@@ -109,7 +109,7 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
       }
     },
     addAccountContact: function addAccountContact() {
-      var view = App.getView('add_account_contact');
+      const view = App.getView('add_account_contact');
       if (view) {
         view.show({
           insert: true
@@ -118,22 +118,22 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
       }
     },
     navigateToConfigurationView: function navigateToConfigurationView() {
-      var view = App.getView(this.configurationView);
+      const view = App.getView(this.configurationView);
       this.navigateToView(view);
     },
     navigateToSettingsView: function navigateToSettingsView() {
-      var view = App.getView(this.settingsView);
+      const view = App.getView(this.settingsView);
       this.navigateToView(view);
     },
     navigateToHelpView: function navigateToHelpView() {
-      var view = App.getView(this.helpView);
+      const view = App.getView(this.helpView);
       this.navigateToView(view);
     },
     hasMoreData: function hasMoreData() {
       return false;
     },
     getGroupForEntry: function getGroupForEntry(entry) {
-      var footerItems = ['ConfigureMenu', 'SettingsAction', 'HelpAction', 'Logout', 'ConnectionIndicator', 'AboutAction'];
+      const footerItems = ['ConfigureMenu', 'SettingsAction', 'HelpAction', 'Logout', 'ConnectionIndicator', 'AboutAction'];
 
       if (entry.view) {
         return {
@@ -163,9 +163,9 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
         return this.layout;
       }
 
-      var layout = [];
+      const layout = [];
 
-      var quickActions = {
+      const quickActions = {
         id: 'actions',
         children: [{
           name: 'AddAccountContactAction',
@@ -177,14 +177,14 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
 
       layout.push(quickActions);
 
-      var goTo = {
+      const goTo = {
         id: 'views',
         children: []
       };
 
-      var configured = _lang2.default.getObject('preferences.home.visible', false, window.App);
-      for (var i = 0; configured && i < configured.length; i++) {
-        var view = App.getView(configured[i]);
+      const configured = _lang2.default.getObject('preferences.home.visible', false, window.App);
+      for (let i = 0; configured && i < configured.length; i++) {
+        const view = App.getView(configured[i]);
         if (view) {
           goTo.children.push({
             action: 'loadAndNavigateToView',
@@ -200,7 +200,7 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
 
       layout.push(goTo);
 
-      var footer = {
+      const footer = {
         id: 'footer',
         children: [{
           name: 'ConfigureMenu',
@@ -241,21 +241,21 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
       $('body').about({
         appName: 'Infor CRM SLX',
         version: App.getVersionInfo(),
-        content: '<p>' + this.currentUserText + ' ' + App.context.user.$descriptor + '</p>'
+        content: `<p>${this.currentUserText} ${App.context.user.$descriptor}</p>`
       });
     },
     createStore: function createStore() {
-      var layout = this._createCustomizedLayout(this.createLayout());
-      var list = [];
-      var total = 0;
-      var section = void 0;
+      const layout = this._createCustomizedLayout(this.createLayout());
+      const list = [];
+      let total = 0;
+      let section;
 
-      for (var i = 0; i < layout.length; i++) {
+      for (let i = 0; i < layout.length; i++) {
         section = layout[i].children;
 
-        for (var j = 0; j < section.length; j++) {
+        for (let j = 0; j < section.length; j++) {
           total = total + 1;
-          var row = section[j];
+          const row = section[j];
           row.$key = total;
 
           if (row.disabled) {
@@ -279,7 +279,7 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
         }
       }
 
-      var store = new _Memory2.default({
+      const store = new _Memory2.default({
         data: list
       });
       store.idProperty = '$key';
@@ -316,14 +316,14 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
       this.refresh();
     },
     refreshRequiredFor: function refreshRequiredFor() {
-      var visible = _lang2.default.getObject('preferences.home.visible', false, App) || [];
-      var shown = this.feed && this.feed.$resources;
+      const visible = _lang2.default.getObject('preferences.home.visible', false, App) || [];
+      const shown = this.feed && this.feed.$resources;
 
       if (!visible || !shown || visible.length !== shown.length) {
         return true;
       }
 
-      for (var i = 0; i < visible.length; i++) {
+      for (let i = 0; i < visible.length; i++) {
         if (visible[i] !== shown[i].$key) {
           return true;
         }
@@ -335,8 +335,8 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
       this.refreshRequired = true;
     },
     _onSearchExpression: function _onSearchExpression(expression) {
-      var view = App.getView(this.searchView);
-      var current = App.getPrimaryActiveView();
+      const view = App.getView(this.searchView);
+      const current = App.getPrimaryActiveView();
 
       if (view) {
         // If the speedsearch list is not our current view, show it first
@@ -348,7 +348,7 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
 
         // Set the search term on the list and call search.
         // This will keep the search terms on each widget in sync.
-        setTimeout(function () {
+        setTimeout(() => {
           view.setSearchTerm(expression);
           if (current && current.id === view.id) {
             view.search();
@@ -361,8 +361,7 @@ define('crm/Views/LeftDrawer', ['module', 'exports', 'dojo/_base/declare', 'dojo
       if (typeof state === 'undefined') {
         return;
       }
-      var searchTerm = state.app.speedsearch.searchTerm;
-
+      const { app: { speedsearch: { searchTerm } } } = state;
       this.searchWidget.set('queryValue', searchTerm);
     }
   });

--- a/src-out/Views/LogOff.js
+++ b/src-out/Views/LogOff.js
@@ -15,22 +15,22 @@ define('crm/Views/LogOff', ['module', 'exports', 'dojo/_base/declare', 'argos/Vi
     };
   }
 
-  var resource = (0, _I18n2.default)('logOff'); /* Copyright 2017 Infor
-                                                 *
-                                                 * Licensed under the Apache License, Version 2.0 (the "License");
-                                                 * you may not use this file except in compliance with the License.
-                                                 * You may obtain a copy of the License at
-                                                 *
-                                                 *    http://www.apache.org/licenses/LICENSE-2.0
-                                                 *
-                                                 * Unless required by applicable law or agreed to in writing, software
-                                                 * distributed under the License is distributed on an "AS IS" BASIS,
-                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                 * See the License for the specific language governing permissions and
-                                                 * limitations under the License.
-                                                 */
+  const resource = (0, _I18n2.default)('logOff'); /* Copyright 2017 Infor
+                                                   *
+                                                   * Licensed under the Apache License, Version 2.0 (the "License");
+                                                   * you may not use this file except in compliance with the License.
+                                                   * You may obtain a copy of the License at
+                                                   *
+                                                   *    http://www.apache.org/licenses/LICENSE-2.0
+                                                   *
+                                                   * Unless required by applicable law or agreed to in writing, software
+                                                   * distributed under the License is distributed on an "AS IS" BASIS,
+                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                   * See the License for the specific language governing permissions and
+                                                   * limitations under the License.
+                                                   */
 
-  var __class = (0, _declare2.default)('crm.Views.LogOff', [_View2.default], {
+  const __class = (0, _declare2.default)('crm.Views.LogOff', [_View2.default], {
     // Templates
     widgetTemplate: new Simplate(['<div class="panel">', '<div class="wrapper">', '<div data-title="{%: $.titleText %}" class="signin {%= $.cls %}" hideBackButton="true">', '<p>{%= $.messageText %}</p>', '<p><a href="#" class="hyperlink" data-action="login">{%: $.loginText %}</a></p>', '</div>', '</div>', '</div>']),
 

--- a/src-out/Views/Login.js
+++ b/src-out/Views/Login.js
@@ -15,24 +15,40 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
     };
   }
 
-  var resource = (0, _I18n2.default)('login'); /* Copyright 2017 Infor
-                                                *
-                                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                                * you may not use this file except in compliance with the License.
-                                                * You may obtain a copy of the License at
-                                                *
-                                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                                *
-                                                * Unless required by applicable law or agreed to in writing, software
-                                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                * See the License for the specific language governing permissions and
-                                                * limitations under the License.
-                                                */
+  const resource = (0, _I18n2.default)('login'); /* Copyright 2017 Infor
+                                                  *
+                                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                                  * you may not use this file except in compliance with the License.
+                                                  * You may obtain a copy of the License at
+                                                  *
+                                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                                  *
+                                                  * Unless required by applicable law or agreed to in writing, software
+                                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                  * See the License for the specific language governing permissions and
+                                                  * limitations under the License.
+                                                  */
 
-  var __class = (0, _declare2.default)('crm.Views.Login', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Login', [_Edit2.default], {
     // Templates
-    widgetTemplate: new Simplate(['\n      <div id="{%= $.id %}" data-title="{%: $.titleText %}" class="view">\n        <div class="wrapper">\n          <section class="signin" role="main">\n            <svg viewBox="0 0 34 34" class="icon icon-logo" focusable="false" aria-hidden="true" role="presentation" aria-label="Infor Logo">\n              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo"></use>\n            </svg>\n            <h1>Infor CRM SLX</h1>\n            <div class="panel-content" data-dojo-attach-event="onkeypress: _onKeyPress, onkeyup: _onKeyUp" data-dojo-attach-point="contentNode">\n            </div>\n            <div class="login-button-container">\n              <button data-dojo-attach-point="loginButton" class="btn-primary hide-focus" data-action="authenticate">{%: $.logOnText %}</button>\n            </div>\n          </section>\n        </div>\n      </div>\n    ']),
+    widgetTemplate: new Simplate([`
+      <div id="{%= $.id %}" data-title="{%: $.titleText %}" class="view">
+        <div class="wrapper">
+          <section class="signin" role="main">
+            <svg viewBox="0 0 34 34" class="icon icon-logo" focusable="false" aria-hidden="true" role="presentation" aria-label="Infor Logo">
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo"></use>
+            </svg>
+            <h1>Infor CRM SLX</h1>
+            <div class="panel-content" data-dojo-attach-event="onkeypress: _onKeyPress, onkeyup: _onKeyUp" data-dojo-attach-point="contentNode">
+            </div>
+            <div class="login-button-container">
+              <button data-dojo-attach-point="loginButton" class="btn-primary hide-focus" data-action="authenticate">{%: $.logOnText %}</button>
+            </div>
+          </section>
+        </div>
+      </div>
+    `]),
 
     id: 'login',
     busy: false,
@@ -61,7 +77,7 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
       }
     },
     _onKeyUp: function _onKeyUp() {
-      var username = this.fields['username-display'].getValue();
+      const username = this.fields['username-display'].getValue();
       if (username && username.length > 0) {
         $(this.domNode).addClass('login-active');
       } else {
@@ -69,7 +85,7 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
       }
     },
     initSoho: function initSoho() {
-      var header = $('.header', App.getContainerNode());
+      const header = $('.header', App.getContainerNode());
       header.hide();
     },
     show: function show() {
@@ -105,7 +121,7 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
       }
     },
     onShow: function onShow() {
-      var credentials = App.getCredentials();
+      const credentials = App.getCredentials();
 
       if (credentials) {
         App.authenticateUser(credentials, {
@@ -148,9 +164,9 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
         return;
       }
 
-      var values = this.getValues(true);
+      const values = this.getValues(true);
 
-      var credentials = {
+      const credentials = {
         username: values['username-display'],
         password: values['password-display'],
         remember: values.remember
@@ -175,14 +191,14 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
       }, {
         name: 'PasswordExpired',
         test: function testExpiredPassword(error) {
-          var xhr = error && error.xhr;
+          const xhr = error && error.xhr;
           if (!xhr) {
             return false;
           }
 
           try {
-            var json = JSON.parse(xhr.responseText)[0];
-            var stackTrace = json.stackTrace || '';
+            const json = JSON.parse(xhr.responseText)[0];
+            const stackTrace = json.stackTrace || '';
             return stackTrace.indexOf('Sage.SalesLogix.User.Rules.IsValidPassword') > -1;
           } catch (_) {
             return false;
@@ -217,7 +233,7 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
           }
           this.enable();
 
-          var attr = this.domNode.attributes.getNamedItem('selected');
+          const attr = this.domNode.attributes.getNamedItem('selected');
           if (attr) {
             attr.value = 'false';
           }
@@ -225,7 +241,7 @@ define('crm/Views/Login', ['module', 'exports', 'dojo/_base/declare', 'argos/Edi
         },
         failure: function failure(result) {
           this.enable();
-          var error = new Error();
+          const error = new Error();
           error.status = result && result.response && result.response.status;
           error.xhr = result && result.response;
           this.handleError(error);

--- a/src-out/Views/MainToolbar.js
+++ b/src-out/Views/MainToolbar.js
@@ -32,17 +32,17 @@ define('crm/Views/MainToolbar', ['module', 'exports', 'dojo/_base/declare', 'doj
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('mainToolbar');
+  const resource = (0, _I18n2.default)('mainToolbar');
 
-  var __class = (0, _declare2.default)('crm.Views.MainToolbar', [_MainToolbar2.default], {
+  const __class = (0, _declare2.default)('crm.Views.MainToolbar', [_MainToolbar2.default], {
     backTooltipText: resource.backTooltipText,
 
     showTools: function showTools(tools) {
-      var isOnEdit = void 0;
-      var isOnFirstView = App.isOnFirstView();
+      let isOnEdit;
+      const isOnFirstView = App.isOnFirstView();
 
       if (tools) {
-        for (var i = 0; i < tools.length; i++) {
+        for (let i = 0; i < tools.length; i++) {
           if (tools[i].id === 'cancel') {
             isOnEdit = true;
           }
@@ -73,10 +73,10 @@ define('crm/Views/MainToolbar', ['module', 'exports', 'dojo/_base/declare', 'doj
       App.navigateToHomeView();
     },
     onTitleClick: function onTitleClick() {
-      var view = App.getPrimaryActiveView();
+      const view = App.getPrimaryActiveView();
 
       if (view) {
-        var scrollerNode = view.get('scroller');
+        const scrollerNode = view.get('scroller');
         if ((0, _has2.default)('android')) {
           // Hack to work around https://code.google.com/p/android/issues/detail?id=19625
           $(scrollerNode).css('overflow', 'hidden');

--- a/src-out/Views/MetricWidget.js
+++ b/src-out/Views/MetricWidget.js
@@ -47,13 +47,13 @@ define('crm/Views/MetricWidget', ['module', 'exports', 'dojo/_base/declare', 'do
   /**
    * @module crm/Views/MetricWidget
    */
-  var resource = (0, _I18n2.default)('metricWidget');
+  const resource = (0, _I18n2.default)('metricWidget');
 
   /**
    * @class
    * @alias module:crm/Views/MetricWidget
    */
-  var __class = (0, _declare2.default)('crm.Views.MetricWidget', [_Widget3.default, _Templated3.default], /** @lends module:crm/Views/MetricWidget.prototype */{
+  const __class = (0, _declare2.default)('crm.Views.MetricWidget', [_Widget3.default, _Templated3.default], /** @lends module:crm/Views/MetricWidget.prototype */{
     /**
      * @property {Simplate}
      * Simple that defines the HTML Markup
@@ -119,12 +119,8 @@ define('crm/Views/MetricWidget', ['module', 'exports', 'dojo/_base/declare', 'do
      * @param {Array} data Array of data used for the metric
      * @return {int} Returns a value calculated from data (SUM/AVG/MAX/MIN/Whatever)
      */
-    valueFn: function valueFn() {
-      var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-
-      return data.reduce(function (p, c) {
-        return p + c.value;
-      }, 0);
+    valueFn: function valueFn(data = []) {
+      return data.reduce((p, c) => p + c.value, 0);
     },
 
     // Functions can't be stored in localstorage, save the module/fn strings and load them later via AMD
@@ -135,8 +131,6 @@ define('crm/Views/MetricWidget', ['module', 'exports', 'dojo/_base/declare', 'do
      * Requests the widget's data, value fn, format fn, and renders it's itemTemplate
      */
     requestData: function requestData() {
-      var _this = this;
-
       this.inherited(requestData, arguments);
 
       if (this._data && this._data.length > 0) {
@@ -147,23 +141,23 @@ define('crm/Views/MetricWidget', ['module', 'exports', 'dojo/_base/declare', 'do
       this.requestDataDeferred = new _Deferred2.default();
       this._getData();
 
-      this.requestDataDeferred.then(function (results) {
-        var data = results;
+      this.requestDataDeferred.then(results => {
+        const data = results;
         if (!data) {
           throw new Error('An error occurred loading the KPI widget data.');
         }
 
-        _this.valueFn = _this.aggregateModule[_this.aggregate];
-        _this.formatter = _this.formatModule[_this.formatter];
+        this.valueFn = this.aggregateModule[this.aggregate];
+        this.formatter = this.formatModule[this.formatter];
 
-        var value = _this.value = _this.valueFn.call(_this, data);
-        $(_this.metricDetailNode).replaceWith(_this.itemTemplate.apply({
-          value: value
-        }, _this));
-      }, function (err) {
+        const value = this.value = this.valueFn.call(this, data);
+        $(this.metricDetailNode).replaceWith(this.itemTemplate.apply({
+          value
+        }, this));
+      }, err => {
         // Error
         console.error(err); // eslint-disable-line
-        $(_this.metricDetailNode).replaceWith(_this.errorTemplate.apply({}, _this));
+        $(this.metricDetailNode).replaceWith(this.errorTemplate.apply({}, this));
       });
     },
     navToReportView: function navToReportView() {
@@ -171,7 +165,7 @@ define('crm/Views/MetricWidget', ['module', 'exports', 'dojo/_base/declare', 'do
         return;
       }
 
-      var view = App.getView(this.chartTypeMapping[this.chartType]);
+      const view = App.getView(this.chartTypeMapping[this.chartType]);
 
       if (view) {
         view.parent = this;
@@ -193,29 +187,27 @@ define('crm/Views/MetricWidget', ['module', 'exports', 'dojo/_base/declare', 'do
       return null;
     },
     _getData: function _getData() {
-      var queryOptions = this._buildQueryOptions();
-      var queryExpression = this._buildQueryExpression();
-      var store = this.get('store');
-      var queryResults = store.query(queryExpression, queryOptions);
+      const queryOptions = this._buildQueryOptions();
+      const queryExpression = this._buildQueryExpression();
+      const store = this.get('store');
+      const queryResults = store.query(queryExpression, queryOptions);
       (0, _when2.default)(queryResults, _lang2.default.hitch(this, this._onQuerySuccess, queryResults), _lang2.default.hitch(this, this._onQueryError));
     },
     _onQuerySuccess: function _onQuerySuccess(queryResults) {
-      var _this2 = this;
+      (0, _when2.default)(queryResults.total, total => {
+        queryResults.forEach(_lang2.default.hitch(this, this._processItem));
 
-      (0, _when2.default)(queryResults.total, function (total) {
-        queryResults.forEach(_lang2.default.hitch(_this2, _this2._processItem));
-
-        var left = -1;
+        let left = -1;
         if (total > -1) {
-          left = total - (_this2.position + _this2.pageSize);
+          left = total - (this.position + this.pageSize);
         }
 
         if (left > 0) {
-          _this2.position = _this2.position + _this2.pageSize;
-          _this2._getData();
+          this.position = this.position + this.pageSize;
+          this._getData();
         } else {
           // Signal complete
-          _this2.requestDataDeferred.resolve(_this2._data);
+          this.requestDataDeferred.resolve(this._data);
         }
       });
     },
@@ -226,7 +218,7 @@ define('crm/Views/MetricWidget', ['module', 'exports', 'dojo/_base/declare', 'do
       this.requestDataDeferred.reject(error);
     },
     createStore: function createStore() {
-      var store = new _SData2.default({
+      const store = new _SData2.default({
         request: this.request,
         service: App.services.crm,
         resourceKind: this.resourceKind,

--- a/src-out/Views/NameEdit.js
+++ b/src-out/Views/NameEdit.js
@@ -32,9 +32,9 @@ define('crm/Views/NameEdit', ['module', 'exports', 'dojo/_base/declare', '../Val
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('nameEdit');
+  const resource = (0, _I18n2.default)('nameEdit');
 
-  var __class = (0, _declare2.default)('crm.Views.NameEdit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.NameEdit', [_Edit2.default], {
     // Localization
     titleText: resource.titleText,
     firstNameText: resource.firstNameText,
@@ -55,7 +55,7 @@ define('crm/Views/NameEdit', ['module', 'exports', 'dojo/_base/declare', '../Val
         name: 'Prefix',
         property: 'Prefix',
         picklist: 'Name Prefix',
-        picklistOptions: function picklistOptions(entry) {
+        picklistOptions: entry => {
           // Checks if entry is a Contact
           if (entry.hasOwnProperty('NameLF')) {
             return {
@@ -102,7 +102,7 @@ define('crm/Views/NameEdit', ['module', 'exports', 'dojo/_base/declare', '../Val
         name: 'Suffix',
         property: 'Suffix',
         picklist: 'Name Suffix',
-        picklistOptions: function picklistOptions(entry) {
+        picklistOptions: entry => {
           // Checks if entry is a Contact
           if (entry.hasOwnProperty('NameLF')) {
             return {

--- a/src-out/Views/Offline/Detail.js
+++ b/src-out/Views/Offline/Detail.js
@@ -39,7 +39,7 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
    * See the License for the specific language governing permissions and
    * limitations under the License.
    */
-  var resource = (0, _I18n2.default)('offlineDetail');
+  const resource = (0, _I18n2.default)('offlineDetail');
   exports.default = (0, _declare2.default)('crm.Views.Offline.Detail', [_DetailBase3.default, _RelatedViewWidgetDetailMixin2.default], {
     id: 'offline_detail',
     titleText: resource.titleText,
@@ -66,7 +66,7 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
       this._model = App.ModelManager.getModel(this.offlineContext.entityName, _Types2.default.OFFLINE);
 
       if (!this.offlineContext.viewId) {
-        this.offlineContext.viewId = this._model.detailViewId ? this._model.detailViewId : this._model.entityName.toLowerCase() + '_detail';
+        this.offlineContext.viewId = this._model.detailViewId ? this._model.detailViewId : `${this._model.entityName.toLowerCase()}_detail`;
       }
 
       this._entityView = this.getEntityView();
@@ -76,8 +76,8 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
       App.setToolBarMode(false);
     },
     getEntityView: function getEntityView() {
-      var newViewId = this.id + '_' + this.offlineContext.viewId;
-      var view = App.getView(this.offlineContext.viewId);
+      const newViewId = `${this.id}_${this.offlineContext.viewId}`;
+      const view = App.getView(this.offlineContext.viewId);
 
       if (this._entityView) {
         this._entityView.destroy();
@@ -85,34 +85,34 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
       }
 
       if (view) {
-        var ViewCtor = view.constructor;
+        const ViewCtor = view.constructor;
         this._entityView = new ViewCtor({ id: newViewId });
       }
       return this._entityView;
     },
     _applyStateToGetOptions: function _applyStateToGetOptions() {},
     _buildGetExpression: function _buildGetExpression() {
-      var options = this.options;
+      const options = this.options;
       return options && (options.id || options.key);
     },
     placeDetailHeader: function placeDetailHeader() {
-      var value = void 0;
-      var offlineDate = '';
+      let value;
+      let offlineDate = '';
       if (this._model && this._model.entityDisplayName) {
         value = _string2.default.substitute(this.informationText, [this._model.entityDisplayName]);
       } else {
         value = _string2.default.substitute(this.informationText, [this.entityText]);
       }
-      value = value + ' - ' + this.offlineText;
+      value = `${value} - ${this.offlineText}`;
       if (this.entry.$offlineDate) {
         offlineDate = _Format2.default.relativeDate(this.entry.$offlineDate);
       }
-      $(this.tabContainer).before(this.detailHeaderTemplate.apply({ value: value, offlineDate: offlineDate }, this));
+      $(this.tabContainer).before(this.detailHeaderTemplate.apply({ value, offlineDate }, this));
     },
     createLayout: function createLayout() {
-      var view = this._entityView;
-      var original = App.getView(this.offlineContext.viewId);
-      var layout = [];
+      const view = this._entityView;
+      const original = App.getView(this.offlineContext.viewId);
+      let layout = [];
       if (view && original) {
         view.entry = this.entry;
         original.entry = this.entry;
@@ -121,9 +121,7 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
         original.refreshRequired = true;
       }
 
-      layout = layout.filter(function (_ref) {
-        var enableOffline = _ref.enableOffline;
-
+      layout = layout.filter(({ enableOffline }) => {
         if (typeof enableOffline === 'undefined' || enableOffline === null) {
           return true;
         }
@@ -135,22 +133,14 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
       this.applyRelatedSections(layout);
       return layout;
     },
-    disableSections: function disableSections() {
-      var _this = this;
-
-      var sections = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-
-      sections.forEach(function (section) {
-        _this.disableSection(section);
+    disableSections: function disableSections(sections = []) {
+      sections.forEach(section => {
+        this.disableSection(section);
       });
     },
-    disableSection: function disableSection() {
-      var _this2 = this;
-
-      var section = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-
-      section.children.forEach(function (property) {
-        _this2.disableProperty(section, property);
+    disableSection: function disableSection(section = []) {
+      section.children.forEach(property => {
+        this.disableProperty(section, property);
       });
     },
     disableProperty: function disableProperty(section, property) {
@@ -159,36 +149,30 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
       }
       property.disabled = true;
     },
-    applyRelatedSections: function applyRelatedSections() {
-      var _this3 = this;
-
-      var sections = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-
+    applyRelatedSections: function applyRelatedSections(sections = []) {
       this._relatedItems = {};
-      sections.forEach(function (section) {
+      sections.forEach(section => {
         if (section.name === 'RelatedItemsSection') {
           section.children = [];
-          _this3.addRelatedLayout(section);
+          this.addRelatedLayout(section);
         }
       });
     },
     addRelatedLayout: function addRelatedLayout(section) {
-      var _this4 = this;
-
-      var rels = this._model.relationships || [];
-      rels.forEach(function (rel) {
+      const rels = this._model.relationships || [];
+      rels.forEach(rel => {
         if (rel && rel.relatedEntity) {
-          var relatedModel = App.ModelManager.getModel(rel.relatedEntity, _Types2.default.OFFLINE);
-          var viewId = void 0;
+          const relatedModel = App.ModelManager.getModel(rel.relatedEntity, _Types2.default.OFFLINE);
+          let viewId;
           if (rel.viewId) {
             viewId = rel.viewId;
           } else if (relatedModel && relatedModel.listViewId) {
             viewId = relatedModel.listViewId;
           } else {
-            viewId = rel.relatedEntity.toLowerCase() + '_related';
+            viewId = `${rel.relatedEntity.toLowerCase()}_related`;
           }
 
-          var item = {
+          const item = {
             name: rel.name,
             entityName: rel.relatedEntity,
             label: rel.displayName,
@@ -196,21 +180,20 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
             relationship: rel
           };
 
-          _this4._relatedItems[item.name] = item;
+          this._relatedItems[item.name] = item;
           section.children.push(item);
         }
       });
     },
     _processRelatedItem: function _processRelatedItem(data, context, rowNode) {
-      var labelNode = $('.related-item-label', rowNode).first();
-      var relationship = data.relationship;
-
+      const labelNode = $('.related-item-label', rowNode).first();
+      const { relationship } = data;
       if (labelNode && relationship) {
-        this._model.getRelatedCount(relationship, this.entry).then(function (count) {
+        this._model.getRelatedCount(relationship, this.entry).then(count => {
           $('.busy-xs', labelNode).remove();
-          var html = '<span class="info badge">' + count + '</span>';
+          const html = `<span class="info badge">${count}</span>`;
           $(labelNode).before(html);
-        }, function (err) {
+        }, err => {
           console.warn('Error getting related item count: ' + err); //eslint-disable-line
         });
       } else {
@@ -229,10 +212,10 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
       }
     },
     navigateToRelatedListView: function navigateToRelatedListView(params) {
-      var rel = this._relatedItems[params.name];
-      var view = App.getView('offline_list');
-      var queryExpression = this._model.buildRelatedQueryExpression(rel.relationship, this.entry);
-      var options = {
+      const rel = this._relatedItems[params.name];
+      const view = App.getView('offline_list');
+      const queryExpression = this._model.buildRelatedQueryExpression(rel.relationship, this.entry);
+      const options = {
         title: rel.label,
         offlineContext: {
           parentEntry: this.entry,
@@ -241,7 +224,7 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
           viewId: rel.view,
           related: rel,
           source: this,
-          queryExpression: queryExpression
+          queryExpression
         } };
       options.fromContext = this;
       options.selectedEntry = this.entry;
@@ -250,15 +233,15 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
       }
     },
     navigateToRelatedDetailView: function navigateToRelatedDetailView(params) {
-      var slot = parseInt(params.context, 10);
-      var rel = this._navigationOptions[slot];
-      var relViewId = params.view;
-      var relView = App.getView(relViewId);
+      const slot = parseInt(params.context, 10);
+      const rel = this._navigationOptions[slot];
+      const relViewId = params.view;
+      const relView = App.getView(relViewId);
 
       if (relView) {
-        var model = relView.getModel();
+        const model = relView.getModel();
         if (model) {
-          var options = {
+          const options = {
             descriptor: params.descriptor,
             title: params.descriptor,
             key: rel.key,
@@ -269,7 +252,7 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
               viewId: relViewId
             }
           };
-          var view = this.getRelatedDetailView(model.entityName);
+          const view = this.getRelatedDetailView(model.entityName);
 
           if (view) {
             view.show(options);
@@ -278,8 +261,8 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
       }
     },
     getRelatedDetailView: function getRelatedDetailView(entityName) {
-      var viewId = 'offline_detail_' + entityName;
-      var view = this.app.getView(viewId);
+      const viewId = `offline_detail_${entityName}`;
+      let view = this.app.getView(viewId);
 
       if (view) {
         return view;
@@ -291,13 +274,13 @@ define('crm/Views/Offline/Detail', ['module', 'exports', 'dojo/_base/declare', '
     },
 
     hasAction: function hasAction(actionName) {
-      var currentHasAction = this.inherited(hasAction, arguments);
+      const currentHasAction = this.inherited(hasAction, arguments);
       return currentHasAction || typeof this._entityView[actionName] === 'function';
     },
     invokeAction: function invokeAction(actionName, parameters, evt, el) {
       // A list of data-actions for the offline detail view (not the _entityView)
       // Note: If any data-actions are added in the templates above, add them here as well!
-      var currentActions = ['activateRelatedList'];
+      const currentActions = ['activateRelatedList'];
 
       // Apply the current view actions in our current context
       if (currentActions.includes(actionName)) {

--- a/src-out/Views/Offline/List.js
+++ b/src-out/Views/Offline/List.js
@@ -23,20 +23,20 @@ define('crm/Views/Offline/List', ['module', 'exports', 'dojo/_base/declare', 'ar
     };
   }
 
-  var resource = (0, _I18n2.default)('offlineList'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('offlineList'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
   exports.default = (0, _declare2.default)('crm.Views.Offline.List', [_ListBase3.default], {
     id: 'offline_list',
@@ -60,7 +60,7 @@ define('crm/Views/Offline/List', ['module', 'exports', 'dojo/_base/declare', 'ar
       return '';
     },
     getItemIconClass: function getItemIconClass(entry) {
-      var iconClass = void 0;
+      let iconClass;
       iconClass = this._model.getIconClass(entry);
       if (!iconClass) {
         iconClass = 'url';
@@ -119,8 +119,8 @@ define('crm/Views/Offline/List', ['module', 'exports', 'dojo/_base/declare', 'ar
       }]);
     },
     getEntityView: function getEntityView() {
-      var newViewId = this.id + '_' + this.offlineContext.viewId;
-      var view = App.getView(this.offlineContext.viewId);
+      const newViewId = `${this.id}_${this.offlineContext.viewId}`;
+      const view = App.getView(this.offlineContext.viewId);
 
       if (this._entityView) {
         this._entityView.destroy();
@@ -128,7 +128,7 @@ define('crm/Views/Offline/List', ['module', 'exports', 'dojo/_base/declare', 'ar
       }
 
       if (view) {
-        var ViewCtor = view.constructor;
+        const ViewCtor = view.constructor;
         this._entityView = new ViewCtor({ id: newViewId });
       }
       return this._entityView;
@@ -143,13 +143,13 @@ define('crm/Views/Offline/List', ['module', 'exports', 'dojo/_base/declare', 'ar
       this.navigateToOfflineDetailView(key, descriptor, additionalOptions);
     },
     navigateToOfflineDetailView: function navigateToOfflineDetailView(key, descriptor, additionalOptions) {
-      var entry = this.entries && this.entries[key];
-      var desc = this.getDescription(entry);
-      var view = this.getDetailView();
-      var options = {
+      const entry = this.entries && this.entries[key];
+      const desc = this.getDescription(entry);
+      const view = this.getDetailView();
+      let options = {
         descriptor: entry.description || desc, // keep for backwards compat
         title: entry.description || desc,
-        key: key,
+        key,
         fromContext: this,
         offlineContext: {
           entityId: this._model.getEntityId(entry),
@@ -165,15 +165,15 @@ define('crm/Views/Offline/List', ['module', 'exports', 'dojo/_base/declare', 'ar
 
       // Ensure we have a valid offline detail view and the
       // entity has a detail view that it can use for layout.
-      var modelDetailView = this._model.detailViewId;
-      var impliedDetailView = this._model.entityName.toLowerCase() + '_detail';
+      const modelDetailView = this._model.detailViewId;
+      const impliedDetailView = `${this._model.entityName.toLowerCase()}_detail`;
       if (view && App.getView(modelDetailView || impliedDetailView)) {
         view.show(options);
       }
     },
     getDetailView: function getDetailView() {
-      var viewId = this.detailView + '_' + this._model.entityName;
-      var view = this.app.getView(viewId);
+      const viewId = `${this.detailView}_${this._model.entityName}`;
+      let view = this.app.getView(viewId);
 
       if (view) {
         return view;

--- a/src-out/Views/Offline/TotalMetricWidget.js
+++ b/src-out/Views/Offline/TotalMetricWidget.js
@@ -19,12 +19,12 @@ define('crm/Views/Offline/TotalMetricWidget', ['module', 'exports', '../MetricWi
       return {};
     },
     _buildQueryExpression: function _buildQueryExpression() {
-      var filters = this.activeEntityFilters || [];
+      const filters = this.activeEntityFilters || [];
       return {
         map: function map(doc, emit) {
           // If the user has entity filters stored in preferences, filter based on that
           if (App.preferences && App.preferences.offlineEntityFilters) {
-            filters.forEach(function (f) {
+            filters.forEach(f => {
               if (doc.entityName === f.name) {
                 emit(1);
               }

--- a/src-out/Views/Offline/_RightDrawerListMixin.js
+++ b/src-out/Views/Offline/_RightDrawerListMixin.js
@@ -15,7 +15,7 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
     };
   }
 
-  var mixinName = 'crm.Views.Offline._RightDrawerListMixin';
+  const mixinName = 'crm.Views.Offline._RightDrawerListMixin';
 
   /**
    * @class
@@ -43,7 +43,7 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
   /**
    * @module crm/Views/Offline/_RightDrawerListMixin
    */
-  var __class = (0, _declare2.default)('crm.Views.Offline._RightDrawerListMixin', [_RightDrawerBaseMixin3.default], /** @lends module:crm/Views/Offline/_RightDrawerListMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views.Offline._RightDrawerListMixin', [_RightDrawerBaseMixin3.default], /** @lends module:crm/Views/Offline/_RightDrawerListMixin.prototype */{
     // Localization
     entitySectionText: 'Entity',
     kpiSectionText: 'KPI',
@@ -60,23 +60,21 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
     },
     setDefaultEntityPreferences: function setDefaultEntityPreferences() {
       if (!App.preferences.offlineEntityFilters) {
-        var defaults = this.getDefaultEntityPreferences();
+        const defaults = this.getDefaultEntityPreferences();
         App.preferences.offlineEntityFilters = defaults;
         App.persistPreferences();
       }
     },
     getDefaultEntityPreferences: function getDefaultEntityPreferences() {
-      return Object.keys(this.entityMappings).map(function (name) {
+      return Object.keys(this.entityMappings).map(name => {
         return {
-          name: name,
+          name,
           enabled: true
         };
       });
     },
     setupRightDrawer: function setupRightDrawer() {
-      var _this = this;
-
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         _lang2.default.mixin(drawer, this._createActions());
         drawer.setLayout(this.createRightDrawerLayout());
@@ -84,24 +82,24 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
           return this.getGroupForRightDrawerEntry(entry);
         });
 
-        App.viewSettingsModal.element.on('close', function () {
-          if (_this._hasChangedEntityPrefs) {
-            _this.clear();
-            _this.refreshRequired = true;
-            _this.refresh();
-            _this.rebuildWidgets();
-            _this._hasChangedEntityPrefs = false;
+        App.viewSettingsModal.element.on('close', () => {
+          if (this._hasChangedEntityPrefs) {
+            this.clear();
+            this.refreshRequired = true;
+            this.refresh();
+            this.rebuildWidgets();
+            this._hasChangedEntityPrefs = false;
           }
 
-          if (_this._hasChangedKPIPrefs && _this.rebuildWidgets) {
-            _this.rebuildWidgets();
-            _this._hasChangedKPIPrefs = false;
+          if (this._hasChangedKPIPrefs && this.rebuildWidgets) {
+            this.rebuildWidgets();
+            this._hasChangedKPIPrefs = false;
           }
         });
       }
     },
     unloadRightDrawer: function unloadRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.setLayout([]);
         drawer.getGroupForEntry = function noop() {};
@@ -114,16 +112,16 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
     },
     _createActions: function _createActions() {
       // These actions will get mixed into the right drawer view.
-      var actions = {
+      const actions = {
         entityFilterClicked: function onentityFilterClicked(params) {
-          var prefs = App.preferences && App.preferences.offlineEntityFilters;
+          const prefs = App.preferences && App.preferences.offlineEntityFilters;
 
-          var results = prefs.filter(function (pref) {
+          const results = prefs.filter(pref => {
             return pref.name === params.entityname;
           });
 
           if (results.length > 0) {
-            var enabled = !!results[0].enabled;
+            const enabled = !!results[0].enabled;
             results[0].enabled = !enabled;
             App.persistPreferences();
             this._hasChangedEntityPrefs = true;
@@ -131,17 +129,17 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
           }
         }.bind(this),
         kpiClicked: function kpiClicked(params) {
-          var metrics = App.getMetricsByResourceKind(this.resourceKind);
-          var results = void 0;
+          const metrics = App.getMetricsByResourceKind(this.resourceKind);
+          let results;
 
           if (metrics.length > 0) {
-            results = metrics.filter(function (metric) {
+            results = metrics.filter(metric => {
               return metric.title === params.title;
             });
           }
 
           if (results.length > 0) {
-            var enabled = !!results[0].enabled;
+            const enabled = !!results[0].enabled;
             results[0].enabled = !enabled;
             App.persistPreferences();
             this._hasChangedKPIPrefs = true;
@@ -154,7 +152,7 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
       return actions;
     },
     getGroupForRightDrawerEntry: function getGroupForRightDrawerEntry(entry) {
-      var mixin = _lang2.default.getObject(mixinName);
+      const mixin = _lang2.default.getObject(mixinName);
 
       if (entry.dataProps && entry.dataProps.entityname) {
         return {
@@ -169,22 +167,21 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
       };
     },
     createRightDrawerLayout: function createRightDrawerLayout() {
-      var _this2 = this;
-
-      var layout = [];
-      var entitySection = {
+      const layout = [];
+      const entitySection = {
         id: 'actions',
-        children: Object.keys(this.entityMappings).map(function (entityName) {
-          var prefs = App.preferences && App.preferences.offlineEntityFilters;
-          var entityPref = prefs.filter(function (pref) {
+        children: Object.keys(this.entityMappings).map(entityName => {
+          const prefs = App.preferences && App.preferences.offlineEntityFilters;
+          const entityPref = prefs.filter(pref => {
             return pref.name === entityName;
           });
-          var enabled = entityPref[0].enabled;
-
+          const {
+            enabled
+          } = entityPref[0];
           return {
             name: entityName,
             action: 'entityFilterClicked',
-            title: _this2.entityText[entityName] || entityName,
+            title: this.entityText[entityName] || entityName,
             dataProps: {
               entityname: entityName,
               enabled: !!enabled
@@ -195,15 +192,13 @@ define('crm/Views/Offline/_RightDrawerListMixin', ['module', 'exports', 'dojo/_b
 
       layout.push(entitySection);
 
-      var metrics = App.getMetricsByResourceKind(this.resourceKind);
+      const metrics = App.getMetricsByResourceKind(this.resourceKind);
 
-      var kpiSection = {
+      const kpiSection = {
         id: 'kpi',
-        children: metrics.filter(function (m) {
-          return m.title;
-        }).map(function (metric, i) {
+        children: metrics.filter(m => m.title).map((metric, i) => {
           return {
-            name: 'KPI' + i,
+            name: `KPI${i}`,
             action: 'kpiClicked',
             title: metric.title,
             dataProps: {

--- a/src-out/Views/OfflineOptions/Edit.js
+++ b/src-out/Views/OfflineOptions/Edit.js
@@ -19,22 +19,22 @@ define('crm/Views/OfflineOptions/Edit', ['module', 'exports', 'dojo/_base/declar
     };
   }
 
-  var resource = (0, _I18n2.default)('offlineOptionsEdit'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('offlineOptionsEdit'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var __class = (0, _declare2.default)('crm.Views.OfflineOptions.Edit', [_EditBase3.default, _RelatedViewWidgetEditMixin2.default], {
+  const __class = (0, _declare2.default)('crm.Views.OfflineOptions.Edit', [_EditBase3.default, _RelatedViewWidgetEditMixin2.default], {
     // Localization
     titleText: resource.titleText,
     multiColumnView: false,
@@ -49,16 +49,14 @@ define('crm/Views/OfflineOptions/Edit', ['module', 'exports', 'dojo/_base/declar
       }]);
     },
     requestData: function requestData() {
-      var _this = this;
-
-      return this.getOfflineOptions().then(function (data) {
-        _this._onGetComplete(data);
-      }, function (err) {
-        _this._onGetError(null, err);
+      return this.getOfflineOptions().then(data => {
+        this._onGetComplete(data);
+      }, err => {
+        this._onGetError(null, err);
       });
     },
     getOfflineOptions: function getOfflineOptions() {
-      var def = new _Deferred2.default();
+      const def = new _Deferred2.default();
       def.resolve({ maxdays: 5 });
       return def.promise;
     },

--- a/src-out/Views/OfflineOptions/UsageWidget.js
+++ b/src-out/Views/OfflineOptions/UsageWidget.js
@@ -31,22 +31,22 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
     };
   }
 
-  var resource = (0, _I18n2.default)('offlineUsageWidget'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('offlineUsageWidget'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var __class = (0, _declare2.default)('crm.Views.OfflineOptions.UsageWidget', [_RelatedViewWidgetBase3.default], {
+  const __class = (0, _declare2.default)('crm.Views.OfflineOptions.UsageWidget', [_RelatedViewWidgetBase3.default], {
 
     totalUsageText: resource.totalUsageText,
     countText: resource.countText,
@@ -68,7 +68,13 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
     relatedContentTemplate: new Simplate(['<div class="offline-usage">', '<span class="label">{%: $$.olderThanText %}</span>', '&nbsp;<span data-dojo-attach-point="_olderThanNode" style="display:inline-block"></span>&nbsp;', '<div data-dojo-attach-point="_lastClearDateNode"></div>', '<p><button class="btn-secondary" data-dojo-attach-event="onclick:onClearAllData">{%: $$.clearDataText %}</button></p>', '<p><button class="btn-secondary" data-dojo-attach-event="onclick:onClearBriefcasedData">{%: $$.clearBriefcasedText %}</button></p>', '<p><button class="btn-secondary" data-dojo-attach-event="onclick:onClearRecentData">{%: $$.clearRecentText %}</button></p>', '<p><button class="btn-secondary" data-dojo-attach-event="onclick:onShowUsage">{%: $$.showUsageText %}</button></p>', '<div data-dojo-attach-point="usageNode" style="margin-top:2rem;">', '</div>']),
     errorTemplate: new Simplate(['<div class="error">', '<span class="fa fa-waring fa-2x"></span>', '<h2>{%= $.message %}</h2>', '</div>']),
     usageHeaderTemplate: new Simplate(['<div class="offline-usage-header twelve columns">', '{%! $$.usageItemTemplate %}', '</div>']),
-    usageItemTemplate: new Simplate(['<div class="offline-usage-item widget">', '<div class="widget-header">', '{% if ($.iconClass) { %}\n    <button type="button" class="btn-icon hide-focus">\n    <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n      <use xlink:href="#icon-{%= $.iconClass %}"></use>\n    </svg>\n    </button>\n    {% } %}', '<h2 class="widget-title">{%: $.label %}</h2>', '</div>', '<div class="content card-content">', '<div class="item"><div class="label">{%: $$.countText %}</div> <span class="value">{%: $.count %}</span><span class="value percent">{%: $.countPercent %}</span></div>', '<div class="item"><div class="label">{%: $$.sizeText %}</div> <span class="value">{%: $.size %}</span><span class="value percent">{%: $.sizePercent %}</span></div>', '<div class="item"><div class="label">{%: $$.sizeAVGText %}</div> <span class="value">{%: $.sizeAVG %}</span></div>', '<div class="bar"></div>', '<div class="item"><div class="label small">{%: $$.oldestText %}</div> <span class="value small">{%: $.oldestDate %}</span></div>', '<div class="item"><div class="label small">{%: $$.newestText %}</div> <span class="value small">{%: $.newestDate %}</span></div>', '</div>', '</div>']),
+    usageItemTemplate: new Simplate(['<div class="offline-usage-item widget">', '<div class="widget-header">', `{% if ($.iconClass) { %}
+    <button type="button" class="btn-icon hide-focus">
+    <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+      <use xlink:href="#icon-{%= $.iconClass %}"></use>
+    </svg>
+    </button>
+    {% } %}`, '<h2 class="widget-title">{%: $.label %}</h2>', '</div>', '<div class="content card-content">', '<div class="item"><div class="label">{%: $$.countText %}</div> <span class="value">{%: $.count %}</span><span class="value percent">{%: $.countPercent %}</span></div>', '<div class="item"><div class="label">{%: $$.sizeText %}</div> <span class="value">{%: $.size %}</span><span class="value percent">{%: $.sizePercent %}</span></div>', '<div class="item"><div class="label">{%: $$.sizeAVGText %}</div> <span class="value">{%: $.sizeAVG %}</span></div>', '<div class="bar"></div>', '<div class="item"><div class="label small">{%: $$.oldestText %}</div> <span class="value small">{%: $.oldestDate %}</span></div>', '<div class="item"><div class="label small">{%: $$.newestText %}</div> <span class="value small">{%: $.newestDate %}</span></div>', '</div>', '</div>']),
     lastClearDateTemplate: new Simplate(['<span class="label">', '{%: $$.lastClearedText %}', '</span', '<span class="value">', ' {%: $.lastClearedDate %}', '</span']),
     /*
      * SoHo class to be applied on multi column.
@@ -79,21 +85,19 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
      */
     multiColumnCount: 3,
     onInit: function onInit() {
-      var _this = this;
-
       this.onLoad();
       if (this.owner) {
-        _aspect2.default.after(this.owner, 'show', function () {
-          _this.onRefreshView();
+        _aspect2.default.after(this.owner, 'show', () => {
+          this.onRefreshView();
         });
 
-        _aspect2.default.after(this.owner, 'save', function () {
-          _this.onSave();
+        _aspect2.default.after(this.owner, 'save', () => {
+          this.onSave();
         });
       }
     },
     onLoad: function onLoad() {
-      var options = _Manager2.default.getOptions();
+      const options = _Manager2.default.getOptions();
       this._options = {
         clearOlderThan: options.clearOlderThan,
         lastClearedDate: options.lastClearedDate
@@ -104,7 +108,7 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
     initUI: function initUI(clearOlderThan) {
       if (!this._olderThanDropdown) {
         this._olderThanDropdown = new _Dropdown2.default({
-          id: 'olderThan-dropdown ' + this.id,
+          id: `olderThan-dropdown ${this.id}`,
           onSelect: this.olderThanSelect,
           onSelectScope: this,
           dropdownClass: 'input-xs'
@@ -125,28 +129,26 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
       }
     },
     setLastClearedDate: function setLastClearedDate(lastClearedDate) {
-      var values = {
+      const values = {
         lastClearedDate: lastClearedDate ? _Format2.default.relativeDate(lastClearedDate) : ''
       };
       this._options.lastClearedDate = lastClearedDate;
-      var clearDateNode = this.lastClearDateTemplate.apply(values, this);
+      const clearDateNode = this.lastClearDateTemplate.apply(values, this);
       $(this._lastClearDateNode).empty().append(clearDateNode);
     },
     olderThanSelect: function olderThanSelect() {
       this._options.clearOlderThan = this._olderThanDropdown.getValue();
     },
     onShowUsage: function onShowUsage() {
-      var _this2 = this;
-
       if (this._showingUsage) {
         this.destroyUsage();
       } else {
         this.showProcessing(true, this.calculatingUsageText);
-        this.getUsage().then(function (data) {
-          _this2.showProcessing(false);
-          _this2.processUsage(data);
-        }, function (err) {
-          _this2.showError(resource.errorCalculatingText, err);
+        this.getUsage().then(data => {
+          this.showProcessing(false);
+          this.processUsage(data);
+        }, err => {
+          this.showError(resource.errorCalculatingText, err);
         });
       }
     },
@@ -174,58 +176,50 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
       }
     },
     showError: function showError(message, error) {
-      var _this3 = this;
-
       if (this.usageNode) {
         this.showProcessing(false);
         _ErrorManager2.default.addSimpleError(message, error);
-        _ErrorManager2.default.showErrorDialog(null, message, function () {
-          _this3.onRefreshView();
+        _ErrorManager2.default.showErrorDialog(null, message, () => {
+          this.onRefreshView();
         });
       }
     },
     onClearAllData: function onClearAllData() {
-      var _this4 = this;
-
       this.showProcessing(true, this.clearingDataText);
-      _Manager2.default.clearAllData().then(function () {
-        _this4.showProcessing(false);
-        _this4.setLastClearedDate(moment().toDate());
-      }, function (err) {
-        _this4.showError(resource.errorClearingDataText, err);
+      _Manager2.default.clearAllData().then(() => {
+        this.showProcessing(false);
+        this.setLastClearedDate(moment().toDate());
+      }, err => {
+        this.showError(resource.errorClearingDataText, err);
       });
     },
     onClearRecentData: function onClearRecentData() {
-      var _this5 = this;
-
       this.showProcessing(true, this.clearingDataText);
-      _Manager2.default.clearRecentData(this._options.clearOlderThan).then(function () {
-        _this5.showProcessing(false);
-        _this5.setLastClearedDate(moment().toDate());
-      }, function (err) {
-        _this5.showError(resource.errorClearingDataText, err);
+      _Manager2.default.clearRecentData(this._options.clearOlderThan).then(() => {
+        this.showProcessing(false);
+        this.setLastClearedDate(moment().toDate());
+      }, err => {
+        this.showError(resource.errorClearingDataText, err);
       });
     },
     onClearBriefcasedData: function onClearBriefcasedData() {
-      var _this6 = this;
-
       this.showProcessing(true, this.clearingDataText);
-      _Manager2.default.clearBriefcaseData(this._options.clearOlderThan).then(function () {
-        _this6.showProcessing(false);
-        _this6.setLastClearedDate(moment().toDate());
-      }, function (err) {
-        _this6.showError(resource.errorClearingDataText, err);
+      _Manager2.default.clearBriefcaseData(this._options.clearOlderThan).then(() => {
+        this.showProcessing(false);
+        this.setLastClearedDate(moment().toDate());
+      }, err => {
+        this.showError(resource.errorClearingDataText, err);
       });
     },
     getUsage: function getUsage() {
       return _Manager2.default.getUsage();
     },
     processUsage: function processUsage(usage) {
-      var i = void 0;
-      var docfrag = document.createDocumentFragment();
-      var totalItem = {};
-      var oldestDate = void 0;
-      var newestDate = void 0;
+      let i;
+      const docfrag = document.createDocumentFragment();
+      const totalItem = {};
+      let oldestDate;
+      let newestDate;
       totalItem.iconClass = 'server';
       totalItem.label = this.totalUsageText;
       totalItem.entityName = '*';
@@ -238,16 +232,16 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
       newestDate = _Utility2.default.getValue(usage, 'newestDate');
       totalItem.oldestDate = oldestDate ? _Format2.default.relativeDate(oldestDate) : '';
       totalItem.newestDate = newestDate ? _Format2.default.relativeDate(newestDate) : '';
-      var headerNode = $(this.usageHeaderTemplate.apply(totalItem, this));
-      var columnHeaderNode = $('<div class="row"></div>').append(headerNode);
+      const headerNode = $(this.usageHeaderTemplate.apply(totalItem, this));
+      const columnHeaderNode = $('<div class="row"></div>').append(headerNode);
       docfrag.appendChild(columnHeaderNode.get(0));
       this._selectFields = {};
-      var entities = usage.entities;
-      var row = [];
+      const entities = usage.entities;
+      let row = [];
       for (i = 0; i < entities.length; i++) {
-        var entity = entities[i];
+        const entity = entities[i];
         try {
-          var item = {};
+          const item = {};
           item.iconClass = entity.iconClass;
           item.label = entity.description;
           item.entityName = entity.entityName;
@@ -260,19 +254,17 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
           newestDate = _Utility2.default.getValue(entity, 'newestDate');
           item.oldestDate = oldestDate ? _Format2.default.relativeDate(oldestDate) : '';
           item.newestDate = newestDate ? _Format2.default.relativeDate(newestDate) : '';
-          var itemNode = $(this.usageItemTemplate.apply(item, this)).get(0);
+          const itemNode = $(this.usageItemTemplate.apply(item, this)).get(0);
 
-          var column = $('<div class="' + this.multiColumnClass + ' columns">').append(itemNode);
+          const column = $(`<div class="${this.multiColumnClass} columns">`).append(itemNode);
           row.push(column);
           if ((i + 1) % this.multiColumnCount === 0 || i === entities.length - 1) {
-            (function () {
-              var rowTemplate = $('<div class="row"></div>');
-              row.forEach(function (element) {
-                rowTemplate.append(element);
-              });
-              docfrag.appendChild(rowTemplate.get(0));
-              row = [];
-            })();
+            const rowTemplate = $('<div class="row"></div>');
+            row.forEach(element => {
+              rowTemplate.append(element);
+            });
+            docfrag.appendChild(rowTemplate.get(0));
+            row = [];
           }
         } catch (err) {
           console.log(err); // eslint-disable-line
@@ -283,7 +275,7 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
     },
     destroyUsage: function destroyUsage() {
       if (this.usageNode) {
-        var node = $('<div></div>');
+        const node = $('<div></div>');
         $(this.usageNode).empty().append(node);
         this._showingUsage = false;
       }
@@ -299,13 +291,13 @@ define('crm/Views/OfflineOptions/UsageWidget', ['module', 'exports', 'dojo/_base
       this.inherited(destroy, arguments);
     },
     onSave: function onSave() {
-      var options = _Manager2.default.getOptions();
+      const options = _Manager2.default.getOptions();
       options.clearOlderThan = this._options.clearOlderThan;
       _Manager2.default.saveOptions(options);
     }
 
   });
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('offlineUsageWidget', __class);
   exports.default = __class;
   module.exports = exports['default'];

--- a/src-out/Views/Opportunity/Detail.js
+++ b/src-out/Views/Opportunity/Detail.js
@@ -36,10 +36,10 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('opportunityDetail');
-  var dtFormatResource = (0, _I18n2.default)('opportunityDetailDateTimeFormat');
+  const resource = (0, _I18n2.default)('opportunityDetail');
+  const dtFormatResource = (0, _I18n2.default)('opportunityDetailDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Opportunity.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Opportunity.Detail', [_Detail2.default], {
     // Localization
     accountText: resource.accountText,
     acctMgrText: resource.acctMgrText,
@@ -91,7 +91,7 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
       App.navigateToActivityInsertView();
     },
     addNote: function addNote() {
-      var view = App.getView(this.noteEditView);
+      const view = App.getView(this.noteEditView);
       if (view) {
         view.show({
           template: {},
@@ -108,12 +108,12 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
       }
     },
     getValues: function getValues() {
-      var estimatedCloseDate = this.fields.EstimatedClose.getValue();
-      var timelessStartDate = estimatedCloseDate.clone().clearTime().add({
+      const estimatedCloseDate = this.fields.EstimatedClose.getValue();
+      const timelessStartDate = estimatedCloseDate.clone().clearTime().add({
         minutes: -1 * estimatedCloseDate.getTimezoneOffset(),
         seconds: 5
       });
-      var values = this.inherited(getValues, arguments);
+      let values = this.inherited(getValues, arguments);
 
       values = values || {};
       values.EstimatedClose = timelessStartDate;
@@ -127,7 +127,7 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
       return _Format2.default.picklist(this.app.picklistService, this._model, property);
     },
     createLayout: function createLayout() {
-      var quickActions = {
+      const quickActions = {
         list: true,
         title: this.actionsText,
         cls: 'action-list',
@@ -147,7 +147,7 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
         }]
       };
 
-      var multiCurrency = {
+      const multiCurrency = {
         title: this.multiCurrencyText,
         name: 'MultiCurrencySection',
         children: [{
@@ -169,7 +169,7 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
           property: 'ExchangeRateLocked'
         }]
       };
-      var details = {
+      const details = {
         title: this.detailsText,
         name: 'DetailsSection',
         children: [{
@@ -193,8 +193,8 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
           property: 'SalesPotential',
           renderer: function renderSalesPotential(val) {
             if (App.hasMultiCurrency()) {
-              var exhangeRate = App.getBaseExchangeRate();
-              var convertedValue = val * exhangeRate.rate;
+              const exhangeRate = App.getBaseExchangeRate();
+              const convertedValue = val * exhangeRate.rate;
               return _Format2.default.multiCurrency.call(null, convertedValue, exhangeRate.code);
             }
             return _Format2.default.currency.call(null, val);
@@ -232,7 +232,7 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
         }]
       };
 
-      var relatedItems = {
+      const relatedItems = {
         list: true,
         title: this.relatedItemsText,
         name: 'RelatedItemsSection',
@@ -268,7 +268,7 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
         }]
       };
 
-      var layout = this.layout || (this.layout = []);
+      const layout = this.layout || (this.layout = []);
 
       if (layout.length > 0) {
         return layout;
@@ -284,8 +284,8 @@ define('crm/Views/Opportunity/Detail', ['module', 'exports', 'dojo/_base/declare
           property: 'SalesPotential',
           renderer: function renderMySalesPotential(val) {
             if (App.hasMultiCurrency()) {
-              var exhangeRate = App.getMyExchangeRate();
-              var convertedValue = val * exhangeRate.rate;
+              const exhangeRate = App.getMyExchangeRate();
+              const convertedValue = val * exhangeRate.rate;
               return _Format2.default.multiCurrency.call(null, convertedValue, exhangeRate.code);
             }
 

--- a/src-out/Views/Opportunity/Edit.js
+++ b/src-out/Views/Opportunity/Edit.js
@@ -36,10 +36,10 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('opportunityEdit');
-  var dtFormatResource = (0, _I18n2.default)('opportunityEditDateTimeFormat');
+  const resource = (0, _I18n2.default)('opportunityEdit');
+  const dtFormatResource = (0, _I18n2.default)('opportunityEditDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.Opportunity.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Opportunity.Edit', [_Edit2.default], {
     // Localization
     accountText: resource.accountText,
     acctMgrText: resource.acctMgrText,
@@ -84,12 +84,12 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
       }
     },
     applyContext: function applyContext(templateEntry) {
-      var found = App.queryNavigationContext(function (o) {
+      const found = App.queryNavigationContext(o => {
         return (/^(accounts|contacts)$/.test(o.resourceKind) && o.key
         );
       });
 
-      var lookup = {
+      const lookup = {
         accounts: this.applyAccountContext,
         contacts: this.applyContactContext
       };
@@ -146,10 +146,10 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
       this.fields.SalesPotential.setCurrencyCode(App.getBaseExchangeRate().code);
     },
     getValues: function getValues() {
-      var values = this.inherited(getValues, arguments);
+      const values = this.inherited(getValues, arguments);
 
       if (values) {
-        var code = values.ExchangeRateCode;
+        const code = values.ExchangeRateCode;
         values.ExchangeRateCode = code && code.$key;
       }
 
@@ -160,16 +160,16 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
       this.fields.Owner.setValue(App.context.defaultOwner);
     },
     applyAccountContext: function applyAccountContext(context) {
-      var view = App.getView(context.id);
-      var entry = view && view.entry;
+      const view = App.getView(context.id);
+      const entry = view && view.entry;
 
       this.fields.Account.setValue(entry);
       this.fields.AccountManager.setValue(_Utility2.default.getValue(entry, 'AccountManager'));
       this.fields.Owner.setValue(_Utility2.default.getValue(entry, 'Owner'));
     },
     applyContactContext: function applyContactContext(context) {
-      var view = App.getView(context.id);
-      var entry = view && view.entry;
+      const view = App.getView(context.id);
+      const entry = view && view.entry;
 
       this.fields.Account.setValue(_Utility2.default.getValue(entry, 'Account'));
       this.fields.AccountManager.setValue(_Utility2.default.getValue(entry, 'AccountManager'));
@@ -177,7 +177,7 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
       this.fields['Contacts.$resources[0].Contact.$key'].setValue(entry.$key);
     },
     onExchangeRateCodeChange: function onExchangeRateCodeChange(value, field) {
-      var selection = field.getSelection();
+      const selection = field.getSelection();
       if (selection && selection.Rate) {
         this.fields.ExchangeRate.setValue(selection.Rate);
         this.fields.ExchangeRateDate.setValue(new Date(Date.now()));
@@ -198,7 +198,7 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
       this.fields.ExchangeRateDate.setValue(new Date(Date.now()));
     },
     onAccountChange: function onAccountChange(value, field) {
-      var selection = field.getSelection();
+      const selection = field.getSelection();
 
       // todo: match behavior in web client; if the account manager (AM) is explicitly set, it should stay, otherwise
       // it should be set to the AM for the selected account (and change each time).
@@ -207,7 +207,7 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
       }
     },
     createLayout: function createLayout() {
-      var details = {
+      const details = {
         title: this.detailsText,
         name: 'OpportunityDetailsEdit',
         children: [{
@@ -244,7 +244,7 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
           textProperty: 'AccountName',
           type: 'lookup',
           view: 'account_related',
-          where: 'upper(SubType) eq "' + this.subTypePickListResellerText + '"',
+          where: `upper(SubType) eq "${this.subTypePickListResellerText}"`,
           viewMixin: {
             hasSettings: false,
             onTransitionTo: function onTransitionTo(self) {
@@ -315,7 +315,7 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
         }]
       };
 
-      var multiCurrency = {
+      const multiCurrency = {
         title: this.multiCurrencyText,
         name: 'OpportunityMultiCurrencyEdit',
         children: [{
@@ -347,7 +347,7 @@ define('crm/Views/Opportunity/Edit', ['module', 'exports', 'dojo/_base/declare',
         }]
       };
 
-      var layout = this.layout || (this.layout = []);
+      const layout = this.layout || (this.layout = []);
 
       if (layout.length > 0) {
         return layout;

--- a/src-out/Views/Opportunity/List.js
+++ b/src-out/Views/Opportunity/List.js
@@ -27,22 +27,22 @@ define('crm/Views/Opportunity/List', ['module', 'exports', 'dojo/_base/declare',
     };
   }
 
-  var resource = (0, _I18n2.default)('opportunityList'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('opportunityList'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var __class = (0, _declare2.default)('crm.Views.Opportunity.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Opportunity.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     // Templates
     // TODO: Support ExchangeRateCode with proper symbol
     itemTemplate: new Simplate(['{% if ($.Account) { %}', '<p class="micro-text">', '{%: $.Account.AccountName %}', '</p>', '<p class="micro-text">', '{% if ($.Account.AccountManager && $.Account.AccountManager.UserInfo) { %}', '{%: $.Account.AccountManager.UserInfo.UserName %}', '{% if ($.Account && $.Account.AccountManager.UserInfo.Region) { %}', ' | {%: $.Account.AccountManager.UserInfo.Region %}', '{% } %}', '{% } %}', '</p>', '{% } %}', '<p class="micro-text">', '{%: $.Status %}', '{% if ($.Stage) { %}', ' | {%: $.Stage %}', '{% } %}', '</p>', '{% if ($.SalesPotential) { %}', '<p class="micro-text"><strong>', '{% if (App.hasMultiCurrency()) { %}', '{%: crm.Format.multiCurrency($.SalesPotential * $.ExchangeRate, $.ExchangeRateCode) %}', '{% } else { %}', '{%: crm.Format.multiCurrency($.SalesPotential, App.getBaseExchangeRate().code) %}', '{% } %}', '</strong></p>', '{% } %}', '<p class="micro-text">{%: $$.formatDate($) %}</p>']),
@@ -137,14 +137,14 @@ define('crm/Views/Opportunity/List', ['module', 'exports', 'dojo/_base/declare',
     },
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Description) like "' + q + '%" or Account.AccountNameUpper like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Description) like "${q}%" or Account.AccountNameUpper like "${q}%")`;
     },
     groupFieldFormatter: {
       CloseProbability: {
         name: 'CloseProbability',
         formatter: function formatter(value) {
-          return _Format2.default.fixedLocale(value, 0) + '%';
+          return `${_Format2.default.fixedLocale(value, 0)}%`;
         }
       }
     }

--- a/src-out/Views/Opportunity/QuickEdit.js
+++ b/src-out/Views/Opportunity/QuickEdit.js
@@ -19,22 +19,22 @@ define('crm/Views/Opportunity/QuickEdit', ['module', 'exports', 'dojo/_base/decl
     };
   }
 
-  var resource = (0, _I18n2.default)('opportunityQuickEdit'); /* Copyright 2017 Infor
-                                                               *
-                                                               * Licensed under the Apache License, Version 2.0 (the "License");
-                                                               * you may not use this file except in compliance with the License.
-                                                               * You may obtain a copy of the License at
-                                                               *
-                                                               *    http://www.apache.org/licenses/LICENSE-2.0
-                                                               *
-                                                               * Unless required by applicable law or agreed to in writing, software
-                                                               * distributed under the License is distributed on an "AS IS" BASIS,
-                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                               * See the License for the specific language governing permissions and
-                                                               * limitations under the License.
-                                                               */
+  const resource = (0, _I18n2.default)('opportunityQuickEdit'); /* Copyright 2017 Infor
+                                                                 *
+                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                 * you may not use this file except in compliance with the License.
+                                                                 * You may obtain a copy of the License at
+                                                                 *
+                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                 *
+                                                                 * Unless required by applicable law or agreed to in writing, software
+                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                 * See the License for the specific language governing permissions and
+                                                                 * limitations under the License.
+                                                                 */
 
-  var __class = (0, _declare2.default)('crm.Views.Opportunity.QuickEdit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Opportunity.QuickEdit', [_Edit2.default], {
     // Localization
     estCloseText: resource.estCloseText,
     detailsText: resource.detailsText,
@@ -64,7 +64,7 @@ define('crm/Views/Opportunity/QuickEdit', ['module', 'exports', 'dojo/_base/decl
       this.fields.EstimatedClose.setValue(templateEntry.EstimatedClose);
     },
     createLayout: function createLayout() {
-      var details = {
+      const details = {
         title: this.detailsText,
         name: 'OpportunityDetailsEdit',
         children: [{
@@ -107,7 +107,7 @@ define('crm/Views/Opportunity/QuickEdit', ['module', 'exports', 'dojo/_base/decl
         }]
       };
 
-      var layout = this.layout || (this.layout = []);
+      const layout = this.layout || (this.layout = []);
 
       if (layout.length > 0) {
         return layout;
@@ -123,21 +123,19 @@ define('crm/Views/Opportunity/QuickEdit', ['module', 'exports', 'dojo/_base/decl
       this.fields.SalesPotential.setCurrencyCode(App.getBaseExchangeRate().code);
     },
     enableStage: function enableStage(opportunityId) {
-      var _this = this;
-
-      var field = this.fields.Stage;
-      var label = this.stageText;
+      const field = this.fields.Stage;
+      let label = this.stageText;
 
       if (!field) {
         return;
       }
 
       field.disable();
-      _SalesProcessUtility2.default.getSalesProcessByEntityId(opportunityId).then(function (salesProcess) {
+      _SalesProcessUtility2.default.getSalesProcessByEntityId(opportunityId).then(salesProcess => {
         if (salesProcess) {
           field.disable();
-          label = _this.salesProcessText + salesProcess.$descriptor;
-          _this.setStageLabel(label);
+          label = this.salesProcessText + salesProcess.$descriptor;
+          this.setStageLabel(label);
         } else {
           field.enable();
         }
@@ -145,16 +143,16 @@ define('crm/Views/Opportunity/QuickEdit', ['module', 'exports', 'dojo/_base/decl
       this.setStageLabel(label);
     },
     setStageLabel: function setStageLabel(label) {
-      var field = this.fields.Stage;
+      const field = this.fields.Stage;
       if (field && field.domNode) {
-        var node = $('[for="Stage"]', field.domNode);
+        const node = $('[for="Stage"]', field.domNode);
         if (node && node.length > 0) {
           $(node[0]).attr('innerHTML', label); // TODO: SDK's _Field should provide a label setter
         }
       }
     },
     enableProbability: function enableProbability(entry) {
-      var field = this.fields.CloseProbability;
+      const field = this.fields.CloseProbability;
       if (!field) {
         return;
       }
@@ -164,7 +162,7 @@ define('crm/Views/Opportunity/QuickEdit', ['module', 'exports', 'dojo/_base/decl
       }
     },
     isClosed: function isClosed(entry) {
-      var status = entry.Status;
+      const status = entry.Status;
       if (status === this.statusClosedWonText || status === this.statusClosedLostText) {
         return true;
       }

--- a/src-out/Views/OpportunityContact/Detail.js
+++ b/src-out/Views/OpportunityContact/Detail.js
@@ -36,9 +36,9 @@ define('crm/Views/OpportunityContact/Detail', ['module', 'exports', 'dojo/_base/
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('opportunityContactDetail');
+  const resource = (0, _I18n2.default)('opportunityContactDetail');
 
-  var __class = (0, _declare2.default)('crm.Views.OpportunityContact.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.OpportunityContact.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     accountText: resource.accountText,
@@ -64,7 +64,7 @@ define('crm/Views/OpportunityContact/Detail', ['module', 'exports', 'dojo/_base/
     modelName: _Names2.default.OPPORTUNITYCONTACT,
 
     removeContact: function removeContact() {
-      var confirmMessage = _string2.default.substitute(this.confirmDeleteText, [this.entry.Contact.NameLF]);
+      const confirmMessage = _string2.default.substitute(this.confirmDeleteText, [this.entry.Contact.NameLF]);
       if (!confirm(confirmMessage)) {
         // eslint-disable-line
         return;

--- a/src-out/Views/OpportunityContact/Edit.js
+++ b/src-out/Views/OpportunityContact/Edit.js
@@ -32,9 +32,9 @@ define('crm/Views/OpportunityContact/Edit', ['module', 'exports', 'dojo/_base/de
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('opportunityContactEdit');
+  const resource = (0, _I18n2.default)('opportunityContactEdit');
 
-  var __class = (0, _declare2.default)('crm.Views.OpportunityContact.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.OpportunityContact.Edit', [_Edit2.default], {
     // Localization
     titleText: resource.titleText,
     nameText: resource.nameText,

--- a/src-out/Views/OpportunityContact/List.js
+++ b/src-out/Views/OpportunityContact/List.js
@@ -19,22 +19,22 @@ define('crm/Views/OpportunityContact/List', ['module', 'exports', 'dojo/_base/de
     };
   }
 
-  var resource = (0, _I18n2.default)('opportunityContactList'); /* Copyright 2017 Infor
-                                                                 *
-                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                 * you may not use this file except in compliance with the License.
-                                                                 * You may obtain a copy of the License at
-                                                                 *
-                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                 *
-                                                                 * Unless required by applicable law or agreed to in writing, software
-                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                 * See the License for the specific language governing permissions and
-                                                                 * limitations under the License.
-                                                                 */
+  const resource = (0, _I18n2.default)('opportunityContactList'); /* Copyright 2017 Infor
+                                                                   *
+                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                   * you may not use this file except in compliance with the License.
+                                                                   * You may obtain a copy of the License at
+                                                                   *
+                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                   *
+                                                                   * Unless required by applicable law or agreed to in writing, software
+                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                   * See the License for the specific language governing permissions and
+                                                                   * limitations under the License.
+                                                                   */
 
-  var __class = (0, _declare2.default)('crm.Views.OpportunityContact.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.OpportunityContact.List', [_List2.default], {
     // Template
     itemTemplate: new Simplate(['<p class="micro-text {% if ($.IsPrimary) { %} primary {% } %}">', '{% if ($.SalesRole) { %}', '{%: $$.formatPicklist("SalesRole")($.SalesRole) %} | ', '{% } %}', '{%: $.Contact.Title %}</p>']),
 
@@ -59,9 +59,9 @@ define('crm/Views/OpportunityContact/List', ['module', 'exports', 'dojo/_base/de
     resourceKind: 'opportunityContacts',
 
     complete: function complete() {
-      var view = App.getPrimaryActiveView();
-      var selectionModel = view && view.get('selectionModel');
-      var entry = void 0;
+      const view = App.getPrimaryActiveView();
+      const selectionModel = view && view.get('selectionModel');
+      let entry;
 
       if (!selectionModel) {
         return;
@@ -71,10 +71,10 @@ define('crm/Views/OpportunityContact/List', ['module', 'exports', 'dojo/_base/de
         ReUI.back();
       }
 
-      var context = App.isNavigationFromResourceKind(['opportunities']);
-      var selections = selectionModel.getSelections();
+      const context = App.isNavigationFromResourceKind(['opportunities']);
+      const selections = selectionModel.getSelections();
 
-      for (var selectionKey in selections) {
+      for (const selectionKey in selections) {
         if (selections.hasOwnProperty(selectionKey)) {
           entry = {
             Opportunity: {
@@ -90,7 +90,7 @@ define('crm/Views/OpportunityContact/List', ['module', 'exports', 'dojo/_base/de
       }
     },
     createNavigationOptions: function createNavigationOptions() {
-      var options = {
+      const options = {
         query: this.expandExpression(this.options.prefilter),
         selectionOnly: true,
         singleSelect: true,
@@ -118,9 +118,9 @@ define('crm/Views/OpportunityContact/List', ['module', 'exports', 'dojo/_base/de
       return options;
     },
     navigateToInsertView: function navigateToInsertView(entry) {
-      var view = App.getView(this.insertView);
-      var options = {
-        entry: entry,
+      const view = App.getView(this.insertView);
+      const options = {
+        entry,
         insert: true
       };
       if (view && options) {
@@ -130,8 +130,8 @@ define('crm/Views/OpportunityContact/List', ['module', 'exports', 'dojo/_base/de
       }
     },
     navigateToSelectView: function navigateToSelectView() {
-      var view = App.getView(this.selectView);
-      var options = this.createNavigationOptions();
+      const view = App.getView(this.selectView);
+      const options = this.createNavigationOptions();
       if (view && options) {
         view.show(options);
       }
@@ -151,8 +151,8 @@ define('crm/Views/OpportunityContact/List', ['module', 'exports', 'dojo/_base/de
       return _Format2.default.picklist(this.app.picklistService, this._model, property);
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Contact.NameLF) like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Contact.NameLF) like "${q}%")`;
     }
   });
 

--- a/src-out/Views/OpportunityProduct/Detail.js
+++ b/src-out/Views/OpportunityProduct/Detail.js
@@ -23,22 +23,22 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
     };
   }
 
-  var resource = (0, _I18n2.default)('opportunityProductDetail'); /* Copyright 2017 Infor
-                                                                   *
-                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                   * you may not use this file except in compliance with the License.
-                                                                   * You may obtain a copy of the License at
-                                                                   *
-                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                   *
-                                                                   * Unless required by applicable law or agreed to in writing, software
-                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                   * See the License for the specific language governing permissions and
-                                                                   * limitations under the License.
-                                                                   */
+  const resource = (0, _I18n2.default)('opportunityProductDetail'); /* Copyright 2017 Infor
+                                                                     *
+                                                                     * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                     * you may not use this file except in compliance with the License.
+                                                                     * You may obtain a copy of the License at
+                                                                     *
+                                                                     *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                     *
+                                                                     * Unless required by applicable law or agreed to in writing, software
+                                                                     * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                     * See the License for the specific language governing permissions and
+                                                                     * limitations under the License.
+                                                                     */
 
-  var __class = (0, _declare2.default)('crm.Views.OpportunityProduct.Detail', [_Detail2.default, _LegacySDataDetailMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.OpportunityProduct.Detail', [_Detail2.default, _LegacySDataDetailMixin3.default], {
     // Localization
     detailsText: resource.detailsText,
     opportunityText: resource.opportunityText,
@@ -69,7 +69,7 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
     resourceKind: 'opportunityProducts',
 
     createEntryForDelete: function createEntryForDelete(e) {
-      var entry = {
+      const entry = {
         $key: e.$key,
         $etag: e.$etag,
         $name: e.$name
@@ -77,15 +77,15 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
       return entry;
     },
     removeOpportunityProduct: function removeOpportunityProduct() {
-      var confirmMessage = _string2.default.substitute(this.confirmDeleteText, [this.entry.Product.Name]);
+      const confirmMessage = _string2.default.substitute(this.confirmDeleteText, [this.entry.Product.Name]);
 
       if (!confirm(confirmMessage)) {
         // eslint-disable-line
         return;
       }
 
-      var entry = this.createEntryForDelete(this.entry);
-      var request = this.createRequest();
+      const entry = this.createEntryForDelete(this.entry);
+      const request = this.createRequest();
 
       if (request) {
         request.delete(entry, {
@@ -96,9 +96,9 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
       }
     },
     onDeleteSuccess: function onDeleteSuccess() {
-      var views = [App.getView('opportunityproduct_related'), App.getView('opportunity_detail'), App.getView('opportunity_list')];
+      const views = [App.getView('opportunityproduct_related'), App.getView('opportunity_detail'), App.getView('opportunity_list')];
 
-      views.forEach(function (view) {
+      views.forEach(view => {
         if (view) {
           view.refreshRequired = true;
         }
@@ -126,13 +126,13 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
       });
     },
     createLayout: function createLayout() {
-      var layout = this.layout || (this.layout = []);
+      let layout = this.layout || (this.layout = []);
 
       if (layout.length > 0) {
         return layout;
       }
 
-      var details = {
+      const details = {
         title: this.detailsText,
         name: 'DetailsSection',
         children: [{
@@ -157,8 +157,8 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
           property: 'Price',
           renderer: function renderPrice(val) {
             if (App.hasMultiCurrency()) {
-              var exhangeRate = App.getBaseExchangeRate();
-              var convertedValue = val * exhangeRate.rate;
+              const exhangeRate = App.getBaseExchangeRate();
+              const convertedValue = val * exhangeRate.rate;
               return _Format2.default.multiCurrency.call(null, convertedValue, exhangeRate.code);
             }
 
@@ -191,7 +191,7 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
         });
       }
 
-      var extendedPrice = {
+      const extendedPrice = {
         title: this.extendedPriceSectionText,
         name: 'OpportunityProductExtendedPriceDetail',
         children: [{
@@ -200,8 +200,8 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
           property: 'ExtendedPrice',
           renderer: function renderExtendedPrice(val) {
             if (App.hasMultiCurrency()) {
-              var exchangeRate = App.getBaseExchangeRate();
-              var convertedValue = val * exchangeRate.rate;
+              const exchangeRate = App.getBaseExchangeRate();
+              const convertedValue = val * exchangeRate.rate;
               return _Format2.default.multiCurrency.call(null, convertedValue, exchangeRate.code);
             }
 
@@ -210,7 +210,7 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
         }]
       };
 
-      var adjustedPrice = {
+      const adjustedPrice = {
         title: this.adjustedPriceSectionText,
         name: 'OpportunityProductAdjustedPriceDetail',
         children: [{
@@ -219,8 +219,8 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
           property: 'CalculatedPrice',
           renderer: function renderCalculatedPrice(val) {
             if (App.hasMultiCurrency()) {
-              var exhangeRate = App.getBaseExchangeRate();
-              var convertedValue = val * exhangeRate.rate;
+              const exhangeRate = App.getBaseExchangeRate();
+              const convertedValue = val * exhangeRate.rate;
               return _Format2.default.multiCurrency.call(null, convertedValue, exhangeRate.code);
             }
 
@@ -231,8 +231,8 @@ define('crm/Views/OpportunityProduct/Detail', ['module', 'exports', 'dojo/_base/
           name: 'CalculatedPriceMine',
           property: 'CalculatedPrice',
           renderer: function renderMyCalculatedPrice(val) {
-            var exhangeRate = App.getMyExchangeRate();
-            var convertedValue = val * exhangeRate.rate;
+            const exhangeRate = App.getMyExchangeRate();
+            const convertedValue = val * exhangeRate.rate;
             return _Format2.default.multiCurrency.call(null, convertedValue, exhangeRate.code);
           }.bindDelegate(this)
         }]

--- a/src-out/Views/OpportunityProduct/Edit.js
+++ b/src-out/Views/OpportunityProduct/Edit.js
@@ -19,22 +19,22 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
     };
   }
 
-  var resource = (0, _I18n2.default)('opportunityProductEdit'); /* Copyright 2017 Infor
-                                                                 *
-                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                 * you may not use this file except in compliance with the License.
-                                                                 * You may obtain a copy of the License at
-                                                                 *
-                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                 *
-                                                                 * Unless required by applicable law or agreed to in writing, software
-                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                 * See the License for the specific language governing permissions and
-                                                                 * limitations under the License.
-                                                                 */
+  const resource = (0, _I18n2.default)('opportunityProductEdit'); /* Copyright 2017 Infor
+                                                                   *
+                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                   * you may not use this file except in compliance with the License.
+                                                                   * You may obtain a copy of the License at
+                                                                   *
+                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                   *
+                                                                   * Unless required by applicable law or agreed to in writing, software
+                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                   * See the License for the specific language governing permissions and
+                                                                   * limitations under the License.
+                                                                   */
 
-  var __class = (0, _declare2.default)('crm.Views.OpportunityProduct.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.OpportunityProduct.Edit', [_Edit2.default], {
     // Localization
     titleText: resource.titleText,
     detailsText: resource.detailsText,
@@ -83,8 +83,8 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
         this.fields.Discount.setValue(values.Discount * 100);
       }
 
-      var myCode = App.getMyExchangeRate().code;
-      var baseCode = App.getBaseExchangeRate().code;
+      const myCode = App.getMyExchangeRate().code;
+      const baseCode = App.getBaseExchangeRate().code;
       this.fields.Price.setCurrencyCode(baseCode);
       this.fields.CalculatedPrice.setCurrencyCode(baseCode);
 
@@ -123,7 +123,7 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       return App.getMyExchangeRate().rate;
     },
     getValues: function getValues() {
-      var o = this.inherited(getValues, arguments);
+      const o = this.inherited(getValues, arguments);
       o.Program = o.Program.Program;
 
       /*
@@ -140,14 +140,14 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       return o;
     },
     applyContext: function applyContext() {
-      var entry = this.options && this.options.selectedEntry;
+      const entry = this.options && this.options.selectedEntry;
 
       if (entry) {
         this.fields.Opportunity.setValue(entry);
       }
     },
     onProductChange: function onProductChange(value, field) {
-      var selection = field && field.currentSelection;
+      const selection = field && field.currentSelection;
       if (selection) {
         this.fields.ProductId.setValueNoTrigger(value.key);
         this.fields['Product.Family'].setValueNoTrigger(selection.Family);
@@ -165,7 +165,7 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       }
     },
     onProgramChange: function onProgramChange(value, field) {
-      var selection = field && field.currentSelection;
+      const selection = field && field.currentSelection;
       if (selection) {
         this.fields.Price.setValueNoTrigger(selection.Price);
         this.fields.Discount.clearValue();
@@ -178,39 +178,39 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       }
     },
     onDiscountChange: function onDiscountChange() {
-      var price = parseFloat(this.fields.Price.getValue()) || 0;
-      var discount = this.fields.Discount.getValue();
+      const price = parseFloat(this.fields.Price.getValue()) || 0;
+      const discount = this.fields.Discount.getValue();
 
-      var adjusted = this._calculateAdjustedPrice(price, discount);
+      const adjusted = this._calculateAdjustedPrice(price, discount);
       this.fields.CalculatedPrice.setValueNoTrigger(adjusted);
 
       this._updateAdjustedPrices(adjusted);
       this._updateExtendedPrice();
     },
     onAdjustedPriceChange: function onAdjustedPriceChange() {
-      var price = parseFloat(this.fields.Price.getValue()) || 0;
-      var adjusted = parseFloat(this.fields.CalculatedPrice.getValue()) || 0;
+      const price = parseFloat(this.fields.Price.getValue()) || 0;
+      const adjusted = parseFloat(this.fields.CalculatedPrice.getValue()) || 0;
 
-      var discount = this._calculateDiscount(price, adjusted);
+      const discount = this._calculateDiscount(price, adjusted);
       this.fields.Discount.setValueNoTrigger(discount);
 
       if (App.hasMultiCurrency()) {
-        var myadjusted = this._getMyRate() * adjusted;
+        const myadjusted = this._getMyRate() * adjusted;
         this.fields.CalculatedPriceMine.setValueNoTrigger(myadjusted);
       }
       this._updateExtendedPrice();
     },
     onAdjustedPriceMineChange: function onAdjustedPriceMineChange() {
-      var myadjusted = this.fields.CalculatedPriceMine.getValue();
-      var price = this.fields.Price.getValue() || 0;
+      const myadjusted = this.fields.CalculatedPriceMine.getValue();
+      const price = this.fields.Price.getValue() || 0;
 
-      var myrate = this._getMyRate();
-      var myprice = price * myrate; // get the price in the users exchange rate
+      const myrate = this._getMyRate();
+      const myprice = price * myrate; // get the price in the users exchange rate
 
-      var discount = this._calculateDiscount(myprice, myadjusted);
+      const discount = this._calculateDiscount(myprice, myadjusted);
       this.fields.Discount.setValueNoTrigger(discount);
 
-      var adjusted = this._calculateAdjustedPrice(price, discount);
+      const adjusted = this._calculateAdjustedPrice(price, discount);
       this.fields.CalculatedPrice.setValueNoTrigger(adjusted);
 
       this._updateExtendedPrice();
@@ -222,7 +222,7 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       this._updateExtendedPrice();
     },
     _calculateDiscount: function _calculateDiscount(price, adjusted) {
-      var discount = void 0;
+      let discount;
       if (price === 0) {
         discount = 0.0;
       } else {
@@ -231,7 +231,7 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       return discount;
     },
     _calculateAdjustedPrice: function _calculateAdjustedPrice(price, discount) {
-      var adjusted = void 0;
+      let adjusted;
       if (discount === 0) {
         adjusted = price;
       } else {
@@ -240,7 +240,7 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       return adjusted;
     },
     _updateAdjustedPrices: function _updateAdjustedPrices(adjusted) {
-      var myadjusted = void 0;
+      let myadjusted;
       this.fields.CalculatedPrice.setValueNoTrigger(adjusted);
       if (App.hasMultiCurrency()) {
         myadjusted = this._getMyRate() * adjusted;
@@ -248,9 +248,9 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       }
     },
     _updateExtendedPrice: function _updateExtendedPrice() {
-      var quantity = parseFloat(this.fields.Quantity.getValue()) || 0;
-      var adjusted = parseFloat(this.fields.CalculatedPrice.getValue()) || 0;
-      var extended = adjusted * quantity;
+      const quantity = parseFloat(this.fields.Quantity.getValue()) || 0;
+      const adjusted = parseFloat(this.fields.CalculatedPrice.getValue()) || 0;
+      const extended = adjusted * quantity;
       this.fields.ExtendedPrice.setValueNoTrigger(extended);
     },
     onUpdateCompleted: function onUpdateCompleted() {
@@ -262,16 +262,16 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
       this.inherited(onInsertCompleted, arguments);
     },
     _refreshOpportunityViews: function _refreshOpportunityViews() {
-      var views = [App.getView('opportunityproduct_related'), App.getView('opportunity_detail'), App.getView('opportunity_list')];
+      const views = [App.getView('opportunityproduct_related'), App.getView('opportunity_detail'), App.getView('opportunity_list')];
 
-      views.forEach(function (view) {
+      views.forEach(view => {
         if (view) {
           view.refreshRequired = true;
         }
       });
     },
     createLayout: function createLayout() {
-      var details = {
+      const details = {
         title: this.detailsText,
         name: 'OpportunityProductDetailsEdit',
         children: [{
@@ -309,8 +309,8 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
           view: 'productprogram_related',
           validator: _Validator2.default.exists,
           where: function where() {
-            var val = this.fields.Product.getValue();
-            return 'Product.Name eq "' + _Utility2.default.escapeSearchQuery(val.Name) + '"';
+            const val = this.fields.Product.getValue();
+            return `Product.Name eq "${_Utility2.default.escapeSearchQuery(val.Name)}"`;
           }.bindDelegate(this)
         }, {
           label: App.hasMultiCurrency() ? this.basePriceText : this.priceText,
@@ -350,7 +350,7 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
         });
       }
 
-      var extendedPrice = {
+      const extendedPrice = {
         title: this.extendedPriceSectionText,
         name: 'OpportunityProductExtendedPriceEdit',
         children: [{
@@ -362,7 +362,7 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
         }]
       };
 
-      var adjustedPrice = {
+      const adjustedPrice = {
         title: this.adjustedPriceSectionText,
         name: 'OpportunityProductAdjustedPriceEdit',
         children: [{
@@ -380,7 +380,7 @@ define('crm/Views/OpportunityProduct/Edit', ['module', 'exports', 'dojo/_base/de
         }]
       };
 
-      var layout = this.layout || (this.layout = []);
+      const layout = this.layout || (this.layout = []);
 
       if (layout.length > 0) {
         return layout;

--- a/src-out/Views/OpportunityProduct/List.js
+++ b/src-out/Views/OpportunityProduct/List.js
@@ -15,22 +15,22 @@ define('crm/Views/OpportunityProduct/List', ['module', 'exports', 'dojo/_base/de
     };
   }
 
-  var resource = (0, _I18n2.default)('opportunityProductList'); /* Copyright 2017 Infor
-                                                                 *
-                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                 * you may not use this file except in compliance with the License.
-                                                                 * You may obtain a copy of the License at
-                                                                 *
-                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                 *
-                                                                 * Unless required by applicable law or agreed to in writing, software
-                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                 * See the License for the specific language governing permissions and
-                                                                 * limitations under the License.
-                                                                 */
+  const resource = (0, _I18n2.default)('opportunityProductList'); /* Copyright 2017 Infor
+                                                                   *
+                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                   * you may not use this file except in compliance with the License.
+                                                                   * You may obtain a copy of the License at
+                                                                   *
+                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                   *
+                                                                   * Unless required by applicable law or agreed to in writing, software
+                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                   * See the License for the specific language governing permissions and
+                                                                   * limitations under the License.
+                                                                   */
 
-  var __class = (0, _declare2.default)('crm.Views.OpportunityProduct.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.OpportunityProduct.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">', '{% if ($.Product) { %} {%: $.Product.Family %} | {% } %}', '{%: $.Program %} | {%: crm.Format.currency($.Price) %}', '</p>', '<p class="micro-text">', '{%: $.Quantity %} x {%: crm.Format.currency($.CalculatedPrice) %} ', '({%: crm.Format.percent($.Discount) %}) = ', '<strong>', '{% if (App.hasMultiCurrency()) { %}', '{%: crm.Format.multiCurrency($.ExtendedPrice, App.getBaseExchangeRate().code) %}', '{% } else { %}', '{%: crm.Format.currency($.ExtendedPrice) %}', '{% } %}', '</strong>', '</p>']),
 
@@ -49,8 +49,8 @@ define('crm/Views/OpportunityProduct/List', ['module', 'exports', 'dojo/_base/de
     enableActions: true,
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Product.Name) like "' + q + '%" or upper(Product.Family) like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Product.Name) like "${q}%" or upper(Product.Family) like "${q}%")`;
     }
   });
 

--- a/src-out/Views/Owner/List.js
+++ b/src-out/Views/Owner/List.js
@@ -15,22 +15,22 @@ define('crm/Views/Owner/List', ['module', 'exports', 'dojo/_base/declare', 'argo
     };
   }
 
-  var resource = (0, _I18n2.default)('ownerList'); /* Copyright 2017 Infor
-                                                    *
-                                                    * Licensed under the Apache License, Version 2.0 (the "License");
-                                                    * you may not use this file except in compliance with the License.
-                                                    * You may obtain a copy of the License at
-                                                    *
-                                                    *    http://www.apache.org/licenses/LICENSE-2.0
-                                                    *
-                                                    * Unless required by applicable law or agreed to in writing, software
-                                                    * distributed under the License is distributed on an "AS IS" BASIS,
-                                                    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                    * See the License for the specific language governing permissions and
-                                                    * limitations under the License.
-                                                    */
+  const resource = (0, _I18n2.default)('ownerList'); /* Copyright 2017 Infor
+                                                      *
+                                                      * Licensed under the Apache License, Version 2.0 (the "License");
+                                                      * you may not use this file except in compliance with the License.
+                                                      * You may obtain a copy of the License at
+                                                      *
+                                                      *    http://www.apache.org/licenses/LICENSE-2.0
+                                                      *
+                                                      * Unless required by applicable law or agreed to in writing, software
+                                                      * distributed under the License is distributed on an "AS IS" BASIS,
+                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                      * See the License for the specific language governing permissions and
+                                                      * limitations under the License.
+                                                      */
 
-  var __class = (0, _declare2.default)('crm.Views.Owner.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Owner.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.OwnerDescription %}</p>']),
 
@@ -47,16 +47,14 @@ define('crm/Views/Owner/List', ['module', 'exports', 'dojo/_base/declare', 'argo
     resourceKind: 'owners',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(OwnerDescription) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(OwnerDescription) like "%${q}%"`;
     },
     processData: function processData(items) {
-      var _this = this;
-
       if (items) {
-        items = items.filter(function (item) {
+        items = items.filter(item => {
           // eslint-disable-line
-          return _this._userEnabled(item) && _this._isCorrectType(item);
+          return this._userEnabled(item) && this._isCorrectType(item);
         }, this);
       }
 

--- a/src-out/Views/PickList.js
+++ b/src-out/Views/PickList.js
@@ -28,7 +28,7 @@ define('crm/Views/PickList', ['module', 'exports', 'dojo/_base/declare', 'argos/
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Views.PickList', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.PickList', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.text %}</p>']),
 
@@ -44,13 +44,9 @@ define('crm/Views/PickList', ['module', 'exports', 'dojo/_base/declare', 'argos/
     isCardView: false,
 
     _onQueryComplete: function _onQueryComplete(queryResults, entries) {
-      var _this = this;
-
       // eslint-disable-line
       if (this.options && this.options.picklistOptions && this.options.picklistOptions.filterByLanguage && this.query) {
-        entries = entries.filter(function (entry) {
-          return entry.languageCode === _this.getLanguageCode() || typeof entry.languageCode === 'undefined' || entry.languageCode === null;
-        });
+        entries = entries.filter(entry => entry.languageCode === this.getLanguageCode() || typeof entry.languageCode === 'undefined' || entry.languageCode === null);
         queryResults.total = entries.length;
       }
       this.inherited(_onQueryComplete, arguments);
@@ -95,9 +91,7 @@ define('crm/Views/PickList', ['module', 'exports', 'dojo/_base/declare', 'argos/
       this.inherited(show, arguments);
     },
     requestData: function requestData() {
-      var _this2 = this;
-
-      var picklistOptions = this.getPicklistOptions();
+      const picklistOptions = this.getPicklistOptions();
       picklistOptions.language = picklistOptions.language || this.getLanguageCode();
       this.languageCode = picklistOptions.language && picklistOptions.language.trim() || this.languageCode;
 
@@ -106,15 +100,11 @@ define('crm/Views/PickList', ['module', 'exports', 'dojo/_base/declare', 'argos/
         return this.inherited(requestData, arguments);
       }
 
-      return this.app.picklistService.requestPicklist(this.picklistName, picklistOptions).then(function (result) {
-        return _this2._onQueryComplete({ total: result && result.items.length }, result && result.items);
-      }, function (err) {
-        return _this2._onQueryError(null, err);
-      });
+      return this.app.picklistService.requestPicklist(this.picklistName, picklistOptions).then(result => this._onQueryComplete({ total: result && result.items.length }, result && result.items), err => this._onQueryError(null, err));
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(text) like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(text) like "${q}%"`;
     }
   });
 

--- a/src-out/Views/Product/List.js
+++ b/src-out/Views/Product/List.js
@@ -15,22 +15,22 @@ define('crm/Views/Product/List', ['module', 'exports', 'dojo/_base/declare', 'ar
     };
   }
 
-  var resource = (0, _I18n2.default)('productList'); /* Copyright 2017 Infor
-                                                      *
-                                                      * Licensed under the Apache License, Version 2.0 (the "License");
-                                                      * you may not use this file except in compliance with the License.
-                                                      * You may obtain a copy of the License at
-                                                      *
-                                                      *    http://www.apache.org/licenses/LICENSE-2.0
-                                                      *
-                                                      * Unless required by applicable law or agreed to in writing, software
-                                                      * distributed under the License is distributed on an "AS IS" BASIS,
-                                                      * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                      * See the License for the specific language governing permissions and
-                                                      * limitations under the License.
-                                                      */
+  const resource = (0, _I18n2.default)('productList'); /* Copyright 2017 Infor
+                                                        *
+                                                        * Licensed under the Apache License, Version 2.0 (the "License");
+                                                        * you may not use this file except in compliance with the License.
+                                                        * You may obtain a copy of the License at
+                                                        *
+                                                        *    http://www.apache.org/licenses/LICENSE-2.0
+                                                        *
+                                                        * Unless required by applicable law or agreed to in writing, software
+                                                        * distributed under the License is distributed on an "AS IS" BASIS,
+                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                        * See the License for the specific language governing permissions and
+                                                        * limitations under the License.
+                                                        */
 
-  var __class = (0, _declare2.default)('crm.Views.Product.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Product.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Name %} | {%: $.Description %}</p>', '<p class="micro-text">', '{%: $.Family %}', '</p>']),
 
@@ -45,8 +45,8 @@ define('crm/Views/Product/List', ['module', 'exports', 'dojo/_base/declare', 'ar
     resourceKind: 'products',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Name) like "' + q + '%" or upper(Family) like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Name) like "${q}%" or upper(Family) like "${q}%")`;
     }
   });
 

--- a/src-out/Views/ProductProgram/List.js
+++ b/src-out/Views/ProductProgram/List.js
@@ -15,22 +15,22 @@ define('crm/Views/ProductProgram/List', ['module', 'exports', 'dojo/_base/declar
     };
   }
 
-  var resource = (0, _I18n2.default)('productProgramList'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('productProgramList'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var __class = (0, _declare2.default)('crm.Views.ProductProgram.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.ProductProgram.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.Program %}</p>', '<p class="micro-text">', '{%: $.Price %}', '</p>']),
 
@@ -45,8 +45,8 @@ define('crm/Views/ProductProgram/List', ['module', 'exports', 'dojo/_base/declar
     resourceKind: 'productPrograms',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Program) like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Program) like "${q}%")`;
     }
   });
 

--- a/src-out/Views/RecentlyViewed/List.js
+++ b/src-out/Views/RecentlyViewed/List.js
@@ -44,14 +44,14 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('recentlyViewedList');
-  var accountResource = (0, _I18n2.default)('accountModel');
-  var contactResource = (0, _I18n2.default)('contactModel');
-  var activityResource = (0, _I18n2.default)('activityModel');
-  var historyResource = (0, _I18n2.default)('historyModel');
-  var oppResource = (0, _I18n2.default)('opportunityModel');
-  var ticketResource = (0, _I18n2.default)('ticketModel');
-  var leadResource = (0, _I18n2.default)('leadModel');
+  const resource = (0, _I18n2.default)('recentlyViewedList');
+  const accountResource = (0, _I18n2.default)('accountModel');
+  const contactResource = (0, _I18n2.default)('contactModel');
+  const activityResource = (0, _I18n2.default)('activityModel');
+  const historyResource = (0, _I18n2.default)('historyModel');
+  const oppResource = (0, _I18n2.default)('opportunityModel');
+  const ticketResource = (0, _I18n2.default)('ticketModel');
+  const leadResource = (0, _I18n2.default)('leadModel');
 
   exports.default = (0, _declare2.default)('crm.Views.RecentlyViewed.List', [_ListBase3.default, _RightDrawerListMixin3.default, _MetricListMixin3.default], {
     id: 'recently_viewed_list',
@@ -71,7 +71,7 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       return true;
     },
     getModel: function getModel() {
-      var model = App.ModelManager.getModel('RecentlyViewed', _Types2.default.OFFLINE);
+      const model = App.ModelManager.getModel('RecentlyViewed', _Types2.default.OFFLINE);
       return model;
     },
     getTitle: function getTitle(entry) {
@@ -87,7 +87,7 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       return options;
     },
     _applyStateToWidgetOptions: function _applyStateToWidgetOptions(widgetOptions) {
-      var options = widgetOptions;
+      const options = widgetOptions;
       options.activeEntityFilters = this.getActiveEntityFilters();
       return options;
     },
@@ -96,13 +96,11 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       delete queryOptions.start;
       queryOptions.include_docs = true;
       queryOptions.descending = true;
-      var filters = this.getActiveEntityFilters();
-      queryOptions.filter = function (entity) {
+      const filters = this.getActiveEntityFilters();
+      queryOptions.filter = entity => {
         // If the user has entity filters stored in preferences, filter based on that
         if (App.preferences && App.preferences.recentlyViewedEntityFilters) {
-          return filters.some(function (filter) {
-            return entity.entityName === filter.name;
-          });
+          return filters.some(filter => entity.entityName === filter.name);
         }
 
         return true;
@@ -113,7 +111,7 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       return [];
     },
     getItemIconClass: function getItemIconClass(entry) {
-      var iconClass = void 0;
+      let iconClass;
       iconClass = entry.iconClass;
       if (!iconClass) {
         iconClass = 'url';
@@ -121,7 +119,7 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       return iconClass;
     },
     navigateToDetailView: function navigateToDetailView(key, descriptor, additionalOptions) {
-      var entry = this.entries && this.entries[key];
+      const entry = this.entries && this.entries[key];
       if (App.onLine) {
         this.navigateToOnlineDetailView(entry, additionalOptions);
       } else {
@@ -129,9 +127,9 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       }
     },
     navigateToOnlineDetailView: function navigateToDetailView(entry, additionalOptions) {
-      var view = this.app.getView(entry.viewId);
+      const view = this.app.getView(entry.viewId);
 
-      var options = {
+      let options = {
         descriptor: entry.description, // keep for backwards compat
         title: entry.description,
         key: entry.entityId,
@@ -147,8 +145,8 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       }
     },
     navigateToOfflineDetailView: function navigateToOfflineDetailView(entry, additionalOptions) {
-      var view = this.getDetailView(entry.entityName);
-      var options = {
+      const view = this.getDetailView(entry.entityName);
+      let options = {
         descriptor: entry.description, // keep for backwards compat
         title: entry.description,
         key: entry.entityId,
@@ -169,8 +167,8 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       }
     },
     getDetailView: function getDetailView(entityName) {
-      var viewId = this.detailView + '_' + entityName;
-      var view = this.app.getView(viewId);
+      const viewId = `${this.detailView}_${entityName}`;
+      let view = this.app.getView(viewId);
 
       if (view) {
         return view;
@@ -183,15 +181,13 @@ define('crm/Views/RecentlyViewed/List', ['module', 'exports', 'dojo/_base/declar
       return view;
     },
     getActiveEntityFilters: function getActiveEntityFilters() {
-      return Object.keys(this.entityMappings).map(function (entityName) {
-        var prefs = App.preferences && App.preferences.recentlyViewedEntityFilters || [];
-        var entityPref = prefs.filter(function (pref) {
+      return Object.keys(this.entityMappings).map(entityName => {
+        const prefs = App.preferences && App.preferences.recentlyViewedEntityFilters || [];
+        const entityPref = prefs.filter(pref => {
           return pref.name === entityName;
         });
         return entityPref[0];
-      }).filter(function (f) {
-        return f && f.enabled;
-      });
+      }).filter(f => f && f.enabled);
     },
 
     // Localization

--- a/src-out/Views/RecentlyViewed/TotalMetricWidget.js
+++ b/src-out/Views/RecentlyViewed/TotalMetricWidget.js
@@ -26,15 +26,13 @@ define('crm/Views/RecentlyViewed/TotalMetricWidget', ['module', 'exports', '../M
   exports.default = (0, _declare2.default)('crm.Views.RecentlyViewed.TotalMetricWidget', [_MetricWidget2.default], {
     navToReportView: function navToReportView() {},
     _buildQueryOptions: function _buildQueryOptions() {
-      var filters = App.preferences && App.preferences.recentlyViewedEntityFilters ? App.preferences.recentlyViewedEntityFilters : [];
+      const filters = App.preferences && App.preferences.recentlyViewedEntityFilters ? App.preferences.recentlyViewedEntityFilters : [];
       return {
         returnQueryResults: true,
-        filter: function filter(entity) {
+        filter: entity => {
           // If the user has entity filters stored in preferences, filter based on that
           if (filters) {
-            return filters.some(function (filter) {
-              return entity.entityName === filter.name && filter.enabled;
-            });
+            return filters.some(filter => entity.entityName === filter.name && filter.enabled);
           }
 
           // User has no entity filter preferences (from right drawer)
@@ -43,15 +41,15 @@ define('crm/Views/RecentlyViewed/TotalMetricWidget', ['module', 'exports', '../M
       };
     },
     _getData: function _getData() {
-      var queryOptions = this._buildQueryOptions();
-      var model = App.ModelManager.getModel('RecentlyViewed', _Types2.default.OFFLINE);
-      var queryResults = model.getEntries(null, queryOptions);
+      const queryOptions = this._buildQueryOptions();
+      const model = App.ModelManager.getModel('RecentlyViewed', _Types2.default.OFFLINE);
+      const queryResults = model.getEntries(null, queryOptions);
       (0, _when2.default)(queryResults, _lang2.default.hitch(this, this._onQuerySuccessCount, queryResults), _lang2.default.hitch(this, this._onQueryError));
     },
     _onQuerySuccessCount: function _onQuerySuccessCount(results) {
-      var def = new _Deferred2.default();
-      (0, _when2.default)(results.total, function (total) {
-        var metricResults = [{
+      const def = new _Deferred2.default();
+      (0, _when2.default)(results.total, total => {
+        const metricResults = [{
           name: 'count',
           value: total
         }];

--- a/src-out/Views/RecentlyViewed/_RightDrawerListMixin.js
+++ b/src-out/Views/RecentlyViewed/_RightDrawerListMixin.js
@@ -35,7 +35,7 @@ define('crm/Views/RecentlyViewed/_RightDrawerListMixin', ['module', 'exports', '
   /**
    * @module crm/Views/RecentlyViewed/_RightDrawerListMixin
    */
-  var resource = (0, _I18n2.default)('rightDrawerListMixin');
+  const resource = (0, _I18n2.default)('rightDrawerListMixin');
 
   /**
    * @class
@@ -44,7 +44,7 @@ define('crm/Views/RecentlyViewed/_RightDrawerListMixin', ['module', 'exports', '
    * @mixes module:crm/Views/_RightDrawerBaseMixin
    *
    */
-  var __class = (0, _declare2.default)('crm.Views.RecentlyViewed._RightDrawerListMixin', [_RightDrawerBaseMixin3.default], /** @lends module:crm/Views/RecentlyViewed/_RightDrawerListMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views.RecentlyViewed._RightDrawerListMixin', [_RightDrawerBaseMixin3.default], /** @lends module:crm/Views/RecentlyViewed/_RightDrawerListMixin.prototype */{
 
     // Dirty flags to refresh the mainview and/or widgets
     _hasChangedEntityPrefs: false,
@@ -58,23 +58,21 @@ define('crm/Views/RecentlyViewed/_RightDrawerListMixin', ['module', 'exports', '
     },
     setDefaultEntityPreferences: function setDefaultEntityPreferences() {
       if (!App.preferences.recentlyViewedEntityFilters) {
-        var defaults = this.getDefaultEntityPreferences();
+        const defaults = this.getDefaultEntityPreferences();
         App.preferences.recentlyViewedEntityFilters = defaults;
         App.persistPreferences();
       }
     },
     getDefaultEntityPreferences: function getDefaultEntityPreferences() {
-      return Object.keys(this.entityMappings).map(function (name) {
+      return Object.keys(this.entityMappings).map(name => {
         return {
-          name: name,
+          name,
           enabled: true
         };
       });
     },
     setupRightDrawer: function setupRightDrawer() {
-      var _this = this;
-
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         _lang2.default.mixin(drawer, this._createActions());
         drawer.setLayout(this.createRightDrawerLayout());
@@ -82,25 +80,25 @@ define('crm/Views/RecentlyViewed/_RightDrawerListMixin', ['module', 'exports', '
           return this.getGroupForRightDrawerEntry(entry);
         });
 
-        App.viewSettingsModal.element.on('close', function () {
-          if (_this._hasChangedEntityPrefs) {
-            _this.clear();
-            _this.refreshRequired = true;
-            _this.refresh();
-            _this._hasChangedEntityPrefs = false;
-            _this._hasChangedKPIPrefs = false;
+        App.viewSettingsModal.element.on('close', () => {
+          if (this._hasChangedEntityPrefs) {
+            this.clear();
+            this.refreshRequired = true;
+            this.refresh();
+            this._hasChangedEntityPrefs = false;
+            this._hasChangedKPIPrefs = false;
           }
 
-          if (_this._hasChangedKPIPrefs && _this.rebuildWidgets) {
-            _this.destroyWidgets();
-            _this.rebuildWidgets();
-            _this._hasChangedKPIPrefs = false;
+          if (this._hasChangedKPIPrefs && this.rebuildWidgets) {
+            this.destroyWidgets();
+            this.rebuildWidgets();
+            this._hasChangedKPIPrefs = false;
           }
         });
       }
     },
     unloadRightDrawer: function unloadRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.setLayout([]);
         drawer.getGroupForEntry = function noop() {};
@@ -113,16 +111,16 @@ define('crm/Views/RecentlyViewed/_RightDrawerListMixin', ['module', 'exports', '
     },
     _createActions: function _createActions() {
       // These actions will get mixed into the right drawer view.
-      var actions = {
+      const actions = {
         entityFilterClicked: function onentityFilterClicked(params) {
-          var prefs = App.preferences && App.preferences.recentlyViewedEntityFilters;
+          const prefs = App.preferences && App.preferences.recentlyViewedEntityFilters;
 
-          var results = prefs.filter(function (pref) {
+          const results = prefs.filter(pref => {
             return pref.name === params.entityname;
           });
 
           if (results.length > 0) {
-            var enabled = !!results[0].enabled;
+            const enabled = !!results[0].enabled;
             results[0].enabled = !enabled;
             App.persistPreferences();
             this._hasChangedEntityPrefs = true;
@@ -130,17 +128,17 @@ define('crm/Views/RecentlyViewed/_RightDrawerListMixin', ['module', 'exports', '
           }
         }.bind(this),
         kpiClicked: function kpiClicked(params) {
-          var metrics = App.getMetricsByResourceKind(this.resourceKind);
-          var results = void 0;
+          const metrics = App.getMetricsByResourceKind(this.resourceKind);
+          let results;
 
           if (metrics.length > 0) {
-            results = metrics.filter(function (metric) {
+            results = metrics.filter(metric => {
               return metric.title === params.title;
             });
           }
 
           if (results.length > 0) {
-            var enabled = !!results[0].enabled;
+            const enabled = !!results[0].enabled;
             results[0].enabled = !enabled;
             App.persistPreferences();
             this._hasChangedKPIPrefs = true;
@@ -166,22 +164,21 @@ define('crm/Views/RecentlyViewed/_RightDrawerListMixin', ['module', 'exports', '
       };
     },
     createRightDrawerLayout: function createRightDrawerLayout() {
-      var _this2 = this;
-
-      var layout = [];
-      var entitySection = {
+      const layout = [];
+      const entitySection = {
         id: 'actions',
-        children: Object.keys(this.entityMappings).map(function (entityName) {
-          var prefs = App.preferences && App.preferences.recentlyViewedEntityFilters;
-          var entityPref = prefs.filter(function (pref) {
+        children: Object.keys(this.entityMappings).map(entityName => {
+          const prefs = App.preferences && App.preferences.recentlyViewedEntityFilters;
+          const entityPref = prefs.filter(pref => {
             return pref.name === entityName;
           });
-          var enabled = entityPref[0].enabled;
-
+          const {
+            enabled
+          } = entityPref[0];
           return {
             name: entityName,
             action: 'entityFilterClicked',
-            title: _this2.entityText[entityName] || entityName,
+            title: this.entityText[entityName] || entityName,
             dataProps: {
               entityname: entityName,
               enabled: !!enabled
@@ -192,15 +189,13 @@ define('crm/Views/RecentlyViewed/_RightDrawerListMixin', ['module', 'exports', '
 
       layout.push(entitySection);
 
-      var metrics = App.getMetricsByResourceKind(this.resourceKind);
+      const metrics = App.getMetricsByResourceKind(this.resourceKind);
 
-      var kpiSection = {
+      const kpiSection = {
         id: 'kpi',
-        children: metrics.filter(function (m) {
-          return m.title;
-        }).map(function (metric, i) {
+        children: metrics.filter(m => m.title).map((metric, i) => {
           return {
-            name: 'KPI' + i,
+            name: `KPI${i}`,
             action: 'kpiClicked',
             title: metric.title,
             dataProps: {

--- a/src-out/Views/RelatedContextWidget.js
+++ b/src-out/Views/RelatedContextWidget.js
@@ -32,50 +32,50 @@ define('crm/Views/RelatedContextWidget', ['module', 'exports', 'dojo/_base/decla
    * limitations under the License.
    */
 
-  var __class = (0, _declare2.default)('crm.Views.RelatedContextWidget', [_RelatedViewWidgetBase3.default], {
+  const __class = (0, _declare2.default)('crm.Views.RelatedContextWidget', [_RelatedViewWidgetBase3.default], {
 
     cls: 'related-context-widget',
     contextCls: null,
     contextWrapperTemplate: new Simplate(['<div class="context-snapshot {%: $$.contextCls %}"></div>']),
     onInit: function onInit() {
-      var self = this;
+      const self = this;
       this.onLoad();
       if (this.owner) {
-        _aspect2.default.after(this.owner, 'show', function () {
+        _aspect2.default.after(this.owner, 'show', () => {
           self.onRefreshView();
         });
       }
     },
     onLoad: function onLoad() {
-      var snapShot = this.getContextSnapShot();
+      const snapShot = this.getContextSnapShot();
       if (snapShot) {
         this.processSnapShot(snapShot);
       }
     },
     getContextSnapShot: function getContextSnapShot() {
-      var snapShot = void 0;
+      let snapShot;
       if (this.owner && this.owner.options && this.owner.options.fromContext) {
-        var ctx = this.owner.options.fromContext;
+        const ctx = this.owner.options.fromContext;
         snapShot = ctx.getContextSnapShot(this.owner.options);
       }
       return snapShot;
     },
     processSnapShot: function processSnapShot(snapShot) {
       if (this.containerNode && snapShot) {
-        var wrapper = $(this.contextWrapperTemplate.apply(this));
+        const wrapper = $(this.contextWrapperTemplate.apply(this));
         $(wrapper).append(snapShot);
         $(this.containerNode).append(wrapper);
       }
     },
     onRefreshView: function onRefreshView() {
       if (this.containerNode) {
-        var node = $('<div></div>');
+        const node = $('<div></div>');
         $(this.containerNode).empty().append(node);
         this.onLoad();
       }
     }
   });
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('relatedContext', __class);
   exports.default = __class;
   module.exports = exports['default'];

--- a/src-out/Views/RelatedEditWidget.js
+++ b/src-out/Views/RelatedEditWidget.js
@@ -23,7 +23,7 @@ define('crm/Views/RelatedEditWidget', ['module', 'exports', 'dojo/_base/declare'
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Views.RelatedEditWidget', [_RelatedViewWidgetBase3.default], {
+  const __class = (0, _declare2.default)('crm.Views.RelatedEditWidget', [_RelatedViewWidgetBase3.default], {
     cls: 'related-edit-widget',
     owner: null,
     id: 'related-edit-widget',
@@ -33,9 +33,9 @@ define('crm/Views/RelatedEditWidget', ['module', 'exports', 'dojo/_base/declare'
       this.processEntry(this.parentEntry);
     },
     processEntry: function processEntry(entry) {
-      var Ctor = this.editView ? this.editView : _Edit2.default;
-      var editView = new Ctor({
-        id: this.id + '_edit'
+      const Ctor = this.editView ? this.editView : _Edit2.default;
+      const editView = new Ctor({
+        id: `${this.id}_edit`
       });
       if (editView && !editView._started) {
         editView.sectionBeginTemplate = new Simplate(['<fieldset class="{%= ($.cls || $.options.cls) %}">']);
@@ -44,14 +44,14 @@ define('crm/Views/RelatedEditWidget', ['module', 'exports', 'dojo/_base/declare'
         editView.onUpdateCompleted = this.onUpdateCompleted.bind(this);
       }
       // Add the toolbar for save
-      var toolBarNode = $(this.toolBarTemplate.apply(entry, this)).get(0);
+      const toolBarNode = $(this.toolBarTemplate.apply(entry, this)).get(0);
       (0, _on2.default)(toolBarNode, 'click', this.onInvokeToolBarAction.bind(this));
       $(this.containerNode).append(toolBarNode);
 
       // Add the edit view to view
       editView.placeAt(this.containerNode, 'last');
 
-      var options = {
+      const options = {
         select: this.getEditSelect(),
         key: entry.$key
       };
@@ -65,9 +65,9 @@ define('crm/Views/RelatedEditWidget', ['module', 'exports', 'dojo/_base/declare'
       _event2.default.stop(evt);
     },
     getEditLayout: function getEditLayout() {
-      var editLayout = [];
+      const editLayout = [];
       if (this.layout) {
-        this.layout.forEach(function (item) {
+        this.layout.forEach(item => {
           if (!item.readonly) {
             editLayout.push(item);
           }
@@ -76,7 +76,7 @@ define('crm/Views/RelatedEditWidget', ['module', 'exports', 'dojo/_base/declare'
       return editLayout;
     },
     getEditSelect: function getEditSelect() {
-      var select = null;
+      let select = null;
       if (this.formModel) {
         select = this.formModel.getEditSelect();
       }
@@ -89,12 +89,12 @@ define('crm/Views/RelatedEditWidget', ['module', 'exports', 'dojo/_base/declare'
       this.inherited(onUpdateCompleted, arguments);
     },
     destroy: function destroy() {
-      this._subscribes.forEach(function (handle) {
+      this._subscribes.forEach(handle => {
         _connect2.default.unsubscribe(handle);
       });
 
       if (this.editViewInstance) {
-        for (var name in this.editViewInstance.fields) {
+        for (const name in this.editViewInstance.fields) {
           if (this.editViewInstance.fields.hasOwnProperty(name)) {
             this.editViewInstance.fields[name].destroy();
           }
@@ -118,7 +118,7 @@ define('crm/Views/RelatedEditWidget', ['module', 'exports', 'dojo/_base/declare'
        * limitations under the License.
        */
 
-  var rvm = new _RelatedViewManager2.default();
+  const rvm = new _RelatedViewManager2.default();
   rvm.registerType('relatedEdit', __class);
   exports.default = __class;
   module.exports = exports['default'];

--- a/src-out/Views/RightDrawer.js
+++ b/src-out/Views/RightDrawer.js
@@ -15,7 +15,7 @@ define('crm/Views/RightDrawer', ['module', 'exports', 'dojo/_base/declare', 'doj
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Views.RightDrawer', [_GroupedList2.default], {
+  const __class = (0, _declare2.default)('crm.Views.RightDrawer', [_GroupedList2.default], {
     // Templates
     cls: ' contextualContent',
     rowTemplate: new Simplate(['<div class="accordion-header list-content" role="presentation">', '<a data-action="{%= $.action %}"', '{% if($.dataProps) { %}', '{% for(var prop in $.dataProps) { %}', ' data-{%= prop %}="{%= $.dataProps[prop] %}"', '{% } %}', '{% } %}', '>', '<span>{%: $.title %}</span></a>', '</div>']),
@@ -47,14 +47,14 @@ define('crm/Views/RightDrawer', ['module', 'exports', 'dojo/_base/declare', 'doj
       return this.layout || [];
     },
     createStore: function createStore() {
-      var layout = this._createCustomizedLayout(this.createLayout());
-      var list = [];
+      const layout = this._createCustomizedLayout(this.createLayout());
+      const list = [];
 
-      for (var i = 0; i < layout.length; i++) {
-        var section = layout[i].children;
+      for (let i = 0; i < layout.length; i++) {
+        const section = layout[i].children;
 
-        for (var j = 0; j < section.length; j++) {
-          var row = section[j];
+        for (let j = 0; j < section.length; j++) {
+          const row = section[j];
 
           if (row.security && !App.hasAccessTo(row.security)) {
             continue;
@@ -65,7 +65,7 @@ define('crm/Views/RightDrawer', ['module', 'exports', 'dojo/_base/declare', 'doj
         }
       }
 
-      var store = new _Memory2.default({
+      const store = new _Memory2.default({
         data: list
       });
       return store;

--- a/src-out/Views/SelectList.js
+++ b/src-out/Views/SelectList.js
@@ -15,7 +15,7 @@ define('crm/Views/SelectList', ['module', 'exports', 'dojo/_base/declare', 'dojo
     };
   }
 
-  var __class = (0, _declare2.default)('crm.Views.SelectList', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.SelectList', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.$descriptor %}</p>']),
 
@@ -39,9 +39,9 @@ define('crm/Views/SelectList', ['module', 'exports', 'dojo/_base/declare', 'dojo
     },
     createStore: function createStore() {
       // caller is responsible for passing in a well-structured feed object.
-      var data = this.expandExpression(this.options && this.options.data && this.options.data.$resources);
-      var store = new _Memory2.default({
-        data: data
+      const data = this.expandExpression(this.options && this.options.data && this.options.data.$resources);
+      const store = new _Memory2.default({
+        data
       });
       store.idProperty = '$key';
       return store;

--- a/src-out/Views/Settings.js
+++ b/src-out/Views/Settings.js
@@ -32,11 +32,16 @@ define('crm/Views/Settings', ['module', 'exports', 'dojo/_base/declare', 'dojo/_
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('settings');
+  const resource = (0, _I18n2.default)('settings');
 
-  var __class = (0, _declare2.default)('crm.Views.Settings', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Settings', [_List2.default], {
     // Templates
-    itemIconTemplate: new Simplate(['<button type="button" data-action="{%= $.action %}" {% if ($.view) { %}data-view="{%= $.view %}"{% } %} class="btn-actions list-item-selector button visible">\n      <span class="audible">{%: $$.actionsText %}</span>\n      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">\n        <use xlink:href="#icon-{%= $$.getItemIconClass($) %}"></use>\n      </svg>\n    </button>']),
+    itemIconTemplate: new Simplate([`<button type="button" data-action="{%= $.action %}" {% if ($.view) { %}data-view="{%= $.view %}"{% } %} class="btn-actions list-item-selector button visible">
+      <span class="audible">{%: $$.actionsText %}</span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-{%= $$.getItemIconClass($) %}"></use>
+      </svg>
+    </button>`]),
     itemTemplate: new Simplate(['<h4 data-action="{%= $.action %}" class="list-item-content ', '{% if ($.icon) { %}', 'list-item-content', '{% } %} ">', '{%: $.title %}</h4>']),
     liRowTemplate: new Simplate(['<li data-action="{%= $.action %}" {% if ($.view) { %}data-view="{%= $.view %}"{% } %}>', '{%! $$.itemIconTemplate %}', '{%! $$.itemTemplate %}', '</li>']),
     isCardView: false,
@@ -100,26 +105,24 @@ define('crm/Views/Settings', ['module', 'exports', 'dojo/_base/declare', 'dojo/_
       return this.itemIndicators || (this.itemIndicators = []);
     },
     viewErrorLogs: function viewErrorLogs() {
-      var view = App.getView('errorlog_list');
+      const view = App.getView('errorlog_list');
       if (view) {
         view.show();
       }
     },
     clearLocalStorage: function clearLocalStorage() {
-      var _this = this;
-
       if (confirm(this.confirmClearLocalStorageMessage)) {
         // eslint-disable-line
         if (window.localStorage) {
           window.localStorage.clear();
         }
 
-        App.clearServiceWorkerCaches().then(function () {
+        App.clearServiceWorkerCaches().then(() => {
           _connect2.default.publish('/app/refresh', [{
             resourceKind: 'localStorage'
           }]);
 
-          alert(_this.localStorageClearedText); // eslint-disable-line
+          alert(this.localStorageClearedText); // eslint-disable-line
           window.location.reload(); // reloaded because of the clock setting
         });
       }
@@ -132,19 +135,19 @@ define('crm/Views/Settings', ['module', 'exports', 'dojo/_base/declare', 'dojo/_
       alert(this.credentialsClearedText); // eslint-disable-line
     },
     viewOfflineOptions: function viewOfflineOptions() {
-      var view = App.getView('offline_options_edit');
+      const view = App.getView('offline_options_edit');
       if (view) {
         view.show();
       }
     },
     viewLanguageOptions: function viewLanguageOptions() {
-      var view = App.getView('language_options_edit');
+      const view = App.getView('language_options_edit');
       if (view) {
         view.show();
       }
     },
     use24HourClock: function use24HourClock() {
-      var message = App.is24HourClock() ? this.confirm12HourClockMessage : this.confirm24HourClockMessage;
+      const message = App.is24HourClock() ? this.confirm12HourClockMessage : this.confirm24HourClockMessage;
       if (confirm(message)) {
         // eslint-disable-line
         if (App.is24HourClock()) {
@@ -159,10 +162,10 @@ define('crm/Views/Settings', ['module', 'exports', 'dojo/_base/declare', 'dojo/_
       return false;
     },
     requestData: function requestData() {
-      var list = [];
+      const list = [];
 
-      for (var i = 0; i < this.actionOrder.length; i++) {
-        var action = this.actionItems[this.actionOrder[i]];
+      for (let i = 0; i < this.actionOrder.length; i++) {
+        const action = this.actionItems[this.actionOrder[i]];
         if (action) {
           list.push({
             action: this.actionOrder[i],

--- a/src-out/Views/SpeedSearchList.js
+++ b/src-out/Views/SpeedSearchList.js
@@ -25,22 +25,22 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
     };
   }
 
-  var resource = (0, _I18n2.default)('speedSearchList'); /* Copyright 2017 Infor
-                                                          *
-                                                          * Licensed under the Apache License, Version 2.0 (the "License");
-                                                          * you may not use this file except in compliance with the License.
-                                                          * You may obtain a copy of the License at
-                                                          *
-                                                          *    http://www.apache.org/licenses/LICENSE-2.0
-                                                          *
-                                                          * Unless required by applicable law or agreed to in writing, software
-                                                          * distributed under the License is distributed on an "AS IS" BASIS,
-                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                          * See the License for the specific language governing permissions and
-                                                          * limitations under the License.
-                                                          */
+  const resource = (0, _I18n2.default)('speedSearchList'); /* Copyright 2017 Infor
+                                                            *
+                                                            * Licensed under the Apache License, Version 2.0 (the "License");
+                                                            * you may not use this file except in compliance with the License.
+                                                            * You may obtain a copy of the License at
+                                                            *
+                                                            *    http://www.apache.org/licenses/LICENSE-2.0
+                                                            *
+                                                            * Unless required by applicable law or agreed to in writing, software
+                                                            * distributed under the License is distributed on an "AS IS" BASIS,
+                                                            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                            * See the License for the specific language governing permissions and
+                                                            * limitations under the License.
+                                                            */
 
-  var __class = (0, _declare2.default)('crm.Views.SpeedSearchList', [_List2.default, _LegacySDataListMixin3.default, _SpeedSearchRightDrawerListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.SpeedSearchList', [_List2.default, _LegacySDataListMixin3.default, _SpeedSearchRightDrawerListMixin3.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text"><strong>{%: $.$heading %}</strong></p>', '{%! $$.fieldTemplate %}']),
 
@@ -115,9 +115,9 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
     },
     _formatFieldName: function _formatFieldName() {},
     getItemIconClass: function getItemIconClass(entry) {
-      var type = entry && entry.type;
-      var typeCls = this.itemIconByType[type];
-      var cls = this.itemIconClass;
+      const type = entry && entry.type;
+      const typeCls = this.itemIconByType[type];
+      let cls = this.itemIconClass;
       if (typeCls) {
         cls = typeCls;
       }
@@ -125,7 +125,7 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       return cls;
     },
     extractTypeFromItem: function extractTypeFromItem(item) {
-      for (var i = 0; i < this.types.length; i++) {
+      for (let i = 0; i < this.types.length; i++) {
         if (item.source.indexOf(this.types[i]) !== -1) {
           return this.types[i];
         }
@@ -134,8 +134,8 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       return null;
     },
     extractDescriptorFromItem: function extractDescriptorFromItem(item) {
-      var descriptor = item && item.uiDisplayName;
-      var rest = void 0;
+      let descriptor = item && item.uiDisplayName;
+      let rest;
 
       if (descriptor) {
         descriptor = descriptor.split(':');
@@ -146,12 +146,12 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
     },
     extractKeyFromItem: function extractKeyFromItem(item) {
       // Extract the entityId from the display name, which is the last 12 characters
-      var displayName = item.displayName;
+      const displayName = item.displayName;
       if (!displayName) {
         return '';
       }
 
-      var len = displayName.length;
+      const len = displayName.length;
       return displayName.substring(len - 12);
     },
     more: function more() {
@@ -159,12 +159,12 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       this.inherited(more, arguments);
     },
     hasMoreData: function hasMoreData() {
-      var total = this.feed.totalCount;
-      var count = (this.currentPage + 1) * this.pageSize;
+      const total = this.feed.totalCount;
+      const count = (this.currentPage + 1) * this.pageSize;
       return count < total;
     },
     processFeed: function processFeed(_feed) {
-      var feed = _feed;
+      let feed = _feed;
       if (!this.feed) {
         this.set('listContent', '');
       }
@@ -178,10 +178,10 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       if (feed.totalCount === 0) {
         this.set('listContent', this.noDataTemplate.apply(this));
       } else if (feed.items) {
-        var docfrag = document.createDocumentFragment();
+        const docfrag = document.createDocumentFragment();
 
-        for (var i = 0; i < feed.items.length; i++) {
-          var entry = feed.items[i];
+        for (let i = 0; i < feed.items.length; i++) {
+          const entry = feed.items[i];
           entry.type = this.extractTypeFromItem(entry);
           entry.$descriptor = entry.$descriptor || entry.uiDisplayName;
           entry.$key = this.extractKeyFromItem(entry);
@@ -190,7 +190,7 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
           entry.fields = entry.fields.filter(filter);
 
           this.entries[entry.$key] = entry;
-          var rowNode = $(this.rowTemplate.apply(entry, this));
+          const rowNode = $(this.rowTemplate.apply(entry, this));
           docfrag.appendChild(rowNode.get(0));
           this.onApplyRowTemplate(entry, rowNode);
         }
@@ -201,19 +201,19 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       }
 
       if (typeof feed.totalCount !== 'undefined') {
-        var remaining = this.feed.totalCount - (this.currentPage + 1) * this.pageSize;
+        const remaining = this.feed.totalCount - (this.currentPage + 1) * this.pageSize;
         this.set('remainingContent', _string2.default.substitute(this.remainingText, [remaining]));
       }
 
       $(this.domNode).toggleClass('list-has-more', this.hasMoreData());
     },
     createRequest: function createRequest() {
-      var request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setContractName('system').setOperationName('executeSearch');
+      const request = new Sage.SData.Client.SDataServiceOperationRequest(this.getService()).setContractName('system').setOperationName('executeSearch');
       return request;
     },
     createSearchEntry: function createSearchEntry() {
       this.appStore.dispatch((0, _speedsearch.setSearchTerm)(this.query));
-      var entry = {
+      const entry = {
         request: {
           docTextItem: -1,
           searchText: this.query,
@@ -234,10 +234,10 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       return entry;
     },
     getActiveIndexes: function getActiveIndexes() {
-      var results = [];
-      var self = this;
-      this.activeIndexes.forEach(function (indexName) {
-        self.indexes.forEach(function (index) {
+      const results = [];
+      const self = this;
+      this.activeIndexes.forEach(indexName => {
+        self.indexes.forEach(index => {
           if (index.indexName === indexName) {
             results.push(index);
           }
@@ -249,8 +249,8 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
     requestData: function requestData() {
       $(this.domNode).addClass('list-loading');
 
-      var request = this.createRequest();
-      var entry = this.createSearchEntry();
+      const request = this.createRequest();
+      const entry = this.createSearchEntry();
 
       request.execute(entry, {
         success: _lang2.default.hitch(this, this.onRequestDataSuccess),
@@ -258,11 +258,11 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       });
     },
     navigateToDetailView: function navigateToDetailView(key, type) {
-      var view = App.getView(type.toLowerCase() + '_detail');
+      const view = App.getView(`${type.toLowerCase()}_detail`);
 
       if (view) {
         view.show({
-          key: key
+          key
         });
       }
     },
@@ -278,23 +278,23 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       return entry.type;
     },
     _intSearchExpressionNode: function _intSearchExpressionNode() {
-      var listNode = $('#' + this.id);
+      const listNode = $(`#${this.id}`);
       if (listNode[0]) {
-        var html = this.searchExpressionTemplate.apply(this);
+        const html = this.searchExpressionTemplate.apply(this);
         $(listNode[0]).prepend(html);
       }
     },
     _isIndexActive: function _isIndexActive(indexName) {
-      var indexFound = false;
+      let indexFound = false;
       if (this.activeIndexes.indexOf(indexName) > -1) {
         indexFound = true;
       }
       return indexFound;
     },
     selectIndex: function selectIndex(e) {
-      var button = e.$source;
-      var indexName = $(button).attr('data-index');
-      var activated = this.activateIndex(indexName);
+      const button = e.$source;
+      const indexName = $(button).attr('data-index');
+      const activated = this.activateIndex(indexName);
       if (activated) {
         $(button).addClass('card-layout-speed-search-index-selected');
       } else {
@@ -302,15 +302,15 @@ define('crm/Views/SpeedSearchList', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     activateIndex: function activateIndex(indexName) {
-      var tempActiveIndex = [];
-      var indexFound = false;
-      var activated = false;
+      const tempActiveIndex = [];
+      let indexFound = false;
+      let activated = false;
 
       if (this.activeIndexes.indexOf(indexName) > -1) {
         indexFound = true;
       }
       if (indexFound) {
-        this.activeIndexes.forEach(function (aIndexName) {
+        this.activeIndexes.forEach(aIndexName => {
           if (aIndexName !== indexName) {
             tempActiveIndex.push(aIndexName);
           }

--- a/src-out/Views/TextEdit.js
+++ b/src-out/Views/TextEdit.js
@@ -15,22 +15,22 @@ define('crm/Views/TextEdit', ['module', 'exports', 'dojo/_base/declare', 'argos/
     };
   }
 
-  var resource = (0, _I18n2.default)('textEdit'); /* Copyright 2017 Infor
-                                                   *
-                                                   * Licensed under the Apache License, Version 2.0 (the "License");
-                                                   * you may not use this file except in compliance with the License.
-                                                   * You may obtain a copy of the License at
-                                                   *
-                                                   *    http://www.apache.org/licenses/LICENSE-2.0
-                                                   *
-                                                   * Unless required by applicable law or agreed to in writing, software
-                                                   * distributed under the License is distributed on an "AS IS" BASIS,
-                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                   * See the License for the specific language governing permissions and
-                                                   * limitations under the License.
-                                                   */
+  const resource = (0, _I18n2.default)('textEdit'); /* Copyright 2017 Infor
+                                                     *
+                                                     * Licensed under the Apache License, Version 2.0 (the "License");
+                                                     * you may not use this file except in compliance with the License.
+                                                     * You may obtain a copy of the License at
+                                                     *
+                                                     *    http://www.apache.org/licenses/LICENSE-2.0
+                                                     *
+                                                     * Unless required by applicable law or agreed to in writing, software
+                                                     * distributed under the License is distributed on an "AS IS" BASIS,
+                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                     * See the License for the specific language governing permissions and
+                                                     * limitations under the License.
+                                                     */
 
-  var __class = (0, _declare2.default)('crm.Views.TextEdit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.TextEdit', [_Edit2.default], {
     // View Properties
     id: 'text_edit',
     titleText: resource.titleText,

--- a/src-out/Views/Ticket/Detail.js
+++ b/src-out/Views/Ticket/Detail.js
@@ -19,22 +19,22 @@ define('crm/Views/Ticket/Detail', ['module', 'exports', 'dojo/_base/declare', '.
     };
   }
 
-  var resource = (0, _I18n2.default)('ticketDetail'); /* Copyright 2017 Infor
-                                                       *
-                                                       * Licensed under the Apache License, Version 2.0 (the "License");
-                                                       * you may not use this file except in compliance with the License.
-                                                       * You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing, software
-                                                       * distributed under the License is distributed on an "AS IS" BASIS,
-                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                       * See the License for the specific language governing permissions and
-                                                       * limitations under the License.
-                                                       */
+  const resource = (0, _I18n2.default)('ticketDetail'); /* Copyright 2017 Infor
+                                                         *
+                                                         * Licensed under the Apache License, Version 2.0 (the "License");
+                                                         * you may not use this file except in compliance with the License.
+                                                         * You may obtain a copy of the License at
+                                                         *
+                                                         *    http://www.apache.org/licenses/LICENSE-2.0
+                                                         *
+                                                         * Unless required by applicable law or agreed to in writing, software
+                                                         * distributed under the License is distributed on an "AS IS" BASIS,
+                                                         * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                         * See the License for the specific language governing permissions and
+                                                         * limitations under the License.
+                                                         */
 
-  var __class = (0, _declare2.default)('crm.Views.Ticket.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Ticket.Detail', [_Detail2.default], {
     // Localization
     accountText: resource.accountText,
     areaText: resource.areaText,

--- a/src-out/Views/Ticket/Edit.js
+++ b/src-out/Views/Ticket/Edit.js
@@ -23,22 +23,22 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
     };
   }
 
-  var resource = (0, _I18n2.default)('ticketEdit'); /* Copyright 2017 Infor
-                                                     *
-                                                     * Licensed under the Apache License, Version 2.0 (the "License");
-                                                     * you may not use this file except in compliance with the License.
-                                                     * You may obtain a copy of the License at
-                                                     *
-                                                     *    http://www.apache.org/licenses/LICENSE-2.0
-                                                     *
-                                                     * Unless required by applicable law or agreed to in writing, software
-                                                     * distributed under the License is distributed on an "AS IS" BASIS,
-                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                     * See the License for the specific language governing permissions and
-                                                     * limitations under the License.
-                                                     */
+  const resource = (0, _I18n2.default)('ticketEdit'); /* Copyright 2017 Infor
+                                                       *
+                                                       * Licensed under the Apache License, Version 2.0 (the "License");
+                                                       * you may not use this file except in compliance with the License.
+                                                       * You may obtain a copy of the License at
+                                                       *
+                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                       *
+                                                       * Unless required by applicable law or agreed to in writing, software
+                                                       * distributed under the License is distributed on an "AS IS" BASIS,
+                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                       * See the License for the specific language governing permissions and
+                                                       * limitations under the License.
+                                                       */
 
-  var __class = (0, _declare2.default)('crm.Views.Ticket.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Ticket.Edit', [_Edit2.default], {
     // Localization
     accountText: resource.accountText,
     areaText: resource.areaText,
@@ -90,7 +90,7 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.connect(this.fields.Category, 'onChange', this.onCategoryChange);
     },
     convertEntry: function convertEntry() {
-      var entry = this.inherited(convertEntry, arguments);
+      const entry = this.inherited(convertEntry, arguments);
 
       if (!this.options.entry) {
         if (entry.StatusCode) {
@@ -112,9 +112,9 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       }
     },
     createPicklistRequest: function createPicklistRequest(name) {
-      var request = new Sage.SData.Client.SDataResourceCollectionRequest(App.getService()).setResourceKind('picklists').setContractName('system');
+      const request = new Sage.SData.Client.SDataResourceCollectionRequest(App.getService()).setResourceKind('picklists').setContractName('system');
 
-      var uri = request.getUri();
+      const uri = request.getUri();
       uri.setPathSegment(Sage.SData.Client.SDataUri.ResourcePropertyIndex, 'items');
       uri.setCollectionPredicate(name);
 
@@ -122,7 +122,7 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       return request;
     },
     requestCodeData: function requestCodeData(picklistName, code, field, entry, name) {
-      var request = this.createPicklistRequest(picklistName);
+      const request = this.createPicklistRequest(picklistName);
       request.read({
         success: _lang2.default.hitch(this, this.onRequestCodeDataSuccess, code, field, entry, name),
         failure: this.onRequestCodeDataFailure,
@@ -130,7 +130,7 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       });
     },
     onRequestCodeDataSuccess: function onRequestCodeDataSuccess(code, field, entry, name, feed) {
-      var value = this.processCodeDataFeed(feed, code);
+      const value = this.processCodeDataFeed(feed, code);
       entry[name] = value;
       field.setValue(code);
       field.setText(value);
@@ -139,10 +139,10 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       _ErrorManager2.default.addError(response, o, this.options, 'failure');
     },
     processCodeDataFeed: function processCodeDataFeed(feed, currentValue, options) {
-      var keyProperty = options && options.keyProperty ? options.keyProperty : '$key';
-      var textProperty = options && options.textProperty ? options.textProperty : 'text';
+      const keyProperty = options && options.keyProperty ? options.keyProperty : '$key';
+      const textProperty = options && options.textProperty ? options.textProperty : 'text';
 
-      for (var i = 0; i < feed.$resources.length; i++) {
+      for (let i = 0; i < feed.$resources.length; i++) {
         if (feed.$resources[i][keyProperty] === currentValue) {
           return feed.$resources[i][textProperty];
         }
@@ -163,14 +163,14 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       }
     },
     onUrgencyChange: function onUrgencyChange(value, field) {
-      var selection = field.getSelection();
+      const selection = field.getSelection();
       if (selection) {
         this.fields.UrgencyCode.setValue(selection.UrgencyCode);
       }
     },
     onContactChange: function onContactChange(value, field) {
-      var selection = field.getSelection();
-      var accountField = this.fields.Account;
+      const selection = field.getSelection();
+      const accountField = this.fields.Account;
 
       if (selection && selection.Account && !accountField.getValue()) {
         accountField.setValue({
@@ -180,10 +180,10 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       }
     },
     onAccountChange: function onAccountChange(value, field) {
-      var selection = field.getSelection();
+      const selection = field.getSelection();
 
       if (selection && selection.$key) {
-        var request = new Sage.SData.Client.SDataResourcePropertyRequest(this.getService()).setResourceKind('accounts').setResourceSelector('\'' + selection.$key + '\'').setResourceProperty('Contacts').setQueryArg('count', 1).setQueryArg('select', 'NameLF').setQueryArg('where', 'IsPrimary eq true');
+        const request = new Sage.SData.Client.SDataResourcePropertyRequest(this.getService()).setResourceKind('accounts').setResourceSelector(`'${selection.$key}'`).setResourceProperty('Contacts').setQueryArg('count', 1).setQueryArg('select', 'NameLF').setQueryArg('where', 'IsPrimary eq true');
 
         request.readFeed({
           success: function success(feed) {
@@ -204,18 +204,18 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       this.fields.Issue.clearValue();
     },
     formatAccountQuery: function formatAccountQuery() {
-      var value = this.fields.Account.getValue();
-      var key = value && value.$key;
+      const value = this.fields.Account.getValue();
+      const key = value && value.$key;
 
-      return key ? 'Account.id eq "' + key + '"' : false;
+      return key ? `Account.id eq "${key}"` : false;
     },
     applyContext: function applyContext() {
-      var found = App.queryNavigationContext(function (o) {
+      const found = App.queryNavigationContext(o => {
         return (/^(accounts|contacts)$/.test(o.resourceKind) && o.key
         );
       });
 
-      var lookup = {
+      const lookup = {
         accounts: this.applyAccountContext,
         contacts: this.applyContactContext
       };
@@ -225,18 +225,18 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       }
     },
     applyAccountContext: function applyAccountContext(context) {
-      var view = App.getView(context.id);
-      var entry = view && view.entry;
+      const view = App.getView(context.id);
+      const entry = view && view.entry;
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setValue(entry);
       this.onAccountChange(entry, accountField);
     },
     applyContactContext: function applyContactContext(context) {
-      var view = App.getView(context.id);
-      var entry = view && view.entry;
+      const view = App.getView(context.id);
+      const entry = view && view.entry;
 
-      var accountField = this.fields.Account;
+      const accountField = this.fields.Account;
       accountField.setValue(entry.Account);
       this.onAccountChange(entry.Account, accountField);
 
@@ -270,11 +270,11 @@ define('crm/Views/Ticket/Edit', ['module', 'exports', 'dojo/_base/declare', 'doj
       return value;
     },
     createLayout: function createLayout() {
-      var distinctServices = ['GetDistinctAreas', 'GetDistinctAreaCategories', 'GetDistinctAreaCategoryIssues'];
-      var hasDistinctServices = false;
+      const distinctServices = ['GetDistinctAreas', 'GetDistinctAreaCategories', 'GetDistinctAreaCategoryIssues'];
+      let hasDistinctServices = false;
       if (Array.isArray(App.context.areaCategoryIssueServices)) {
         // We must have every distinct service availble to use new lookups
-        hasDistinctServices = distinctServices.every(function (s) {
+        hasDistinctServices = distinctServices.every(s => {
           return App.context.areaCategoryIssueServices.indexOf(s) >= 0;
         });
       }

--- a/src-out/Views/Ticket/List.js
+++ b/src-out/Views/Ticket/List.js
@@ -27,29 +27,29 @@ define('crm/Views/Ticket/List', ['module', 'exports', 'dojo/_base/declare', '../
     };
   }
 
-  var resource = (0, _I18n2.default)('ticketList'); /* Copyright 2017 Infor
-                                                     *
-                                                     * Licensed under the Apache License, Version 2.0 (the "License");
-                                                     * you may not use this file except in compliance with the License.
-                                                     * You may obtain a copy of the License at
-                                                     *
-                                                     *    http://www.apache.org/licenses/LICENSE-2.0
-                                                     *
-                                                     * Unless required by applicable law or agreed to in writing, software
-                                                     * distributed under the License is distributed on an "AS IS" BASIS,
-                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                     * See the License for the specific language governing permissions and
-                                                     * limitations under the License.
-                                                     */
+  const resource = (0, _I18n2.default)('ticketList'); /* Copyright 2017 Infor
+                                                       *
+                                                       * Licensed under the Apache License, Version 2.0 (the "License");
+                                                       * you may not use this file except in compliance with the License.
+                                                       * You may obtain a copy of the License at
+                                                       *
+                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                       *
+                                                       * Unless required by applicable law or agreed to in writing, software
+                                                       * distributed under the License is distributed on an "AS IS" BASIS,
+                                                       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                       * See the License for the specific language governing permissions and
+                                                       * limitations under the License.
+                                                       */
 
-  var __class = (0, _declare2.default)('crm.Views.Ticket.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
+  const __class = (0, _declare2.default)('crm.Views.Ticket.List', [_List2.default, _RightDrawerListMixin3.default, _MetricListMixin3.default, _GroupListMixin3.default], {
     format: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">{%: $.Subject %}</p>', '{% if(($.Account) && (!$.Contact)) { %}', '<p class="micro-text">{%: $$.viewContactActionText + ": " + $.Account.AccountName %}</p>', '{% } %}', '{% if(($.Account) && ($.Contact)) { %}', '<p class="micro-text">{%: $$.viewContactActionText + ": " + $.Contact.NameLF + " | " + $.Account.AccountName %}</p>', '{% } %}', '<p class="micro-text"> {%: $.AssignedTo ? ($$.assignedToText + $.AssignedTo.OwnerDescription) : this.notAssignedText %}</p>', '{% if($.Urgency) { %}', '<p class="micro-text">{%: $$.urgencyText + $.Urgency.Description %}</p>', '{% } %}', '{% if($.Area) { %}', '<p class="micro-text">{%: $$._areaCategoryIssueText($) %}</p>', '{% } %}', '{% if($.CreateDate) { %}', '<p class="micro-text">{%: $$.createdOnText %}  {%: $$.format.relativeDate($.CreateDate) %}</p>', '{% } %}', '{% if($.ModifyDate) { %}', '<p class="micro-text">{%: $$.modifiedText %}  {%: $$.format.relativeDate($.ModifyDate) %}</p>', '{% } %}', '{% if($.NeededByDate) { %}', '<p class="micro-text">{%: $$.neededByText %}  {%: $$.format.relativeDate($.NeededByDate) %}</p>', '{% } %}']),
 
     _areaCategoryIssueText: function _areaCategoryIssueText(feedItem) {
-      var results = [feedItem.Area, feedItem.Category, feedItem.Issue];
-      return results.filter(function (item) {
+      const results = [feedItem.Area, feedItem.Category, feedItem.Issue];
+      return results.filter(item => {
         return item !== '' && typeof item !== 'undefined' && item !== null;
       }).join(' > ');
     },
@@ -130,8 +130,8 @@ define('crm/Views/Ticket/List', ['module', 'exports', 'dojo/_base/declare', '../
     },
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'TicketNumber like "' + q + '%" or AlternateKeySuffix like "' + q + '%" or upper(Subject) like "' + q + '%" or Account.AccountNameUpper like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `TicketNumber like "${q}%" or AlternateKeySuffix like "${q}%" or upper(Subject) like "${q}%" or Account.AccountNameUpper like "${q}%"`;
     }
   });
 

--- a/src-out/Views/Ticket/UrgencyLookup.js
+++ b/src-out/Views/Ticket/UrgencyLookup.js
@@ -15,22 +15,22 @@ define('crm/Views/Ticket/UrgencyLookup', ['module', 'exports', 'dojo/_base/decla
     };
   }
 
-  var resource = (0, _I18n2.default)('ticketUrgencyLookup'); /* Copyright 2017 Infor
-                                                              *
-                                                              * Licensed under the Apache License, Version 2.0 (the "License");
-                                                              * you may not use this file except in compliance with the License.
-                                                              * You may obtain a copy of the License at
-                                                              *
-                                                              *    http://www.apache.org/licenses/LICENSE-2.0
-                                                              *
-                                                              * Unless required by applicable law or agreed to in writing, software
-                                                              * distributed under the License is distributed on an "AS IS" BASIS,
-                                                              * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                              * See the License for the specific language governing permissions and
-                                                              * limitations under the License.
-                                                              */
+  const resource = (0, _I18n2.default)('ticketUrgencyLookup'); /* Copyright 2017 Infor
+                                                                *
+                                                                * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                * you may not use this file except in compliance with the License.
+                                                                * You may obtain a copy of the License at
+                                                                *
+                                                                *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                *
+                                                                * Unless required by applicable law or agreed to in writing, software
+                                                                * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                * See the License for the specific language governing permissions and
+                                                                * limitations under the License.
+                                                                */
 
-  var __class = (0, _declare2.default)('crm.Views.Ticket.UrgencyLookup', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.Ticket.UrgencyLookup', [_List2.default], {
     // Localization
     titleText: resource.titleText,
 
@@ -44,9 +44,9 @@ define('crm/Views/Ticket/UrgencyLookup', ['module', 'exports', 'dojo/_base/decla
     resourceKind: 'urgencies',
     isCardView: false,
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var toUpper = searchQuery && searchQuery.toUpperCase() || '';
-      var escaped = this.escapeSearchQuery(toUpper);
-      return 'upper(Description) like "%' + escaped + '%"';
+      const toUpper = searchQuery && searchQuery.toUpperCase() || '';
+      const escaped = this.escapeSearchQuery(toUpper);
+      return `upper(Description) like "%${escaped}%"`;
     }
   });
 

--- a/src-out/Views/TicketActivity/Detail.js
+++ b/src-out/Views/TicketActivity/Detail.js
@@ -36,9 +36,9 @@ define('crm/Views/TicketActivity/Detail', ['module', 'exports', 'dojo/_base/decl
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('ticketActivityDetail');
+  const resource = (0, _I18n2.default)('ticketActivityDetail');
 
-  var __class = (0, _declare2.default)('crm.Views.TicketActivity.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.TicketActivity.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     accountText: resource.accountText,
@@ -80,10 +80,10 @@ define('crm/Views/TicketActivity/Detail', ['module', 'exports', 'dojo/_base/decl
       });
     },
     processCodeDataFeed: function processCodeDataFeed(feed, currentValue, options) {
-      var keyProperty = options && options.keyProperty ? options.keyProperty : '$key';
-      var textProperty = options && options.textProperty ? options.textProperty : 'text';
+      const keyProperty = options && options.keyProperty ? options.keyProperty : '$key';
+      const textProperty = options && options.textProperty ? options.textProperty : 'text';
 
-      for (var i = 0; i < feed.$resources.length; i++) {
+      for (let i = 0; i < feed.$resources.length; i++) {
         if (feed.$resources[i][keyProperty] === currentValue) {
           return feed.$resources[i][textProperty];
         }

--- a/src-out/Views/TicketActivity/Edit.js
+++ b/src-out/Views/TicketActivity/Edit.js
@@ -40,10 +40,10 @@ define('crm/Views/TicketActivity/Edit', ['module', 'exports', 'dojo/_base/declar
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('ticketActivityEdit');
-  var dtFormatResource = (0, _I18n2.default)('ticketActivityEditDateTimeFormat');
+  const resource = (0, _I18n2.default)('ticketActivityEdit');
+  const dtFormatResource = (0, _I18n2.default)('ticketActivityEditDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.TicketActivity.Edit', [_Edit2.default], {
+  const __class = (0, _declare2.default)('crm.Views.TicketActivity.Edit', [_Edit2.default], {
     // Localization
     titleText: resource.titleText,
     activityTypeText: resource.activityTypeText,
@@ -73,9 +73,9 @@ define('crm/Views/TicketActivity/Edit', ['module', 'exports', 'dojo/_base/declar
       }
     },
     createPicklistRequest: function createPicklistRequest(name) {
-      var request = new Sage.SData.Client.SDataResourceCollectionRequest(App.getService()).setResourceKind('picklists').setContractName('system');
+      const request = new Sage.SData.Client.SDataResourceCollectionRequest(App.getService()).setResourceKind('picklists').setContractName('system');
 
-      var uri = request.getUri();
+      const uri = request.getUri();
       uri.setPathSegment(Sage.SData.Client.SDataUri.ResourcePropertyIndex, 'items');
       uri.setCollectionPredicate(name);
 
@@ -83,7 +83,7 @@ define('crm/Views/TicketActivity/Edit', ['module', 'exports', 'dojo/_base/declar
       return request;
     },
     requestCodeData: function requestCodeData(picklistName, code, field) {
-      var request = this.createPicklistRequest(picklistName);
+      const request = this.createPicklistRequest(picklistName);
       request.read({
         success: _lang2.default.hitch(this, this.onRequestCodeDataSuccess, code, field),
         failure: this.onRequestCodeDataFailure,
@@ -91,7 +91,7 @@ define('crm/Views/TicketActivity/Edit', ['module', 'exports', 'dojo/_base/declar
       });
     },
     onRequestCodeDataSuccess: function onRequestCodeDataSuccess(code, field, feed) {
-      var value = this.processCodeDataFeed(feed, code);
+      const value = this.processCodeDataFeed(feed, code);
       field.setValue(code);
       field.setText(value);
     },
@@ -99,10 +99,10 @@ define('crm/Views/TicketActivity/Edit', ['module', 'exports', 'dojo/_base/declar
       _ErrorManager2.default.addError(response, o, this.options, 'failure');
     },
     processCodeDataFeed: function processCodeDataFeed(feed, currentValue, options) {
-      var keyProperty = options && options.keyProperty ? options.keyProperty : '$key';
-      var textProperty = options && options.textProperty ? options.textProperty : 'text';
+      const keyProperty = options && options.keyProperty ? options.keyProperty : '$key';
+      const textProperty = options && options.textProperty ? options.textProperty : 'text';
 
-      for (var i = 0; i < feed.$resources.length; i++) {
+      for (let i = 0; i < feed.$resources.length; i++) {
         if (feed.$resources[i][keyProperty] === currentValue) {
           return feed.$resources[i][textProperty];
         }
@@ -114,10 +114,10 @@ define('crm/Views/TicketActivity/Edit', ['module', 'exports', 'dojo/_base/declar
     applyContext: function applyContext() {
       this.inherited(applyContext, arguments);
 
-      var ticketContext = App.isNavigationFromResourceKind(['tickets']);
-      var ticketKey = ticketContext && ticketContext.key;
-      var user = App.context.user;
-      var userField = this.fields.User;
+      const ticketContext = App.isNavigationFromResourceKind(['tickets']);
+      const ticketKey = ticketContext && ticketContext.key;
+      const user = App.context.user;
+      const userField = this.fields.User;
 
       if (ticketKey) {
         this.fields.TicketId.setValue(ticketKey);

--- a/src-out/Views/TicketActivity/List.js
+++ b/src-out/Views/TicketActivity/List.js
@@ -19,24 +19,24 @@ define('crm/Views/TicketActivity/List', ['module', 'exports', 'dojo/_base/declar
     };
   }
 
-  var resource = (0, _I18n2.default)('ticketActivityList'); /* Copyright 2017 Infor
-                                                             *
-                                                             * Licensed under the Apache License, Version 2.0 (the "License");
-                                                             * you may not use this file except in compliance with the License.
-                                                             * You may obtain a copy of the License at
-                                                             *
-                                                             *    http://www.apache.org/licenses/LICENSE-2.0
-                                                             *
-                                                             * Unless required by applicable law or agreed to in writing, software
-                                                             * distributed under the License is distributed on an "AS IS" BASIS,
-                                                             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                             * See the License for the specific language governing permissions and
-                                                             * limitations under the License.
-                                                             */
+  const resource = (0, _I18n2.default)('ticketActivityList'); /* Copyright 2017 Infor
+                                                               *
+                                                               * Licensed under the Apache License, Version 2.0 (the "License");
+                                                               * you may not use this file except in compliance with the License.
+                                                               * You may obtain a copy of the License at
+                                                               *
+                                                               *    http://www.apache.org/licenses/LICENSE-2.0
+                                                               *
+                                                               * Unless required by applicable law or agreed to in writing, software
+                                                               * distributed under the License is distributed on an "AS IS" BASIS,
+                                                               * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                               * See the License for the specific language governing permissions and
+                                                               * limitations under the License.
+                                                               */
 
-  var dtFormatResource = (0, _I18n2.default)('ticketActivityListDateTimeFormat');
+  const dtFormatResource = (0, _I18n2.default)('ticketActivityListDateTimeFormat');
 
-  var __class = (0, _declare2.default)('crm.Views.TicketActivity.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.TicketActivity.List', [_List2.default], {
     format: _Format2.default,
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">{%: $$.format.date($.AssignedDate, (App.is24HourClock()) ? $$.startDateFormatText24 : $$.startDateFormatText) %}</p>', '<div class="note-text-item">', '<div class="note-text-wrap">', '{%: $.ActivityDescription %}', '</div>', '<div class="note-text-more"></div>', '</div>']),
@@ -59,9 +59,9 @@ define('crm/Views/TicketActivity/List', ['module', 'exports', 'dojo/_base/declar
     resourceKind: 'ticketActivities',
 
     _onResize: function _onResize() {
-      $('.note-text-item', this.contentNode).each(function (i, node) {
-        var wrapNode = $('.note-text-wrap', node)[0];
-        var moreNode = $('.note-text-more', node)[0];
+      $('.note-text-item', this.contentNode).each((i, node) => {
+        const wrapNode = $('.note-text-wrap', node)[0];
+        const moreNode = $('.note-text-more', node)[0];
         if ($(node).height() < $(wrapNode).height()) {
           $(moreNode).show();
         } else {
@@ -78,8 +78,8 @@ define('crm/Views/TicketActivity/List', ['module', 'exports', 'dojo/_base/declar
       $(window).on('resize', this._onResize.bind(this));
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'ActivityDescription like "' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `ActivityDescription like "${q}%"`;
     }
   });
 

--- a/src-out/Views/TicketActivity/RateLookup.js
+++ b/src-out/Views/TicketActivity/RateLookup.js
@@ -15,22 +15,22 @@ define('crm/Views/TicketActivity/RateLookup', ['module', 'exports', 'dojo/_base/
     };
   }
 
-  var resource = (0, _I18n2.default)('ticketActivityRateLookup'); /* Copyright 2017 Infor
-                                                                   *
-                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                   * you may not use this file except in compliance with the License.
-                                                                   * You may obtain a copy of the License at
-                                                                   *
-                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                   *
-                                                                   * Unless required by applicable law or agreed to in writing, software
-                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                   * See the License for the specific language governing permissions and
-                                                                   * limitations under the License.
-                                                                   */
+  const resource = (0, _I18n2.default)('ticketActivityRateLookup'); /* Copyright 2017 Infor
+                                                                     *
+                                                                     * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                     * you may not use this file except in compliance with the License.
+                                                                     * You may obtain a copy of the License at
+                                                                     *
+                                                                     *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                     *
+                                                                     * Unless required by applicable law or agreed to in writing, software
+                                                                     * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                     * See the License for the specific language governing permissions and
+                                                                     * limitations under the License.
+                                                                     */
 
-  var __class = (0, _declare2.default)('crm.Views.TicketActivity.RateLookup', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.TicketActivity.RateLookup', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.RateTypeCode %} - {%: $.Amount %}</p>', '<p class="micro-text">{%: $.TypeDescription %}</p>']),
 
@@ -45,8 +45,8 @@ define('crm/Views/TicketActivity/RateLookup', ['module', 'exports', 'dojo/_base/
     resourceKind: 'ticketActivityRates',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(RateTypeCode) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(RateTypeCode) like "%${q}%"`;
     }
   });
 

--- a/src-out/Views/TicketActivityItem/Detail.js
+++ b/src-out/Views/TicketActivityItem/Detail.js
@@ -32,9 +32,9 @@ define('crm/Views/TicketActivityItem/Detail', ['module', 'exports', 'dojo/_base/
    * limitations under the License.
    */
 
-  var resource = (0, _I18n2.default)('ticketActivityItemDetail');
+  const resource = (0, _I18n2.default)('ticketActivityItemDetail');
 
-  var __class = (0, _declare2.default)('crm.Views.TicketActivityItem.Detail', [_Detail2.default], {
+  const __class = (0, _declare2.default)('crm.Views.TicketActivityItem.Detail', [_Detail2.default], {
     // Localization
     titleText: resource.titleText,
     productNameText: resource.productNameText,

--- a/src-out/Views/TicketActivityItem/List.js
+++ b/src-out/Views/TicketActivityItem/List.js
@@ -15,22 +15,22 @@ define('crm/Views/TicketActivityItem/List', ['module', 'exports', 'dojo/_base/de
     };
   }
 
-  var resource = (0, _I18n2.default)('ticketActivityItemList'); /* Copyright 2017 Infor
-                                                                 *
-                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                 * you may not use this file except in compliance with the License.
-                                                                 * You may obtain a copy of the License at
-                                                                 *
-                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                 *
-                                                                 * Unless required by applicable law or agreed to in writing, software
-                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                 * See the License for the specific language governing permissions and
-                                                                 * limitations under the License.
-                                                                 */
+  const resource = (0, _I18n2.default)('ticketActivityItemList'); /* Copyright 2017 Infor
+                                                                   *
+                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                   * you may not use this file except in compliance with the License.
+                                                                   * You may obtain a copy of the License at
+                                                                   *
+                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                   *
+                                                                   * Unless required by applicable law or agreed to in writing, software
+                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                   * See the License for the specific language governing permissions and
+                                                                   * limitations under the License.
+                                                                   */
 
-  var __class = (0, _declare2.default)('crm.Views.TicketActivityItem.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.TicketActivityItem.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">{%: $.Product.ActualId %} - {%: crm.Format.currency($.ItemAmount) %}</p>', '<p class="micro-text">{%: $.ItemDescription %}</p>']),
 
@@ -50,8 +50,8 @@ define('crm/Views/TicketActivityItem/List', ['module', 'exports', 'dojo/_base/de
       });
     },
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return '(upper(Product.Name) like "' + q + '%" or upper(Product.Family) like "' + q + '%")';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `(upper(Product.Name) like "${q}%" or upper(Product.Family) like "${q}%")`;
     }
   });
 

--- a/src-out/Views/UpdateToolbar.js
+++ b/src-out/Views/UpdateToolbar.js
@@ -15,22 +15,22 @@ define('crm/Views/UpdateToolbar', ['module', 'exports', 'dojo/_base/declare', 'a
     };
   }
 
-  var resource = (0, _I18n2.default)('updateToolbar'); /* Copyright 2017 Infor
-                                                        *
-                                                        * Licensed under the Apache License, Version 2.0 (the "License");
-                                                        * you may not use this file except in compliance with the License.
-                                                        * You may obtain a copy of the License at
-                                                        *
-                                                        *    http://www.apache.org/licenses/LICENSE-2.0
-                                                        *
-                                                        * Unless required by applicable law or agreed to in writing, software
-                                                        * distributed under the License is distributed on an "AS IS" BASIS,
-                                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                        * See the License for the specific language governing permissions and
-                                                        * limitations under the License.
-                                                        */
+  const resource = (0, _I18n2.default)('updateToolbar'); /* Copyright 2017 Infor
+                                                          *
+                                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                                          * you may not use this file except in compliance with the License.
+                                                          * You may obtain a copy of the License at
+                                                          *
+                                                          *    http://www.apache.org/licenses/LICENSE-2.0
+                                                          *
+                                                          * Unless required by applicable law or agreed to in writing, software
+                                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                          * See the License for the specific language governing permissions and
+                                                          * limitations under the License.
+                                                          */
 
-  var __class = (0, _declare2.default)('crm.Views.UpdateToolbar', [_MainToolbar2.default], {
+  const __class = (0, _declare2.default)('crm.Views.UpdateToolbar', [_MainToolbar2.default], {
     widgetTemplate: new Simplate(['<div class="update-toolbar">', '<h1 data-action="reload">{%= $.updateText %}</h1>', '</div>']),
 
     updateText: resource.updateText,

--- a/src-out/Views/User/CalendarAccessList.js
+++ b/src-out/Views/User/CalendarAccessList.js
@@ -15,22 +15,22 @@ define('crm/Views/User/CalendarAccessList', ['module', 'exports', 'dojo/_base/de
     };
   }
 
-  var resource = (0, _I18n2.default)('userCalendarAccessList'); /* Copyright 2017 Infor
-                                                                 *
-                                                                 * Licensed under the Apache License, Version 2.0 (the "License");
-                                                                 * you may not use this file except in compliance with the License.
-                                                                 * You may obtain a copy of the License at
-                                                                 *
-                                                                 *    http://www.apache.org/licenses/LICENSE-2.0
-                                                                 *
-                                                                 * Unless required by applicable law or agreed to in writing, software
-                                                                 * distributed under the License is distributed on an "AS IS" BASIS,
-                                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                                 * See the License for the specific language governing permissions and
-                                                                 * limitations under the License.
-                                                                 */
+  const resource = (0, _I18n2.default)('userCalendarAccessList'); /* Copyright 2017 Infor
+                                                                   *
+                                                                   * Licensed under the Apache License, Version 2.0 (the "License");
+                                                                   * you may not use this file except in compliance with the License.
+                                                                   * You may obtain a copy of the License at
+                                                                   *
+                                                                   *    http://www.apache.org/licenses/LICENSE-2.0
+                                                                   *
+                                                                   * Unless required by applicable law or agreed to in writing, software
+                                                                   * distributed under the License is distributed on an "AS IS" BASIS,
+                                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                                   * See the License for the specific language governing permissions and
+                                                                   * limitations under the License.
+                                                                   */
 
-  var __class = (0, _declare2.default)('crm.Views.User.CalendarAccessList', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.User.CalendarAccessList', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="micro-text">{%: $.SubType %}</p>']),
 
@@ -42,14 +42,14 @@ define('crm/Views/User/CalendarAccessList', ['module', 'exports', 'dojo/_base/de
     queryOrderBy: 'Name',
 
     queryWhere: function queryWhere() {
-      return 'AllowAdd AND (AccessId eq \'EVERYONE\' or AccessId eq \'' + App.context.user.$key + '\') AND Type eq \'User\'';
+      return `AllowAdd AND (AccessId eq 'EVERYONE' or AccessId eq '${App.context.user.$key}') AND Type eq 'User'`;
     },
     querySelect: ['Name', 'SubType', 'AccessId', 'ResourceId'],
     resourceKind: 'activityresourceviews',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(Name) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(Name) like "%${q}%"`;
     }
   });
 

--- a/src-out/Views/User/List.js
+++ b/src-out/Views/User/List.js
@@ -15,22 +15,22 @@ define('crm/Views/User/List', ['module', 'exports', 'dojo/_base/declare', 'argos
     };
   }
 
-  var resource = (0, _I18n2.default)('userList'); /* Copyright 2017 Infor
-                                                   *
-                                                   * Licensed under the Apache License, Version 2.0 (the "License");
-                                                   * you may not use this file except in compliance with the License.
-                                                   * You may obtain a copy of the License at
-                                                   *
-                                                   *    http://www.apache.org/licenses/LICENSE-2.0
-                                                   *
-                                                   * Unless required by applicable law or agreed to in writing, software
-                                                   * distributed under the License is distributed on an "AS IS" BASIS,
-                                                   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                   * See the License for the specific language governing permissions and
-                                                   * limitations under the License.
-                                                   */
+  const resource = (0, _I18n2.default)('userList'); /* Copyright 2017 Infor
+                                                     *
+                                                     * Licensed under the Apache License, Version 2.0 (the "License");
+                                                     * you may not use this file except in compliance with the License.
+                                                     * You may obtain a copy of the License at
+                                                     *
+                                                     *    http://www.apache.org/licenses/LICENSE-2.0
+                                                     *
+                                                     * Unless required by applicable law or agreed to in writing, software
+                                                     * distributed under the License is distributed on an "AS IS" BASIS,
+                                                     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                     * See the License for the specific language governing permissions and
+                                                     * limitations under the License.
+                                                     */
 
-  var __class = (0, _declare2.default)('crm.Views.User.List', [_List2.default], {
+  const __class = (0, _declare2.default)('crm.Views.User.List', [_List2.default], {
     // Templates
     itemTemplate: new Simplate(['<p class="listview-heading">{%: $.UserInfo.LastName %}, {%: $.UserInfo.FirstName %}</p>', '<p class="micro-text">{%: $.UserInfo.Title %}</p>']),
 
@@ -53,8 +53,8 @@ define('crm/Views/User/List', ['module', 'exports', 'dojo/_base/declare', 'argos
     resourceKind: 'users',
 
     formatSearchQuery: function formatSearchQuery(searchQuery) {
-      var q = this.escapeSearchQuery(searchQuery.toUpperCase());
-      return 'upper(UserInfo.UserName) like "%' + q + '%"';
+      const q = this.escapeSearchQuery(searchQuery.toUpperCase());
+      return `upper(UserInfo.UserName) like "%${q}%"`;
     }
   });
 

--- a/src-out/Views/_GroupListMixin.js
+++ b/src-out/Views/_GroupListMixin.js
@@ -51,7 +51,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
   /**
    * @module crm/Views/_GroupListMixin
    */
-  var resource = (0, _I18n2.default)('groupListMixin');
+  const resource = (0, _I18n2.default)('groupListMixin');
 
   /**
    * @class
@@ -60,7 +60,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
    * @classdesc Mixin for slx group list layouts.
    * @since 3.1
    */
-  var __class = (0, _declare2.default)('crm.Views._GroupListMixin', null, /** @lends module:crm/Views/_GroupListMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views._GroupListMixin', null, /** @lends module:crm/Views/_GroupListMixin.prototype */{
     noDefaultGroupText: resource.noDefaultGroupText,
     currentGroupNotFoundText: resource.currentGroupNotFoundText,
     groupTemplateSummaryText: resource.groupTemplateSummaryText,
@@ -115,7 +115,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
     },
     getTitle: function getTitle(entry, labelProperty) {
       // labelproperty will default to the group's family, which doesn't work with all groups...
-      var value = _Utility2.default.getValue(entry, labelProperty);
+      let value = _Utility2.default.getValue(entry, labelProperty);
       if (value) {
         return value;
       }
@@ -127,13 +127,13 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       }
 
       // Fallback to the first layout item
-      var firstLayoutItem = this.layout && this.layout[0];
+      const firstLayoutItem = this.layout && this.layout[0];
       if (firstLayoutItem && firstLayoutItem.alias) {
         return _Utility2.default.getValue(entry, firstLayoutItem.alias);
       }
 
       // Should never land here
-      console.warn('No descriptor found for ' + labelProperty); // eslint-disable-line
+      console.warn(`No descriptor found for ${labelProperty}`); // eslint-disable-line
       return '';
     },
     requestData: function requestData() {
@@ -169,8 +169,8 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     getDefaultGroup: function getDefaultGroup() {
-      var defaultGroup = null;
-      var defaultGroupName = null;
+      let defaultGroup = null;
+      let defaultGroupName = null;
 
       defaultGroup = _GroupUtility2.default.getDefaultGroup(this.entityName);
 
@@ -190,12 +190,10 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return null;
     },
     initOverrideGroupLayout: function initOverrideGroupLayout() {
-      var _this = this;
-
-      this._requestOverrideGroupLayout().then(function (result) {
-        _this._overrideLayoutInitalized = true;
-        _this._overrideGroupLayout = result && result.length > 0 ? result[0].layout : null;
-        _this.initGroup();
+      this._requestOverrideGroupLayout().then(result => {
+        this._overrideLayoutInitalized = true;
+        this._overrideGroupLayout = result && result.length > 0 ? result[0].layout : null;
+        this.initGroup();
       });
     },
     initGroup: function initGroup() {
@@ -203,7 +201,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
         this.initOverrideGroupLayout();
         return;
       }
-      var group = this.getCurrentGroup();
+      let group = this.getCurrentGroup();
 
       if (!group) {
         group = this.getDefaultGroup();
@@ -227,7 +225,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       this._clearResolvedEntryCache();
 
       // Set the toolbar title to the current group displayName
-      var title = this.getGroupTitle(group);
+      const title = this.getGroupTitle(group);
       App.setPrimaryTitle(title);
       this.set('title', title);
 
@@ -246,10 +244,10 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       });
 
       // Try to select the entity id as well
-      this.selectColumns.push(group.family + 'ID');
+      this.selectColumns.push(`${group.family}ID`);
       this.querySelect = this.selectColumns;
       this.queryOrderBy = '';
-      this.idProperty = group.family.toUpperCase() + 'ID';
+      this.idProperty = `${group.family.toUpperCase()}ID`;
       this.labelProperty = group.family.toUpperCase();
       this.store = null;
       this.clear(true);
@@ -258,13 +256,13 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       this.requestData();
     },
     _requestOverrideGroupLayout: function _requestOverrideGroupLayout() {
-      var def = new _Deferred2.default();
-      var groupName = this.overrideGroupLayoutName;
-      var store = new _SData2.default({
+      const def = new _Deferred2.default();
+      const groupName = this.overrideGroupLayoutName;
+      const store = new _SData2.default({
         service: App.services.crm,
         resourceKind: 'groups',
         contractName: 'system',
-        where: '((upper(family) eq \'' + this.entityName.toUpperCase() + '\') and (upper(Name) eq \'' + groupName.toUpperCase() + '\'))',
+        where: `((upper(family) eq '${this.entityName.toUpperCase()}') and (upper(Name) eq '${groupName.toUpperCase()}'))`,
         include: ['layout', 'tableAliases'],
         idProperty: '$key',
         applicationName: 'slx',
@@ -272,23 +270,23 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       });
 
       if (store) {
-        var queryResults = store.query();
-        (0, _when2.default)(queryResults, function (relatedFeed) {
+        const queryResults = store.query();
+        (0, _when2.default)(queryResults, relatedFeed => {
           def.resolve(relatedFeed);
-        }, function () {
+        }, () => {
           def.resolve(null);
         });
       }
       return def.promise;
     },
     _requestGroup: function _requestGroup(groupName, groupId, onSuccess) {
-      var store = void 0;
+      let store;
       if (typeof groupName === 'string' && groupName !== '') {
         store = new _SData2.default({
           service: App.services.crm,
           resourceKind: 'groups',
           contractName: 'system',
-          where: '((upper(family) eq \'' + this.entityName.toUpperCase() + '\') and (upper(Name) eq \'' + groupName.toUpperCase() + '\') or PluginId eq \'' + groupId + '\')',
+          where: `((upper(family) eq '${this.entityName.toUpperCase()}') and (upper(Name) eq '${groupName.toUpperCase()}') or PluginId eq '${groupId}')`,
           include: ['layout', 'tableAliases'],
           idProperty: '$key',
           applicationName: 'slx',
@@ -297,7 +295,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       }
 
       if (store) {
-        var queryResults = store.query();
+        const queryResults = store.query();
 
         (function queryWhen(context, queryResult) {
           try {
@@ -318,10 +316,10 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
      * Sets the titlebar to the current group's displayName.
      */
     setPrimaryTitle: function setPrimaryTitle() {
-      var group = this._currentGroup;
+      const group = this._currentGroup;
 
       if (group) {
-        var title = this.getGroupTitle(group);
+        const title = this.getGroupTitle(group);
         this.set('title', title);
       }
 
@@ -329,12 +327,12 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
     },
     _onGroupRequestSuccess: function _onGroupRequestSuccess(result) {
       if (result.length > 0) {
-        var group = result[0];
+        const group = result[0];
         this.setCurrentGroup(group);
         _GroupUtility2.default.addToGroupPreferences([group], this.entityName);
         this._onApplyGroup(group);
       } else {
-        var title = this.getGroupTitle();
+        const title = this.getGroupTitle();
         App.setPrimaryTitle(title);
         this.set('title', title);
         this._selectGroups();
@@ -359,9 +357,9 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
      *
      */
     getItemTemplate: function getItemTemplate() {
-      var layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
+      const layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
       if (this.enableDynamicGroupLayout) {
-        var layoutTemplate = this.getSelectedGroupLayoutTemplate();
+        const layoutTemplate = this.getSelectedGroupLayoutTemplate();
         if (layoutTemplate) {
           if (layoutTemplate.type === 'Dynamic') {
             return this.getDynamicLayoutItemTemplate(layout, layoutTemplate.options);
@@ -372,12 +370,12 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
         }
         return this.defaultGroupLayoutItemTemplate;
       }
-      var template = layout.map(this.getItemLayoutTemplate);
+      const template = layout.map(this.getItemLayoutTemplate);
       return new Simplate(template);
     },
     getItemLayoutTemplate: function getItemLayoutTemplate(item) {
-      var jsonString = _json2.default.stringify(item);
-      var template = ['<p class="micro-text"><span class="group-label">', item.caption, '</span> <span class="group-entry">{%= $$.groupTransformValue($[$$.getFieldNameByLayout(' + jsonString + ')],' + jsonString + ',$$.getFormatterByLayout(' + jsonString + ')) %}</span>', '</p>'].join('');
+      const jsonString = _json2.default.stringify(item);
+      const template = ['<p class="micro-text"><span class="group-label">', item.caption, `</span> <span class="group-entry">{%= $$.groupTransformValue($[$$.getFieldNameByLayout(${jsonString})],${jsonString},$$.getFormatterByLayout(${jsonString})) %}</span>`, '</p>'].join('');
 
       return template;
     },
@@ -414,10 +412,10 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return this.groupTemplateLayouts;
     },
     getSelectedGroupLayoutTemplate: function getSelectedGroupLayoutTemplate() {
-      var name = _GroupUtility2.default.getSelectedGroupLayoutTemplate(this.entityName);
+      let name = _GroupUtility2.default.getSelectedGroupLayoutTemplate(this.entityName);
       name = name ? name : '';
-      var layoutTemplate = null;
-      this.groupTemplateLayouts.forEach(function (item) {
+      let layoutTemplate = null;
+      this.groupTemplateLayouts.forEach(item => {
         if (item.name === name) {
           layoutTemplate = item;
         }
@@ -431,45 +429,45 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       this.groupTemplateLayouts = this._createCustomizedLayout(this.createGroupTemplateLayouts(), 'group-templates');
     },
     getDynamicLayoutItemTemplate: function getDynamicLayoutItemTemplate(layout, options) {
-      var layoutOptions = this.applyDynamicLayoutOptions(options);
-      var rows = 0;
-      var columns = 1;
-      var column = 1;
-      var row = 1;
+      const layoutOptions = this.applyDynamicLayoutOptions(options);
+      let rows = 0;
+      let columns = 1;
+      let column = 1;
+      let row = 1;
       columns = layoutOptions.columns.length;
-      layoutOptions.columns.forEach(function (item) {
+      layoutOptions.columns.forEach(item => {
         rows = rows + item.rows;
       });
 
-      var template = [];
+      const template = [];
       template.push('<div class="group-item">');
       template.push('<p>');
-      template.push('{%= $$.getGroupFieldValueByName($,"' + layout[0].propertyPath + '", true) %}');
+      template.push(`{%= $$.getGroupFieldValueByName($,"${layout[0].propertyPath}", true) %}`);
       template.push('</p">');
-      for (var i = 0; i < layout.length; i++) {
-        var columnItem = layoutOptions.columns[column - 1];
+      for (let i = 0; i < layout.length; i++) {
+        const columnItem = layoutOptions.columns[column - 1];
         if (columnItem && column <= columns && i !== 0) {
           if (row === 1) {
-            var columnClass = columnItem.clss || '';
-            template.push('<div class="micro-text group-column ' + columnClass + '">');
+            const columnClass = columnItem.clss || '';
+            template.push(`<div class="micro-text group-column ${columnClass}">`);
           }
-          var item = layout[i];
+          const item = layout[i];
           if (item && columnItem.rows > 0) {
             if (i !== 0) {
               template.push('<div>');
               if (!columnItem.hideLabels) {
-                template.push('<span class="group-label">' + this.getGroupFieldLabelByName(item.propertyPath) + ' </span>');
+                template.push(`<span class="group-label">${this.getGroupFieldLabelByName(item.propertyPath)} </span>`);
               }
 
-              var formatOptions = this.getGroupFieldFormatOptions(item);
-              var formatClss = formatOptions.clss || '';
-              var jsonString = _json2.default.stringify(formatOptions);
+              const formatOptions = this.getGroupFieldFormatOptions(item);
+              const formatClss = formatOptions.clss || '';
+              const jsonString = _json2.default.stringify(formatOptions);
               if (item.format === 'Phone') {
-                template.push('<span class="hyperlink" data-action="groupInvokeListAction" data-name="callPhone" data-key="{%:$$.getGroupItemKey($)%}" data-propertyname="' + item.propertyPath + '">{%= $$.getGroupFieldValueByName($,"' + item.propertyPath + '", true,' + jsonString + ') %}</span>');
+                template.push(`<span class="hyperlink" data-action="groupInvokeListAction" data-name="callPhone" data-key="{%:$$.getGroupItemKey($)%}" data-propertyname="${item.propertyPath}">{%= $$.getGroupFieldValueByName($,"${item.propertyPath}", true,${jsonString}) %}</span>`);
               } else if (item.propertyPath === 'Email') {
-                template.push('<span class="hyperlink" data-action="groupInvokeListAction" data-name="sendEmail" data-key="{%:$$.getGroupItemKey($)%}" data-propertyname="' + item.propertyPath + '">{%= $$.getGroupFieldValueByName($,"' + item.propertyPath + '", true,' + jsonString + ') %}</span>');
+                template.push(`<span class="hyperlink" data-action="groupInvokeListAction" data-name="sendEmail" data-key="{%:$$.getGroupItemKey($)%}" data-propertyname="${item.propertyPath}">{%= $$.getGroupFieldValueByName($,"${item.propertyPath}", true,${jsonString}) %}</span>`);
               } else {
-                template.push('<span class="group-entry ' + formatClss + '">{%= $$.getGroupFieldValueByName($,"' + item.propertyPath + '", true,' + jsonString + ') %}</span>');
+                template.push(`<span class="group-entry ${formatClss}">{%= $$.getGroupFieldValueByName($,"${item.propertyPath}", true,${jsonString}) %}</span>`);
               }
               template.push('</div>');
             }
@@ -489,7 +487,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return new Simplate(template);
     },
     applyDynamicLayoutOptions: function applyDynamicLayoutOptions(options) {
-      var layoutOptions = {
+      const layoutOptions = {
         columns: [{
           rows: 3
         }]
@@ -501,8 +499,8 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return groupEntry[this.idProperty];
     },
     getGroupFieldFormatOptions: function getGroupFieldFormatOptions(layoutItem) {
-      var formatter = this.getFormatterByLayout(layoutItem);
-      var options = {
+      const formatter = this.getFormatterByLayout(layoutItem);
+      const options = {
         formatString: formatter && formatter.formatString ? formatter.formatString : null
       };
 
@@ -512,9 +510,9 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return options;
     },
     getGroupFieldLabelByName: function getGroupFieldLabelByName(name) {
-      var layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
-      var layoutItem = null;
-      layout.forEach(function (item) {
+      const layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
+      let layoutItem = null;
+      layout.forEach(item => {
         if (item.propertyPath === name) {
           layoutItem = item;
         }
@@ -525,9 +523,9 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return '';
     },
     getGroupFieldValueByName: function getGroupFieldValueByName(entry, name, applyFormat, formatOptions) {
-      var layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
-      var layoutItem = null;
-      layout.forEach(function (item) {
+      const layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
+      let layoutItem = null;
+      layout.forEach(item => {
         if (item.propertyPath === name) {
           layoutItem = item;
         }
@@ -535,23 +533,23 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return this.getGroupFieldValue(entry, layoutItem, applyFormat, formatOptions);
     },
     getGroupFieldLabelByIndex: function getGroupFieldLabelByIndex(layoutIndex) {
-      var layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
+      const layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
       if (layout[layoutIndex]) {
         return layout[layoutIndex].caption;
       }
       return '';
     },
     getGroupFieldValueByIndex: function getGroupFieldValueByIndex(entry, layoutIndex, applyFormat, formatOptions) {
-      var layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
-      var layoutItem = layout[layoutIndex];
+      const layout = this.enableOverrideLayout && this._overrideGroupLayout ? this._overrideGroupLayout : this.layout;
+      const layoutItem = layout[layoutIndex];
       return this.getGroupFieldValue(entry, layoutItem, applyFormat, formatOptions);
     },
     getGroupFieldValue: function getGroupFieldValue(entry, layoutItem, applyFormat, formatOptions) {
-      var value = null;
-      var formatter = null;
+      let value = null;
+      let formatter = null;
 
       if (layoutItem && applyFormat) {
-        var fieldName = this.getFieldNameByLayout(layoutItem);
+        const fieldName = this.getFieldNameByLayout(layoutItem);
         if (applyFormat) {
           formatter = this.getFormatterByLayout(layoutItem);
         }
@@ -561,8 +559,8 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
           value = entry[fieldName];
         }
       } else if (layoutItem) {
-        var _fieldName = this.getFieldNameByLayout(layoutItem);
-        value = entry[_fieldName];
+        const fieldName = this.getFieldNameByLayout(layoutItem);
+        value = entry[fieldName];
       } else {
         value = null;
       }
@@ -573,8 +571,8 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       if (!this._fieldFormatters) {
         this._fieldFormatters = {};
       }
-      var path = layoutItem.propertyPath + '_' + layoutItem.index;
-      var formatter = this._fieldFormatters[path];
+      const path = `${layoutItem.propertyPath}_${layoutItem.index}`;
+      let formatter = this._fieldFormatters[path];
       if (!formatter) {
         formatter = this.getGroupFieldFormatter(layoutItem);
         this._fieldFormatters[path] = formatter;
@@ -582,7 +580,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return formatter;
     },
     getGroupFieldFormatter: function getGroupFieldFormatter(layoutItem) {
-      var formatter = void 0;
+      let formatter;
       if (this.groupFieldFormatter) {
         formatter = this.groupFieldFormatter[layoutItem.propertyPath];
       }
@@ -608,7 +606,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
 
       this._originalProps = {};
 
-      var original = this._originalProps;
+      const original = this._originalProps;
 
       original.request = this.request ? this.request.clone() : null;
       original.querySelect = this.querySelect;
@@ -629,7 +627,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       this.groupsMode = true;
     },
     _clearGroupMode: function _clearGroupMode() {
-      var original = this._originalProps;
+      const original = this._originalProps;
 
       this.groupsMode = false;
 
@@ -687,12 +685,12 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     _groupActivateEntry: function _groupActivateEntry(params) {
-      var self = this;
+      const self = this;
 
       if (params.key) {
-        var resolvedEntry = this._getResolvedEntry(params.key);
+        const resolvedEntry = this._getResolvedEntry(params.key);
         if (!resolvedEntry) {
-          this._fetchResolvedEntry(params.key).then(function (resolvedEnt) {
+          this._fetchResolvedEntry(params.key).then(resolvedEnt => {
             params.descriptor = resolvedEnt.$descriptor;
             params.resolved = true;
             self.activateEntry(params);
@@ -704,9 +702,7 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
         }
       }
     },
-    _invokeAction: function _invokeAction(theAction) {
-      var selection = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
+    _invokeAction: function _invokeAction(theAction, selection = {}) {
       if (this.groupsEnabled && this.groupsMode && !selection.resolved) {
         this._groupInvokeAction(theAction, selection);
       } else {
@@ -714,10 +710,10 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     _groupInvokeAction: function _groupInvokeAction(theAction, selection) {
-      var self = this;
-      var resolvedEntry = this._getResolvedEntry(selection.data.$key);
+      const self = this;
+      const resolvedEntry = this._getResolvedEntry(selection.data.$key);
       if (!resolvedEntry) {
-        this._fetchResolvedEntry(selection.data.$key).then(function (resolvedEnt) {
+        this._fetchResolvedEntry(selection.data.$key).then(resolvedEnt => {
           self._invokeAction(theAction, {
             data: resolvedEnt,
             resolved: true
@@ -738,11 +734,11 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     _groupShowActionPanel: function _groupShowActionPanel(rowNode) {
-      var selection = this._getCurrentSelection();
-      var self = this;
-      var resolvedEntry = this._getResolvedEntry(selection.data.$key);
+      const selection = this._getCurrentSelection();
+      const self = this;
+      const resolvedEntry = this._getResolvedEntry(selection.data.$key);
       if (!resolvedEntry) {
-        this._fetchResolvedEntry(selection.data.$key).then(function (resolvedEnt) {
+        this._fetchResolvedEntry(selection.data.$key).then(resolvedEnt => {
           self._groupCheckActionState(resolvedEnt, rowNode);
         });
       } else {
@@ -753,9 +749,9 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       _ListBase3.default.prototype.showActionPanel.call(this, rowNode);
     },
     _getCurrentSelection: function _getCurrentSelection() {
-      var selectedItems = this.get('selectionModel').getSelections();
-      var selection = void 0;
-      for (var key in selectedItems) {
+      const selectedItems = this.get('selectionModel').getSelections();
+      let selection;
+      for (const key in selectedItems) {
         if (selectedItems.hasOwnProperty(key)) {
           selection = selectedItems[key];
           selection.data.$key = key;
@@ -765,39 +761,39 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       return selection;
     },
     _fetchResolvedEntry: function _fetchResolvedEntry(entryKey) {
-      var def = new _Deferred2.default();
-      var self = this;
-      var store = new _SData2.default({
+      const def = new _Deferred2.default();
+      const self = this;
+      const store = new _SData2.default({
         service: App.services.crm,
         resourceKind: this.resourceKind,
         contractName: this.contractName,
         scope: this
       });
 
-      var select = this._originalProps.querySelect;
+      let select = this._originalProps.querySelect;
 
       // Use querySelect from the model if available
       // TODO: Expose _getQueryModelByName better somehow
       if (this._originalProps._model) {
-        var queryModel = this._originalProps._model._getQueryModelByName('list');
+        const queryModel = this._originalProps._model._getQueryModelByName('list');
         if (queryModel && queryModel.querySelect) {
           select = queryModel.querySelect;
         }
       }
 
-      var queryOptions = {
-        select: select,
-        where: 'Id eq \'' + entryKey + '\''
+      const queryOptions = {
+        select,
+        where: `Id eq '${entryKey}'`
       };
 
-      var queryResults = store.query(null, queryOptions);
+      const queryResults = store.query(null, queryOptions);
 
-      (0, _when2.default)(queryResults, function (feed) {
-        var entry = feed[0];
+      (0, _when2.default)(queryResults, feed => {
+        const entry = feed[0];
         entry[self.idProperty] = entry.$key; // we need this because the group key is different, and it used later on when invoking an action;
         self._addResolvedEntry(entry);
         def.resolve(entry);
-      }, function (err) {
+      }, err => {
         def.reject(err);
       });
 
@@ -816,16 +812,16 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       this._resolvedEntryCache[entry.$key] = entry;
     },
     _groupCheckActionState: function _groupCheckActionState(resolvedEntry, rowNode) {
-      var resolvedSelection = {
+      const resolvedSelection = {
         data: resolvedEntry
       };
       this._applyStateToActions(resolvedSelection, rowNode);
     },
     _refreshList: function _refreshList() {
-      var self = this;
+      const self = this;
       if (this.groupsEnabled && this.groupList && this._currentGroup) {
         this._requestGroup(this._currentGroup.name, this._currentGroup.$key, function checkGroup(results) {
-          var group = results[0];
+          const group = results[0];
           if (group) {
             _GroupUtility2.default.addToGroupPreferences([group], this.entityName);
             self.setCurrentGroup(group);
@@ -840,34 +836,32 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     groupInvokeListAction: function groupInvokeListAction(params) {
-      var _this2 = this;
-
-      var key = params.key;
-      var propertyName = params.propertyname;
-      var actionName = params.name;
-      var resolvedEntry = this._getResolvedEntry(key);
+      const key = params.key;
+      const propertyName = params.propertyname;
+      const actionName = params.name;
+      const resolvedEntry = this._getResolvedEntry(key);
       if (!resolvedEntry) {
-        this._fetchResolvedEntry(key).then(function (resolvedEnt) {
-          var options = {
+        this._fetchResolvedEntry(key).then(resolvedEnt => {
+          const options = {
             selection: {
               data: resolvedEnt
             },
-            propertyName: propertyName
+            propertyName
           };
-          _this2.groupInvokeActionByName(actionName, options);
+          this.groupInvokeActionByName(actionName, options);
         });
       } else {
-        var options = {
+        const options = {
           selection: {
             data: resolvedEntry
           },
-          propertyName: propertyName
+          propertyName
         };
         this.groupInvokeActionByName(actionName, options);
       }
     },
     groupInvokeActionByName: function groupInvokeActionByName(actionName, options) {
-      var opt = options;
+      let opt = options;
       if (!opt) {
         opt = {};
       }
@@ -883,10 +877,10 @@ define('crm/Views/_GroupListMixin', ['module', 'exports', 'dojo/_base/declare', 
       }
     },
     getContextSnapShot: function getContextSnapShot(options) {
-      var snapShot = void 0;
+      let snapShot;
       if (this._groupInitialized && this.groupsMode) {
-        var entry = this.entries[options.key];
-        var template = this.rowTemplate;
+        const entry = this.entries[options.key];
+        const template = this.rowTemplate;
         snapShot = template.apply(entry, this);
         return snapShot;
       }

--- a/src-out/Views/_MetricDetailMixin.js
+++ b/src-out/Views/_MetricDetailMixin.js
@@ -39,7 +39,7 @@ define('crm/Views/_MetricDetailMixin', ['module', 'exports', 'dojo/_base/declare
   /**
    * @module crm/Views/_MetricDetailMixin
    */
-  var __class = (0, _declare2.default)('crm.Views._MetricDetailMixin', null, /** @lends module:crm/Views/_MetricDetailMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views._MetricDetailMixin', null, /** @lends module:crm/Views/_MetricDetailMixin.prototype */{
     // Metrics
     metricNode: null,
     metricWidgets: null,
@@ -53,7 +53,7 @@ define('crm/Views/_MetricDetailMixin', ['module', 'exports', 'dojo/_base/declare
     },
     destroyWidgets: function destroyWidgets() {
       if (this.metricWidgets) {
-        this.metricWidgets.forEach(function (widget) {
+        this.metricWidgets.forEach(widget => {
           widget.destroy();
         });
       }
@@ -64,19 +64,17 @@ define('crm/Views/_MetricDetailMixin', ['module', 'exports', 'dojo/_base/declare
     },
     createMetricWidgetsLayout: function createMetricWidgetsLayout() {},
     rebuildWidgets: function rebuildWidgets(entry) {
-      var _this = this;
-
       this.destroyWidgets();
       this.metricWidgets = [];
 
       // Create metrics widgets and place them in the metricNode
-      var widgetOptions = this.createMetricWidgetsLayout(entry) || [];
-      widgetOptions.forEach(function (options) {
-        if (_this.hasValidOptions(options)) {
-          var widget = new _MetricWidget2.default(options);
-          widget.placeAt(_this.metricNode, 'last');
+      const widgetOptions = this.createMetricWidgetsLayout(entry) || [];
+      widgetOptions.forEach(options => {
+        if (this.hasValidOptions(options)) {
+          const widget = new _MetricWidget2.default(options);
+          widget.placeAt(this.metricNode, 'last');
           widget.requestData();
-          _this.metricWidgets.push(widget);
+          this.metricWidgets.push(widget);
         }
       }, this);
     },

--- a/src-out/Views/_MetricListMixin.js
+++ b/src-out/Views/_MetricListMixin.js
@@ -22,7 +22,7 @@ define('crm/Views/_MetricListMixin', ['module', 'exports', 'dojo/_base/declare',
    * @classdesc Mixin for adding KPI widgets to list views.
    * @since 3.0
    */
-  var __class = (0, _declare2.default)('crm.Views._MetricListMixin', null, /** @lends module:crm/Views/_MetricListMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views._MetricListMixin', null, /** @lends module:crm/Views/_MetricListMixin.prototype */{
     // Metrics
     metricTemplate: new Simplate(['<div class="metric-list">', '</div>']),
     metricWrapper: new Simplate(['<div data-dojo-attach-point="metricNode" class="metric-wrapper"></div>']),
@@ -35,21 +35,19 @@ define('crm/Views/_MetricListMixin', ['module', 'exports', 'dojo/_base/declare',
     rebuildingWidgets: false,
 
     createMetricWidgetsLayout: function createMetricWidgetsLayout() {
-      var metrics = App.getMetricsByResourceKind(this.resourceKind);
-      return metrics.filter(function (item) {
-        return item.enabled;
-      });
+      const metrics = App.getMetricsByResourceKind(this.resourceKind);
+      return metrics.filter(item => item.enabled);
     },
     postCreate: function postCreate() {
       this.inherited(postCreate, arguments);
-      var metricList = $(this.metricTemplate.apply(this)).get(0);
+      const metricList = $(this.metricTemplate.apply(this)).get(0);
       this.metricNode = $(this.metricWrapper.apply(this)).get(0);
       $(metricList).append(this.metricNode);
       $(this.scrollerNode).prepend(metricList);
     },
     destroyWidgets: function destroyWidgets() {
       if (this.metricWidgets) {
-        this.metricWidgets.forEach(function (widget) {
+        this.metricWidgets.forEach(widget => {
           widget.destroy();
         });
       }
@@ -91,17 +89,13 @@ define('crm/Views/_MetricListMixin', ['module', 'exports', 'dojo/_base/declare',
       return options;
     },
     _instantiateMetricWidget: function _instantiateMetricWidget(options) {
-      var _this = this;
-
-      return new Promise(function (resolve) {
-        var Ctor = _this.metricWidgetCtor || _MetricWidget2.default;
-        var instance = new Ctor(_this._applyStateToWidgetOptions(options));
+      return new Promise(resolve => {
+        const Ctor = this.metricWidgetCtor || _MetricWidget2.default;
+        const instance = new Ctor(this._applyStateToWidgetOptions(options));
         resolve(instance);
       });
     },
     rebuildWidgets: function rebuildWidgets() {
-      var _this2 = this;
-
       if (this.metricWidgetsBuilt || this.rebuildingWidgets) {
         return;
       }
@@ -113,30 +107,28 @@ define('crm/Views/_MetricListMixin', ['module', 'exports', 'dojo/_base/declare',
       }
 
       // Create metrics widgets and place them in the metricNode
-      var widgetOptions = this.createMetricWidgetsLayout() || [];
-      var widgets = widgetOptions.filter(function (options) {
-        return _this2._hasValidOptions(options);
-      }).map(function (options) {
-        var clonedOptions = Object.assign({}, options);
-        return _this2._instantiateMetricWidget(clonedOptions).then(function (widget) {
-          widget.placeAt(_this2.metricNode, 'last');
+      const widgetOptions = this.createMetricWidgetsLayout() || [];
+      const widgets = widgetOptions.filter(options => this._hasValidOptions(options)).map(options => {
+        const clonedOptions = Object.assign({}, options);
+        return this._instantiateMetricWidget(clonedOptions).then(widget => {
+          widget.placeAt(this.metricNode, 'last');
           widget.requestData();
           return widget;
         });
       });
 
-      Promise.all(widgets).then(function (results) {
-        _this2.metricWidgets = results;
-        _this2.metricWidgetsBuilt = true;
-        _this2.rebuildingWidgets = false;
+      Promise.all(widgets).then(results => {
+        this.metricWidgets = results;
+        this.metricWidgetsBuilt = true;
+        this.rebuildingWidgets = false;
       });
     },
     _getCurrentQuery: function _getCurrentQuery(options) {
       // Get the current query from the search box, and any context query located in options.where
-      var query = this.query;
-      var where = this.options && this.options.where;
-      var optionsQuery = options && options.queryArgs && options.queryArgs.activeFilter;
-      return [query, where, optionsQuery].filter(function (item) {
+      const query = this.query;
+      const where = this.options && this.options.where;
+      const optionsQuery = options && options.queryArgs && options.queryArgs.activeFilter;
+      return [query, where, optionsQuery].filter(item => {
         return !!item;
       }).join(' and ');
     },

--- a/src-out/Views/_RightDrawerBaseMixin.js
+++ b/src-out/Views/_RightDrawerBaseMixin.js
@@ -26,7 +26,7 @@ define('crm/Views/_RightDrawerBaseMixin', ['module', 'exports', 'dojo/_base/decl
    *   2. unloadRightDrawer
    * @since 3.0
    */
-  var __class = (0, _declare2.default)('crm.Views._RightDrawerBaseMixin', null, /** @lends module:crm/Views/_RightDrawerBaseMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views._RightDrawerBaseMixin', null, /** @lends module:crm/Views/_RightDrawerBaseMixin.prototype */{
     drawerLoaded: false,
     /**
      * @property {Boolean}
@@ -46,7 +46,7 @@ define('crm/Views/_RightDrawerBaseMixin', ['module', 'exports', 'dojo/_base/decl
       }
 
       this.setupRightDrawer();
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.refresh();
         // this.drawerLoaded = true;
@@ -63,7 +63,7 @@ define('crm/Views/_RightDrawerBaseMixin', ['module', 'exports', 'dojo/_base/decl
       }
     },
     onToolLayoutCreated: function onToolLayoutCreated(tools) {
-      var theTools = tools || {
+      const theTools = tools || {
         tbar: []
       };
       if (!this.toolsAdded) {
@@ -90,7 +90,7 @@ define('crm/Views/_RightDrawerBaseMixin', ['module', 'exports', 'dojo/_base/decl
         return;
       }
 
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         this.unloadRightDrawer();
         drawer.clear();

--- a/src-out/Views/_RightDrawerListMixin.js
+++ b/src-out/Views/_RightDrawerListMixin.js
@@ -23,7 +23,7 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
     };
   }
 
-  var resource = (0, _I18n2.default)('rightDrawerListMixin');
+  const resource = (0, _I18n2.default)('rightDrawerListMixin');
 
   /**
    * @class
@@ -51,7 +51,7 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
   /**
    * @module crm/Views/_RightDrawerListMixin
    */
-  var __class = (0, _declare2.default)('crm.Views._RightDrawerListMixin', [_RightDrawerBaseMixin3.default], /** @lends module:crm/Views/_RightDrawerListMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views._RightDrawerListMixin', [_RightDrawerBaseMixin3.default], /** @lends module:crm/Views/_RightDrawerListMixin.prototype */{
     // Localization
     hashTagsSectionText: resource.hashTagsSectionText,
     groupsSectionText: resource.groupsSectionText,
@@ -68,7 +68,7 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
     hasSettings: true,
 
     setupRightDrawer: function setupRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.pageSize = this.DRAWER_PAGESIZE;
         this.groupList = _GroupUtility2.default.getGroupPreferences(this.entityName);
@@ -76,7 +76,7 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
       }
     },
     refreshRightDrawer: function refreshRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.clear();
         drawer.layout = null;
@@ -85,8 +85,6 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
       }
     },
     _finishSetup: function _finishSetup(drawer) {
-      var _this = this;
-
       _lang2.default.mixin(drawer, this._createActions());
       drawer.setLayout(this.createRightDrawerLayout());
       drawer.getGroupForEntry = function getGroupForEntry(entry) {
@@ -94,26 +92,26 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
       }.bind(this);
 
       if (this.rebuildWidgets) {
-        App.viewSettingsModal.element.on('close', function () {
-          if (_this._hasChangedKPIPrefs) {
-            _this.destroyWidgets();
+        App.viewSettingsModal.element.on('close', () => {
+          if (this._hasChangedKPIPrefs) {
+            this.destroyWidgets();
 
             // HACK: Don't rebuild widgets if a hashtag was clicked,
             // because the widget mixin will rebuild on a data refresh anyways.
             // TODO: Fix multiple calls to rebuildWidets() at the same time.
-            if (!_this._hashTagClicked) {
-              _this.rebuildWidgets();
+            if (!this._hashTagClicked) {
+              this.rebuildWidgets();
             }
-            _this._hasChangedKPIPrefs = false;
+            this._hasChangedKPIPrefs = false;
           }
 
           // Reset state
-          _this._hashTagClicked = false;
+          this._hashTagClicked = false;
         });
       }
     },
     unloadRightDrawer: function unloadRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.setLayout([]);
         drawer.getGroupForEntry = function getGroupForEntry() {};
@@ -133,10 +131,9 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
     },
     _createActions: function _createActions() {
       // These actions will get mixed into the right drawer view.
-      var actions = {
+      const actions = {
         hashTagClicked: function hashTagClicked(params) {
-          var hashtag = params.hashtag;
-
+          const { hashtag } = params;
 
           if (this.groupsMode) {
             this._clearGroupMode();
@@ -147,7 +144,7 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
             if (hashtag.startsWith('#')) {
               this.setSearchTerm(hashtag);
             } else {
-              this.setSearchTerm('#' + hashtag);
+              this.setSearchTerm(`#${hashtag}`);
             }
 
             this.search();
@@ -155,17 +152,17 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
           }
         }.bind(this),
         kpiClicked: function kpiClicked(params) {
-          var metrics = App.getMetricsByResourceKind(this.resourceKind);
-          var results = void 0;
+          const metrics = App.getMetricsByResourceKind(this.resourceKind);
+          let results;
 
           if (metrics.length > 0) {
-            results = metrics.filter(function (metric) {
+            results = metrics.filter(metric => {
               return metric.title === unescape(params.title);
             });
           }
 
           if (results.length > 0) {
-            var enabled = !!results[0].enabled;
+            const enabled = !!results[0].enabled;
             results[0].enabled = !enabled;
             App.persistPreferences();
             this._hasChangedKPIPrefs = true;
@@ -179,13 +176,13 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
         }.bind(this),
         groupClicked: function groupClicked(params) {
           this._startGroupMode();
-          var groupId = params.$key;
+          const groupId = params.$key;
 
-          $(params.$source.parentElement.parentElement).find('a').each(function (i, a) {
+          $(params.$source.parentElement.parentElement).find('a').each((i, a) => {
             $(a).attr('data-enabled', ($(a).attr('data-$key') === groupId).toString());
           });
 
-          var group = this.groupList.filter(function (item) {
+          const group = this.groupList.filter(item => {
             return item.$key === groupId;
           })[0];
 
@@ -197,8 +194,8 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
           App.viewSettingsModal.close();
         }.bind(this),
         layoutSelectedClicked: function layoutSelectedClicked(params) {
-          var name = params.name;
-          $(params.$source.parentElement.parentElement).find('a').each(function (i, a) {
+          const name = params.name;
+          $(params.$source.parentElement.parentElement).find('a').each((i, a) => {
             $(a).attr('data-enabled', ($(a).attr('data-name') === name).toString());
           });
 
@@ -213,40 +210,40 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
       return actions;
     },
     _selectGroups: function _selectGroups() {
-      var view = App.getView(this.groupLookupId);
+      const view = App.getView(this.groupLookupId);
       view.family = this.entityName;
       view.set('store', null);
       view.clear();
       view.refreshRequired = true;
 
-      var field = new _LookupField2.default({
+      const field = new _LookupField2.default({
         owner: this,
-        view: view,
+        view,
         singleSelect: false,
-        previousSelections: this.groupList && this.groupList.map(function (group) {
+        previousSelections: this.groupList && this.groupList.map(group => {
           return group.$key;
         })
       });
 
-      var handle = _aspect2.default.after(field, 'complete', function afterComplete() {
-        var self = this;
-        var list = this.owner;
-        var items = [];
+      const handle = _aspect2.default.after(field, 'complete', function afterComplete() {
+        const self = this;
+        const list = this.owner;
+        const items = [];
 
         // We will get an object back where the property names are the keys (groupId's)
         // Extract them out, and save the entry, which is the data property on the extracted object
-        for (var groupId in self.currentValue) {
+        for (const groupId in self.currentValue) {
           if (self.currentValue.hasOwnProperty(groupId)) {
-            var entry = self.currentValue[groupId].data;
+            const entry = self.currentValue[groupId].data;
             if (entry) {
               items.push(entry);
             }
           }
         }
 
-        var hasDefaultGroup = list.hasDefaultGroup;
+        const hasDefaultGroup = list.hasDefaultGroup;
         _GroupUtility2.default.addToGroupPreferences(items, list.entityName, true);
-        var currentGroup = _GroupUtility2.default.getDefaultGroup(list.entityName);
+        const currentGroup = _GroupUtility2.default.getDefaultGroup(list.entityName);
         if (currentGroup) {
           list.setCurrentGroup(currentGroup);
         }
@@ -256,7 +253,7 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
 
         if (hasDefaultGroup) {
           // We will transition back to the list, pop back open the right drawer so the user is back where they started
-          var processDataHandle = _aspect2.default.after(list, 'processData', function postProcessData() {
+          const processDataHandle = _aspect2.default.after(list, 'processData', function postProcessData() {
             App.viewSettingsModal.close();
             processDataHandle.remove();
             if (this.transitionHandle) {
@@ -305,12 +302,10 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
       };
     },
     createRightDrawerLayout: function createRightDrawerLayout() {
-      var _this2 = this;
-
-      var layout = [];
+      const layout = [];
 
       if (this.groupsEnabled) {
-        var groupsSection = {
+        const groupsSection = {
           id: 'actions',
           children: []
         };
@@ -323,9 +318,9 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
           iconCls: 'fa fa-cog fa-fw '
         });
 
-        var defaultGroup = _GroupUtility2.default.getDefaultGroup(this.entityName);
+        const defaultGroup = _GroupUtility2.default.getDefaultGroup(this.entityName);
         if (this.groupList && this.groupList.length > 0) {
-          this.groupList.forEach(function (group) {
+          this.groupList.forEach(group => {
             groupsSection.children.push({
               name: group.name,
               action: 'groupClicked',
@@ -338,15 +333,15 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
             });
           });
         }
-        var layoutSection = {
+        const layoutSection = {
           id: 'actions',
           children: []
         };
         if (this.groupTemplateLayouts && this.groupTemplateLayouts.length > 0) {
-          var layoutSelected = false;
-          this.groupTemplateLayouts.forEach(function (theLayout) {
+          let layoutSelected = false;
+          this.groupTemplateLayouts.forEach(theLayout => {
             if (!layoutSelected) {
-              layoutSelected = theLayout.name === _GroupUtility2.default.getSelectedGroupLayoutTemplate(_this2.entityName);
+              layoutSelected = theLayout.name === _GroupUtility2.default.getSelectedGroupLayoutTemplate(this.entityName);
             }
             layoutSection.children.push({
               name: theLayout.name,
@@ -355,7 +350,7 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
               dataProps: {
                 name: theLayout.name,
                 title: theLayout.displayName,
-                enabled: theLayout.name === _GroupUtility2.default.getSelectedGroupLayoutTemplate(_this2.entityName)
+                enabled: theLayout.name === _GroupUtility2.default.getSelectedGroupLayoutTemplate(this.entityName)
               }
             });
           });
@@ -371,15 +366,15 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
       }
 
       if (App.enableHashTags) {
-        var hashTagsSection = {
+        const hashTagsSection = {
           id: 'actions',
           children: []
         };
 
         if (this._hasHashTags()) {
-          var len = this.searchWidget.hashTagQueries.length;
-          for (var i = 0; i < len; i++) {
-            var hashTag = this.searchWidget.hashTagQueries[i];
+          const len = this.searchWidget.hashTagQueries.length;
+          for (let i = 0; i < len; i++) {
+            const hashTag = this.searchWidget.hashTagQueries[i];
             hashTagsSection.children.push({
               name: hashTag.key,
               action: 'hashTagClicked',
@@ -395,18 +390,18 @@ define('crm/Views/_RightDrawerListMixin', ['module', 'exports', 'dojo/_base/decl
       }
 
       if (this.createMetricWidgetsLayout) {
-        var metrics = App.getMetricsByResourceKind(this.resourceKind);
+        const metrics = App.getMetricsByResourceKind(this.resourceKind);
 
-        var kpiSection = {
+        const kpiSection = {
           id: 'kpi',
           children: []
         };
 
         if (metrics.length > 0) {
-          metrics.forEach(function (metric, i) {
+          metrics.forEach((metric, i) => {
             if (metric.title) {
               kpiSection.children.push({
-                name: 'KPI' + i,
+                name: `KPI${i}`,
                 action: 'kpiClicked',
                 title: metric.title,
                 dataProps: {

--- a/src-out/Views/_SpeedSearchRightDrawerListMixin.js
+++ b/src-out/Views/_SpeedSearchRightDrawerListMixin.js
@@ -35,7 +35,7 @@ define('crm/Views/_SpeedSearchRightDrawerListMixin', ['module', 'exports', 'dojo
   /**
    * @module crm/Views/_SpeedSearchRightDrawerListMixin
    */
-  var resource = (0, _I18n2.default)('speedSearchRightDrawerListMixin');
+  const resource = (0, _I18n2.default)('speedSearchRightDrawerListMixin');
 
   /**
    * @class
@@ -44,7 +44,7 @@ define('crm/Views/_SpeedSearchRightDrawerListMixin', ['module', 'exports', 'dojo
    * @mixes module:crm/Views/_RightDrawerBaseMixin
    *
    */
-  var __class = (0, _declare2.default)('crm.Views._SpeedSearchRightDrawerListMixin', [_RightDrawerBaseMixin3.default], /** @lends module:crm/Views/_SpeedSearchRightDrawerListMixin.prototype */{
+  const __class = (0, _declare2.default)('crm.Views._SpeedSearchRightDrawerListMixin', [_RightDrawerBaseMixin3.default], /** @lends module:crm/Views/_SpeedSearchRightDrawerListMixin.prototype */{
     // Localization
     indexSectionText: resource.indexSectionText,
 
@@ -59,29 +59,25 @@ define('crm/Views/_SpeedSearchRightDrawerListMixin', ['module', 'exports', 'dojo
     },
     setDefaultIndexPreferences: function setDefaultIndexPreferences() {
       if (!App.preferences.speedSeacrchIndexes) {
-        var defaults = this.getDefaultIndexPrefences();
+        const defaults = this.getDefaultIndexPrefences();
         App.preferences.speedSearchIndexes = defaults;
         App.persistPreferences();
       }
     },
     getDefaultIndexPrefences: function getDefaultIndexPrefences() {
-      var _this = this;
-
-      var defaults = [];
+      const defaults = [];
       if (this.indexes) {
-        this.indexes.forEach(function (index) {
+        this.indexes.forEach(index => {
           defaults.push({
             indexName: index.indexName,
-            enabled: _this._isIndexActive(index.indexName)
+            enabled: this._isIndexActive(index.indexName)
           });
         });
       }
       return defaults;
     },
     setupRightDrawer: function setupRightDrawer() {
-      var _this2 = this;
-
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         _lang2.default.mixin(drawer, this._createActions());
         drawer.setLayout(this.createRightDrawerLayout());
@@ -90,17 +86,17 @@ define('crm/Views/_SpeedSearchRightDrawerListMixin', ['module', 'exports', 'dojo
         });
 
         if (this.rebuildWidgets) {
-          App.viewSettingsModal.element.on('close', function () {
-            if (_this2._hasChangedIndexPrefs) {
-              _this2.rebuildWidgets();
-              _this2._hasChangedIndexPrefs = false;
+          App.viewSettingsModal.element.on('close', () => {
+            if (this._hasChangedIndexPrefs) {
+              this.rebuildWidgets();
+              this._hasChangedIndexPrefs = false;
             }
           });
         }
       }
     },
     unloadRightDrawer: function unloadRightDrawer() {
-      var drawer = App.getView('right_drawer');
+      const drawer = App.getView('right_drawer');
       if (drawer) {
         drawer.setLayout([]);
         drawer.getGroupForEntry = function snapperOff() {};
@@ -113,16 +109,16 @@ define('crm/Views/_SpeedSearchRightDrawerListMixin', ['module', 'exports', 'dojo
     },
     _createActions: function _createActions() {
       // These actions will get mixed into the right drawer view.
-      var actions = {
+      const actions = {
         indexClicked: _lang2.default.hitch(this, function onIndexClicked(params) {
-          var prefs = App.preferences && App.preferences.speedSearchIndexes;
+          const prefs = App.preferences && App.preferences.speedSearchIndexes;
 
-          var results = prefs.filter(function (pref) {
+          const results = prefs.filter(pref => {
             return pref.indexName === params.indexname; // the index name is lower cased.
           });
           this.activateIndex(params.indexname);
           if (results.length > 0) {
-            var enabled = !!results[0].enabled;
+            const enabled = !!results[0].enabled;
             results[0].enabled = !enabled;
             App.persistPreferences();
             this._hasChangedIndexPrefs = true;
@@ -142,37 +138,33 @@ define('crm/Views/_SpeedSearchRightDrawerListMixin', ['module', 'exports', 'dojo
       }
     },
     createRightDrawerLayout: function createRightDrawerLayout() {
-      var _this3 = this;
+      const layout = [];
 
-      var layout = [];
-
-      var indexSection = {
+      const indexSection = {
         id: 'actions',
         children: []
       };
-      var prefs = App.preferences && App.preferences.speedSearchIndexes;
+      const prefs = App.preferences && App.preferences.speedSearchIndexes;
       if (this.indexes) {
-        for (var i in this.indexes) {
+        for (const i in this.indexes) {
           if (this.indexes.hasOwnProperty(i)) {
-            (function () {
-              var index = _this3.indexes[i];
-              var indexPref = prefs.filter(function (pref) {
-                // eslint-disable-line
-                return pref.indexName === index.indexName;
+            let index = this.indexes[i];
+            const indexPref = prefs.filter(pref => {
+              // eslint-disable-line
+              return pref.indexName === index.indexName;
+            });
+            index = this.indexes[i];
+            if (index.hasOwnProperty('indexName')) {
+              indexSection.children.push({
+                name: index.indexName,
+                action: 'indexClicked',
+                title: this.indexesText[index.indexName] || index.indexName,
+                dataProps: {
+                  indexname: index.indexName,
+                  enabled: !!indexPref[0].enabled
+                }
               });
-              index = _this3.indexes[i];
-              if (index.hasOwnProperty('indexName')) {
-                indexSection.children.push({
-                  name: index.indexName,
-                  action: 'indexClicked',
-                  title: _this3.indexesText[index.indexName] || index.indexName,
-                  dataProps: {
-                    indexname: index.indexName,
-                    enabled: !!indexPref[0].enabled
-                  }
-                });
-              }
-            })();
+            }
           }
         }
       }

--- a/src-out/actions/config.js
+++ b/src-out/actions/config.js
@@ -20,8 +20,8 @@ define('crm/actions/config', ['exports'], function (exports) {
    */
 
   // action Types
-  var SET_CONFIG = exports.SET_CONFIG = 'SET_CONFIG';
-  var SET_ENDPOINT = exports.SET_ENDPOINT = 'SET_ENDPOINT';
+  const SET_CONFIG = exports.SET_CONFIG = 'SET_CONFIG';
+  const SET_ENDPOINT = exports.SET_ENDPOINT = 'SET_ENDPOINT';
 
   /*
   
@@ -45,7 +45,7 @@ define('crm/actions/config', ['exports'], function (exports) {
     return {
       type: SET_CONFIG,
       payload: {
-        config: config
+        config
       }
     };
   }
@@ -54,7 +54,7 @@ define('crm/actions/config', ['exports'], function (exports) {
     return {
       type: SET_ENDPOINT,
       payload: {
-        url: url
+        url
       }
     };
   }

--- a/src-out/actions/speedsearch.js
+++ b/src-out/actions/speedsearch.js
@@ -19,7 +19,7 @@ define('crm/actions/speedsearch', ['exports'], function (exports) {
    */
 
   // action Types
-  var SET_SEARCHTERM = exports.SET_SEARCHTERM = 'SET_SEARCHTERM';
+  const SET_SEARCHTERM = exports.SET_SEARCHTERM = 'SET_SEARCHTERM';
 
   /*
   
@@ -43,7 +43,7 @@ define('crm/actions/speedsearch', ['exports'], function (exports) {
     return {
       type: SET_SEARCHTERM,
       payload: {
-        searchTerm: searchTerm
+        searchTerm
       }
     };
   }

--- a/src-out/actions/user.js
+++ b/src-out/actions/user.js
@@ -19,7 +19,7 @@ define('crm/actions/user', ['exports'], function (exports) {
    */
 
   // action Types
-  var SET_USER = exports.SET_USER = 'SET_USER';
+  const SET_USER = exports.SET_USER = 'SET_USER';
 
   /*
   
@@ -43,7 +43,7 @@ define('crm/actions/user', ['exports'], function (exports) {
     return {
       type: SET_USER,
       payload: {
-        entry: entry
+        entry
       }
     };
   }

--- a/src-out/polyfills/index.js
+++ b/src-out/polyfills/index.js
@@ -18,20 +18,20 @@ define('crm/polyfills/index', ['./nodelist'], function (_nodelist) {
     }
   }
 
-  var p = Object.assign({}, nodelist); /* Copyright 2017 Infor
-                                        *
-                                        * Licensed under the Apache License, Version 2.0 (the "License");
-                                        * you may not use this file except in compliance with the License.
-                                        * You may obtain a copy of the License at
-                                        *
-                                        *    http://www.apache.org/licenses/LICENSE-2.0
-                                        *
-                                        * Unless required by applicable law or agreed to in writing, software
-                                        * distributed under the License is distributed on an "AS IS" BASIS,
-                                        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                        * See the License for the specific language governing permissions and
-                                        * limitations under the License.
-                                        */
+  const p = Object.assign({}, nodelist); /* Copyright 2017 Infor
+                                          *
+                                          * Licensed under the Apache License, Version 2.0 (the "License");
+                                          * you may not use this file except in compliance with the License.
+                                          * You may obtain a copy of the License at
+                                          *
+                                          *    http://www.apache.org/licenses/LICENSE-2.0
+                                          *
+                                          * Unless required by applicable law or agreed to in writing, software
+                                          * distributed under the License is distributed on an "AS IS" BASIS,
+                                          * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                          * See the License for the specific language governing permissions and
+                                          * limitations under the License.
+                                          */
 
   p.nodelist();
 });

--- a/src-out/polyfills/nodelist.js
+++ b/src-out/polyfills/nodelist.js
@@ -25,7 +25,7 @@ define("crm/polyfills/nodelist", ["exports"], function (exports) {
       NodeList.prototype.forEach = function (callback, argument) {
         // eslint-disable-line
         argument = argument || window;
-        for (var i = 0; i < this.length; i++) {
+        for (let i = 0; i < this.length; i++) {
           callback.call(argument, this[i], i, this);
         }
       };

--- a/src-out/reducers/config.js
+++ b/src-out/reducers/config.js
@@ -6,7 +6,7 @@ define('crm/reducers/config', ['exports', '../actions/config'], function (export
 
 
   // TODO: Refactor the settings passed into the app to use these instead.
-  var initialConfigState = {
+  const initialConfigState = {
     connections: null,
     endpoint: '',
     maxUploadFileSize: 40000000,
@@ -35,14 +35,8 @@ define('crm/reducers/config', ['exports', '../actions/config'], function (export
       * limitations under the License.
       */
 
-  function config() {
-    var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialConfigState;
-    var action = arguments[1];
-    var type = action.type,
-        payload = action.payload,
-        error = action.error,
-        meta = action.meta;
-    // eslint-disable-line
+  function config(state = initialConfigState, action) {
+    const { type, payload, error, meta } = action; // eslint-disable-line
     switch (type) {
       case _config.SET_CONFIG:
         return Object.assign({}, state, payload.config);

--- a/src-out/reducers/index.js
+++ b/src-out/reducers/index.js
@@ -3,7 +3,7 @@ define('crm/reducers/index', ['exports', './config', './user', './speedsearch'],
     value: true
   });
   exports.app = undefined;
-  var app = exports.app = Redux.combineReducers({
+  const app = exports.app = Redux.combineReducers({
     user: _user.user,
     config: _config.config,
     speedsearch: _speedsearch.speedsearch

--- a/src-out/reducers/speedsearch.js
+++ b/src-out/reducers/speedsearch.js
@@ -5,7 +5,7 @@ define('crm/reducers/speedsearch', ['exports', '../actions/speedsearch'], functi
   exports.speedsearch = speedsearch;
 
 
-  var initialUserState = {
+  const initialUserState = {
     searchTerm: ''
   }; /* Copyright 2020 Infor
       *
@@ -22,14 +22,8 @@ define('crm/reducers/speedsearch', ['exports', '../actions/speedsearch'], functi
       * limitations under the License.
       */
 
-  function speedsearch() {
-    var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialUserState;
-    var action = arguments[1];
-    var type = action.type,
-        payload = action.payload,
-        error = action.error,
-        meta = action.meta;
-    // eslint-disable-line
+  function speedsearch(state = initialUserState, action) {
+    const { type, payload, error, meta } = action; // eslint-disable-line
     switch (type) {
       case _speedsearch.SET_SEARCHTERM:
         return Object.assign({}, state, {

--- a/src-out/reducers/user.js
+++ b/src-out/reducers/user.js
@@ -5,29 +5,23 @@ define('crm/reducers/user', ['exports', '../actions/user'], function (exports, _
   exports.user = user;
 
 
-  var initialUserState = null; /* Copyright 2017 Infor
-                                *
-                                * Licensed under the Apache License, Version 2.0 (the "License");
-                                * you may not use this file except in compliance with the License.
-                                * You may obtain a copy of the License at
-                                *
-                                *    http://www.apache.org/licenses/LICENSE-2.0
-                                *
-                                * Unless required by applicable law or agreed to in writing, software
-                                * distributed under the License is distributed on an "AS IS" BASIS,
-                                * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                * See the License for the specific language governing permissions and
-                                * limitations under the License.
-                                */
+  const initialUserState = null; /* Copyright 2017 Infor
+                                  *
+                                  * Licensed under the Apache License, Version 2.0 (the "License");
+                                  * you may not use this file except in compliance with the License.
+                                  * You may obtain a copy of the License at
+                                  *
+                                  *    http://www.apache.org/licenses/LICENSE-2.0
+                                  *
+                                  * Unless required by applicable law or agreed to in writing, software
+                                  * distributed under the License is distributed on an "AS IS" BASIS,
+                                  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                  * See the License for the specific language governing permissions and
+                                  * limitations under the License.
+                                  */
 
-  function user() {
-    var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialUserState;
-    var action = arguments[1];
-    var type = action.type,
-        payload = action.payload,
-        error = action.error,
-        meta = action.meta;
-    // eslint-disable-line
+  function user(state = initialUserState, action) {
+    const { type, payload, error, meta } = action; // eslint-disable-line
     switch (type) {
       case _user.SET_USER:
         return Object.assign({}, state, payload.entry);

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,6 +810,7 @@ babel-plugin-transform-es2015-block-scoping@^6.24.1:
 babel-plugin-transform-es2015-classes@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
+  integrity sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=
   dependencies:
     babel-helper-define-map "^6.24.1"
     babel-helper-function-name "^6.24.1"


### PR DESCRIPTION
- IOS has supported ES6 since IOS 10 (in 2016) and Object rest...spread since IOS 11.3 (2018)
- Kept es2015-classes transform due to dojo declare compatibility