### PR TITLE
Reset query state when changing date ranges in dashboard widget

### DIFF
--- a/src-out/Integrations/BOE/Views/Account/SalesDashboardWidget.js
+++ b/src-out/Integrations/BOE/Views/Account/SalesDashboardWidget.js
@@ -208,6 +208,10 @@ define('crm/Integrations/BOE/Views/Account/SalesDashboardWidget', ['module', 'ex
 
       return metricLayout;
     },
+    rebuildWidgets: function rebuildWidgets() {
+      this.queriedOnce = false;
+      this.inherited(rebuildWidgets, arguments);
+    },
     setQueryArgs: function setQueryArgs(entry) {
       // This function builds the query args array in an order that matches the queryIndex values needed by the values array
       this.queryArgs = [];

--- a/src/Integrations/BOE/Views/Account/SalesDashboardWidget.js
+++ b/src/Integrations/BOE/Views/Account/SalesDashboardWidget.js
@@ -191,6 +191,10 @@ const __class = declare('crm.Integrations.BOE.Views.Account.SalesDashboardWidget
 
     return metricLayout;
   },
+  rebuildWidgets: function rebuildWidgets() {
+    this.queriedOnce = false;
+    this.inherited(rebuildWidgets, arguments);
+  },
   setQueryArgs: function setQueryArgs(entry) {
     // This function builds the query args array in an order that matches the queryIndex values needed by the values array
     this.queryArgs = [];


### PR DESCRIPTION
When changing the date range in the ERP account dashboard widget,
the widgets are destroyed and rebuilt. The state that kept track of
the query fetching was not reset, causing some of the widgets to
show 0.00%.

Refs:
INFORCRM-27008