### PR TITLE
Fix authorization header

### DIFF
--- a/src-out/FileManager.js
+++ b/src-out/FileManager.js
@@ -126,14 +126,15 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
       request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
       if (service) {
-        request.setRequestHeader('Authorization', service.createBasicAuthToken());
-        request.setRequestHeader('X-Authorization', service.createBasicAuthToken());
         request.setRequestHeader('X-Authorization-Mode', 'no-challenge');
 
         if (App.isMingleEnabled()) {
           var accessToken = App.mingleAuthResults.access_token;
           request.setRequestHeader('Authorization', 'Bearer ' + accessToken);
           request.setRequestHeader('X-Authorization', 'Bearer ' + accessToken);
+        } else {
+          request.setRequestHeader('Authorization', service.createBasicAuthToken());
+          request.setRequestHeader('X-Authorization', service.createBasicAuthToken());
         }
       }
 
@@ -264,14 +265,15 @@ define('crm/FileManager', ['module', 'exports', 'dojo/_base/lang', 'dojo/_base/d
       request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
       if (service) {
-        request.setRequestHeader('Authorization', service.createBasicAuthToken());
-        request.setRequestHeader('X-Authorization', service.createBasicAuthToken());
         request.setRequestHeader('X-Authorization-Mode', 'no-challenge');
 
         if (App.isMingleEnabled()) {
           var accessToken = App.mingleAuthResults.access_token;
           request.setRequestHeader('Authorization', 'Bearer ' + accessToken);
           request.setRequestHeader('X-Authorization', 'Bearer ' + accessToken);
+        } else {
+          request.setRequestHeader('Authorization', service.createBasicAuthToken());
+          request.setRequestHeader('X-Authorization', service.createBasicAuthToken());
         }
       }
 

--- a/src/FileManager.js
+++ b/src/FileManager.js
@@ -115,14 +115,15 @@ const __class = declare('crm.FileManager', null, /** @lends module:crm/FileManag
     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
     if (service) {
-      request.setRequestHeader('Authorization', service.createBasicAuthToken());
-      request.setRequestHeader('X-Authorization', service.createBasicAuthToken());
       request.setRequestHeader('X-Authorization-Mode', 'no-challenge');
 
       if (App.isMingleEnabled()) {
         const accessToken = App.mingleAuthResults.access_token;
         request.setRequestHeader('Authorization', `Bearer ${accessToken}`);
         request.setRequestHeader('X-Authorization', `Bearer ${accessToken}`);
+      } else {
+        request.setRequestHeader('Authorization', service.createBasicAuthToken());
+        request.setRequestHeader('X-Authorization', service.createBasicAuthToken());
       }
     }
 
@@ -253,14 +254,15 @@ const __class = declare('crm.FileManager', null, /** @lends module:crm/FileManag
     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
     if (service) {
-      request.setRequestHeader('Authorization', service.createBasicAuthToken());
-      request.setRequestHeader('X-Authorization', service.createBasicAuthToken());
       request.setRequestHeader('X-Authorization-Mode', 'no-challenge');
 
       if (App.isMingleEnabled()) {
         const accessToken = App.mingleAuthResults.access_token;
         request.setRequestHeader('Authorization', `Bearer ${accessToken}`);
         request.setRequestHeader('X-Authorization', `Bearer ${accessToken}`);
+      } else {
+        request.setRequestHeader('Authorization', service.createBasicAuthToken());
+        request.setRequestHeader('X-Authorization', service.createBasicAuthToken());
       }
     }
 


### PR DESCRIPTION
When uploading a file in mobile when configured for Mingle SSO, the authorization header contained Basic and Bearer values. The XMLHttpRequest setRequestHeader method will append values if it is called multiple times for the same header value.

refs:
INFORCRM-14849
INFORCRM-12947