### PR TITLE
Setting enableCustomizations to true on DefaultMetrics

### DIFF
--- a/src-out/DefaultMetrics.js
+++ b/src-out/DefaultMetrics.js
@@ -61,6 +61,7 @@ define('crm/DefaultMetrics', ['module', 'exports', 'dojo/_base/declare', 'argos/
     },
     customizationSet: 'metrics',
     id: 'default_metrics',
+    enableCustomizations: true,
     getDefinitions: function getDefinitions() {
       return this._createCustomizedLayout(this.createLayout(), 'definitions');
     },

--- a/src/DefaultMetrics.js
+++ b/src/DefaultMetrics.js
@@ -50,6 +50,7 @@ const __class = declare('crm.DefaultMetrics', [_CustomizationMixin], {
   },
   customizationSet: 'metrics',
   id: 'default_metrics',
+  enableCustomizations: true,
   getDefinitions: function getDefinitions() {
     return this._createCustomizedLayout(this.createLayout(), 'definitions');
   },


### PR DESCRIPTION
Customizations can work around this by adding this to the argos-sample, prior to registering their customization:

crm.DefaultMetrics.prototype.enableCustomizations = true;