### PR TITLE
Topic update bundler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,37 +11,37 @@ module.exports = function(grunt) {
     },
     'lang-pack': {
       'de': {
-        bundleName: "Mobile 4.3 DE",
+        bundleName: "Mobile 4.4 DE",
       },
       'en-GB': {
-        bundleName: "Mobile 4.3 EN-GB",
+        bundleName: "Mobile 4.4 EN-GB",
       },
       'es': {
-        bundleName: "Mobile 4.3 ES",
+        bundleName: "Mobile 4.4 ES",
       },
       'pt-BR': {
-        bundleName: "Mobile 4.3 PT-BR",
+        bundleName: "Mobile 4.4 PT-BR",
       },
       'fr': {
-        bundleName: "Mobile 4.3 FR",
+        bundleName: "Mobile 4.4 FR",
       },
       'it': {
-        bundleName: "Mobile 4.3 IT",
+        bundleName: "Mobile 4.4 IT",
       },
       'ja': {
-        bundleName: "Mobile 4.3 JA",
+        bundleName: "Mobile 4.4 JA",
       },
       'nl': {
-        bundleName: "Mobile 4.3 NL",
+        bundleName: "Mobile 4.4 NL",
       },
       'ru': {
-        bundleName: "Mobile 4.3 RU",
+        bundleName: "Mobile 4.4 RU",
       },
       'th': {
-        bundleName: "Mobile 4.3 TH",
+        bundleName: "Mobile 4.4 TH",
       },
       'zh-CN': {
-        bundleName: "Mobile 4.3 ZH-CN",
+        bundleName: "Mobile 4.4 ZH-CN",
         includes: [
           {
             src: './index.aspx',
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
         }],
       },
       'zh-TW': {
-        bundleName: "Mobile 4.3 ZH-TW",
+        bundleName: "Mobile 4.4 ZH-TW",
         includes: [
           {
             src: './index.aspx',

--- a/build/bundle.bat
+++ b/build/bundle.bat
@@ -31,4 +31,4 @@ xcopy *.* %SDK%\deploy\temp\ /E /Y /exclude:build\bundleExcludes.txt
 xcopy %SDK%\deploy\temp\*.* deploy\bundle\model\Portal\SlxMobile\SourceFiles\products\argos-saleslogix\ /E /Y
 rmdir %SDK%\deploy\temp /S /Q
 
-%SDK%\tools\bundler\Bundler.exe /ProjectPath:"%CD%\deploy\bundle\model" /BundleFileName:"%CD%\deploy\%BUNDLE_NAME%" /BundleMethod:All /ConfigFileName:"%CD%\build\bundle.config"
+%SDK%\tools\bundler\Bundler.exe /BundlerAction:b /IsCRMBundle:true /ProjectPath:"%CD%\deploy\bundle\model" /BundleFileName:"%CD%\deploy\%BUNDLE_NAME%" /BundleMethod:All /ConfigFileName:"%CD%\build\bundle.config"

--- a/build/bundle.bat
+++ b/build/bundle.bat
@@ -1,7 +1,7 @@
 SET SDK=%CD%\..\..\argos-sdk
 SET VERSION=%~1
 REM :: Mobile supports the current platform + one prior
-SET BUNDLE_NAME=ICRM SLX Mobile v%VERSION% for 8.4 and later VFS.zip
+SET BUNDLE_NAME=ICRM SLX Mobile v%VERSION% for 9.1 and later VFS.zip
 
 call grunt clean:css clean:js less
 call yarn run build

--- a/build/bundle.config
+++ b/build/bundle.config
@@ -2,12 +2,12 @@
 <BundleConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <ConnString />
   <Name>argos-saleslogix</Name>
-  <Description>ICRM SLX Mobile v4.3 for 8.4 and later VFS</Description>
-  <Address>8660 E. Hartford Drive, Suite 100, Scottsdale, AZ 85255</Address>
+  <Description>ICRM SLX Mobile v4.4 for 9.1 and later VFS</Description>
+  <Address>641 Avenue of the Americas, New York,NY 10011</Address>
   <Company>Infor</Company>
-  <Copyright><![CDATA[Copyright 2021 Infor. All rights reserved. www.infor.com]]></Copyright>
+  <Copyright><![CDATA[Copyright 2024 Infor. All rights reserved. www.infor.com]]></Copyright>
   <MajorVersion>4</MajorVersion>
-  <MinorVersion>3</MinorVersion>
+  <MinorVersion>4</MinorVersion>
   <Revision>0</Revision>
   <Build>1</Build>
   <InstallPassword></InstallPassword>

--- a/build/bundleConfig.tmpl
+++ b/build/bundleConfig.tmpl
@@ -3,11 +3,11 @@
   <ConnString />
   <Name><%=bundleName %></Name>
   <Description></Description>
-  <Address></Address>
+  <Address>641 Avenue of the Americas, New York,NY 10011</Address>
   <Company>Infor</Company>
-  <Copyright><![CDATA[Copyright 2021 Infor. All rights reserved. www.infor.com]]></Copyright>
+  <Copyright><![CDATA[Copyright 2024 Infor. All rights reserved. www.infor.com]]></Copyright>
   <MajorVersion>4</MajorVersion>
-  <MinorVersion>3</MinorVersion>
+  <MinorVersion>4</MinorVersion>
   <Revision>0</Revision>
   <Build>0</Build>
   <InstallPassword></InstallPassword>

--- a/build/langBundle.bat
+++ b/build/langBundle.bat
@@ -3,4 +3,4 @@ SET BUNDLE_NAME=%~1
 SET BUNDLE_CONFIG_FILE=%~2
 SET BUNDLE_FILE_NAME=%BUNDLE_NAME%.zip
 
-%SDK%\tools\bundler\Bundler.exe /ProjectPath:"%CD%\deploy\bundle\model" /BundleFileName:"%CD%\deploy\%BUNDLE_FILE_NAME%" /BundleMethod:All /ConfigFileName:"%CD%\deploy\%BUNDLE_CONFIG_FILE%"
+%SDK%\tools\bundler\Bundler.exe /BundlerAction:b /IsCRMBundle:true /ProjectPath:"%CD%\deploy\bundle\model" /BundleFileName:"%CD%\deploy\%BUNDLE_FILE_NAME%" /BundleMethod:All /ConfigFileName:"%CD%\deploy\%BUNDLE_CONFIG_FILE%"

--- a/grunt-tasks/grunt-shell.js
+++ b/grunt-tasks/grunt-shell.js
@@ -1,7 +1,7 @@
 /*eslint-disable*/
 var os = require('os');
 
-var MAX_BUFFER = 800 * 1024;
+var MAX_BUFFER = 2000 * 1024;
 
 module.exports = function(grunt) {
   grunt.config('shell', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argos-saleslogix",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Saleslogix/argos-saleslogix"

--- a/serviceworker.js
+++ b/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '4.3.0';
+const CACHE_VERSION = '4.4.0';
 const CURRENT_CACHE = 'argos-saleslogix-cache-v' + CACHE_VERSION; // eslint-disable-line
 
 self.addEventListener('install', (event) => { // eslint-disable-line

--- a/src-out/Application.js
+++ b/src-out/Application.js
@@ -193,13 +193,13 @@ define('crm/Application', ['module', 'exports', 'dojo/string', './DefaultMetrics
       _this.systemOptionsToRequest = ['BaseCurrency', 'MultiCurrency', 'ChangeOpportunityRate', 'LockOpportunityRate'];
       _this.appName = 'argos-saleslogix';
       _this.serverVersion = {
-        major: 8,
-        minor: 0,
+        major: 9,
+        minor: 1,
         revision: 0
       };
       _this.mobileVersion = {
         major: 4,
-        minor: 3,
+        minor: 4,
         revision: 0
       };
       _this.versionInfoText = resource.versionInfoText;

--- a/src/Application.js
+++ b/src/Application.js
@@ -103,13 +103,13 @@ class Application extends SDKApplication {
     ];
     this.appName = 'argos-saleslogix';
     this.serverVersion = {
-      major: 8,
-      minor: 0,
+      major: 9,
+      minor: 1,
       revision: 0,
     };
     this.mobileVersion = {
       major: 4,
-      minor: 3,
+      minor: 4,
       revision: 0,
     };
     this.versionInfoText = resource.versionInfoText;


### PR DESCRIPTION
The SDK bundler was updated to 9.3 so we can now use the /IsCRMBundle flag when generating bundles. We had to manually add the <IsCRMBundle> element to the manifest in earlier versions. Bump version to reflect upcoming version number.